### PR TITLE
Fast rise drop alerts

### DIFF
--- a/xdrip/Constants/ConstantsDefaultAlertLevels.swift
+++ b/xdrip/Constants/ConstantsDefaultAlertLevels.swift
@@ -17,6 +17,12 @@ enum ConstantsDefaultAlertLevels {
     static let high = 170
     static let low = 70
     
+    // blood glucose fast drop delta alert in mgdl
+    static let fastdrop = 10
+
+    // blood glucose fast rise delta alert in mgdl
+    static let fastrise = 10
+    
     // in minutes, after how many minutes of now reading should alert be raised
     static let missedReading = 30
     

--- a/xdrip/Constants/ConstantsNotifications.swift
+++ b/xdrip/Constants/ConstantsNotifications.swift
@@ -18,6 +18,8 @@ enum ConstantsNotifications {
         static let missedReadingAlert = "missedReadingAlert"
         /// battery low
         static let batteryLow = "batteryLow"
+        /// fast drop
+        static let fastdrop = "fastDrop"
     }
     
     /// identifiers for alert notifications
@@ -34,6 +36,10 @@ enum ConstantsNotifications {
         static let missedReadingAlert = "missedReadingAlert"
         /// battery low
         static let batteryLow = "batteryLow"
+        /// fast drop
+        static let fastDropAlert = "fastDropAlert"
+        /// fast rise
+        static let fastRiseAlert = "fastRiseAlert"
     }
     
     /// identifiers for calibration requests

--- a/xdrip/Texts/TextsAlerts.swift
+++ b/xdrip/Texts/TextsAlerts.swift
@@ -33,6 +33,14 @@ class Texts_Alerts {
         return NSLocalizedString("alerts_batterylow", tableName: filename, bundle: Bundle.main, value: "Battery Low Alert", comment: "transmitter battery low, this is the title of the alert notification, also in alert settings list, for the name of the alert")
     }()
     
+    static let fastDropAlertTitle: String = {
+        return NSLocalizedString("alerts_fastdrop", tableName: filename, bundle: Bundle.main, value: "Fast Drop Alert", comment: "When fast drop alert rises, this is the start of the text shown in the title of the alert notification, also in alert settings list, for the name of the alert")
+    }()
+
+    static let fastRiseAlertTitle: String = {
+        return NSLocalizedString("alerts_fastrise", tableName: filename, bundle: Bundle.main, value: "Fast Rise Alert", comment: "When fast drop alert rises, this is the start of the text shown in the title of the alert notification, also in alert settings list, for the name of the alert")
+    }()
+    
     static let snooze: String = {
         return NSLocalizedString("alerts_snooze", tableName: filename, bundle: Bundle.main, value: "Snooze", comment: "Action text for alerts. This is the button that allows to snooze the alert")
     }()


### PR DESCRIPTION
Adds fast drop and fast rise alerts, by default they're triggered when delta exceeds 20mg/dl. 

One thing I'm not sure about is how to handle the default value depending on the user's setting for blood glucose value units (mgdl/mmol). There's likely a quick fix for this scenario but it got me wondering if there should be a value type to represent the BGValue and to this end I've made a proposal at https://github.com/JohanDegraeve/xdripswift/issues/67.