### PR TITLE
make ActionClosurable compilable

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,6 +6,6 @@ target 'xdrip' do
   use_frameworks!
 
   # Pods for xdrip
-  pod "ActionClosurable"
+  pod "ActionClosurable", :git => 'https://github.com/takasek/ActionClosurable.git'
 
 end


### PR DESCRIPTION
The newest version from the GitHub repo solves compilation issues. This solves the problems until the newest version of ActionClosurable will be available via 'pod install'.