### PR TITLE
Upload calibrations to Nightscout

### DIFF
--- a/xdrip.xcodeproj/project.pbxproj
+++ b/xdrip.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		470CE1FC246802EB00D5CB74 /* BluetoothPeripheralsView.strings in Resources */ = {isa = PBXBuildFile; fileRef = 470CE1FE246802EB00D5CB74 /* BluetoothPeripheralsView.strings */; };
 		47503382247420A200D2260B /* BluetoothPeripheralView.strings in Resources */ = {isa = PBXBuildFile; fileRef = 47503384247420A200D2260B /* BluetoothPeripheralView.strings */; };
 		A48D2DE552F4A356AA32746A /* Pods_xdrip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 662BEA7F7991B9BD2E7D3EA4 /* Pods_xdrip.framework */; };
+		F52E9C0024A937FE00318B0A /* Calibration+NightScout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52E9BFF24A937FE00318B0A /* Calibration+NightScout.swift */; };
 		F8025C0A21D94FD700ECF0C0 /* CBManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8025C0921D94FD700ECF0C0 /* CBManagerState.swift */; };
 		F8025C1321DA683400ECF0C0 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8025C1221DA683400ECF0C0 /* Data.swift */; };
 		F8025E4E21ED450300ECF0C0 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8025E4D21ED450300ECF0C0 /* Double.swift */; };
@@ -335,6 +336,7 @@
 		475DED96244AF92A00F78473 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Alerts.strings; sourceTree = "<group>"; };
 		662BEA7F7991B9BD2E7D3EA4 /* Pods_xdrip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_xdrip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2648F65F347D56D7DFFFAB7 /* Pods-xdrip.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xdrip.release.xcconfig"; path = "Target Support Files/Pods-xdrip/Pods-xdrip.release.xcconfig"; sourceTree = "<group>"; };
+		F52E9BFF24A937FE00318B0A /* Calibration+NightScout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calibration+NightScout.swift"; sourceTree = "<group>"; };
 		F8025C0921D94FD700ECF0C0 /* CBManagerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBManagerState.swift; sourceTree = "<group>"; };
 		F8025C1221DA683400ECF0C0 /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		F8025E4D21ED450300ECF0C0 /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
@@ -1024,6 +1026,7 @@
 				F821CF53229BF43A005C1E43 /* BgReading+NightScout.swift */,
 				F821CF6E229FC280005C1E43 /* Endpoint+NightScout.swift */,
 				F821CF7A22A1D359005C1E43 /* NightScoutFollowerDelegate.swift */,
+				F52E9BFF24A937FE00318B0A /* Calibration+NightScout.swift */,
 			);
 			path = NightScout;
 			sourceTree = "<group>";
@@ -2226,6 +2229,7 @@
 				F897AAF92200F2D200CDDD10 /* CBPeripheralState.swift in Sources */,
 				F8F971B623A5914D00C3F17D /* M5Stack+BluetoothPeripheral.swift in Sources */,
 				F830992323C291EE005741DF /* Watlaa+BluetoothPeripheral.swift in Sources */,
+				F52E9C0024A937FE00318B0A /* Calibration+NightScout.swift in Sources */,
 				F821CF57229BF43A005C1E43 /* SnoozeParameters.swift in Sources */,
 				F830992823C32A13005741DF /* TextsWatlaaView.swift in Sources */,
 				F8B3A79722635A25004BA588 /* AlertEntry+CoreDataProperties.swift in Sources */,

--- a/xdrip/Extensions/UserDefaults.swift
+++ b/xdrip/Extensions/UserDefaults.swift
@@ -146,6 +146,9 @@ extension UserDefaults {
         /// timestamp lastest reading uploaded to NightScout
         case timeStampLatestNSUploadedBgReadingToNightScout = "timeStampLatestUploadedBgReading"
         
+        /// timestamp latest calibration uploaded to NightScout
+        case timeStampLatestNSUploadedCalibrationToNightScout = "timeStampLatestUploadedCalibration"
+        
         // Transmitter
         /// Transmitter Battery Level
         case transmitterBatteryInfo = "transmitterbatteryinfo"
@@ -731,6 +734,16 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: Key.timeStampLatestNSUploadedBgReadingToNightScout.rawValue)
+        }
+    }
+    
+    /// timestamp latest calibration uploaded to NightScout
+    var timeStampLatestNightScoutUploadedCalibration:Date? {
+        get {
+            return object(forKey: Key.timeStampLatestNSUploadedCalibrationToNightScout.rawValue) as? Date
+        }
+        set {
+            set(newValue, forKey: Key.timeStampLatestNSUploadedCalibrationToNightScout.rawValue)
         }
     }
     

--- a/xdrip/Managers/NightScout/Calibration+NightScout.swift
+++ b/xdrip/Managers/NightScout/Calibration+NightScout.swift
@@ -1,0 +1,47 @@
+//
+//  Calibration+NightScout.swift
+//  xdrip
+//
+//  Created by Tudor-Andrei Vrabie on 27/06/2020.
+//  Copyright © 2020 Johan Degraeve. All rights reserved.
+//
+
+import Foundation
+
+extension Calibration {
+    
+    /// dictionary representation for cal record upload to NightScout
+    public var dictionaryRepresentationForCalRecordNightScoutUpload: [String: Any] {
+        
+        return  [
+            "_id": id,
+            "device": deviceName ?? "",
+            "date": timeStamp.toMillisecondsAsInt64(),
+            "dateString": timeStamp.ISOStringFromDate(),
+            "type": "cal",
+            "sysTime": timeStamp.ISOStringFromDate(),
+            // adjusted slope and intercept values for Nightscout
+            "slope": 1000 / slope,
+            "intercept": -(intercept * 1000) / slope,
+            "scale": 1
+        ]
+        
+    }
+    
+    /// dictionary representation for mbg record upload to NightScout
+    public var dictionaryRepresentationForMbgRecordNightScoutUpload: [String: Any] {
+        
+        return  [
+            // the mbg record cannot have the same Id as the cal record
+            "_id": UniqueId.createEventId(),
+            "device": deviceName ?? "",
+            "date": timeStamp.toMillisecondsAsInt64(),
+            "dateString": timeStamp.ISOStringFromDate(),
+            "type": "mbg",
+            "mbg": bg,
+            "sysTime": timeStamp.ISOStringFromDate()
+        ]
+        
+    }
+}
+

--- a/xdrip/Managers/NightScout/NightScoutUploadManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutUploadManager.swift
@@ -27,6 +27,9 @@ public class NightScoutUploadManager:NSObject {
     /// SensorsAccessor instance
     private let sensorsAccessor: SensorsAccessor
     
+    /// CalibrationsAccessor instance
+    private let calibrationsAccessor: CalibrationsAccessor
+    
     /// reference to coreDataManager
     private let coreDataManager: CoreDataManager
     
@@ -47,6 +50,7 @@ public class NightScoutUploadManager:NSObject {
         // init properties
         self.coreDataManager = coreDataManager
         self.bgReadingsAccessor = BgReadingsAccessor(coreDataManager: coreDataManager)
+        self.calibrationsAccessor = CalibrationsAccessor(coreDataManager: coreDataManager)
         self.messageHandler = messageHandler
         self.sensorsAccessor = SensorsAccessor(coreDataManager: coreDataManager)
         
@@ -85,6 +89,8 @@ public class NightScoutUploadManager:NSObject {
         
         // upload readings
         uploadBgReadingsToNightScout(siteURL: siteURL, apiKey: apiKey)
+        // upload calibrations
+        uploadCalibrationsToNightScout(siteURL: siteURL, apiKey: apiKey)
         
         // upload activeSensor if needed
         if UserDefaults.standard.uploadSensorStartTimeToNS, let activeSensor = sensorsAccessor.fetchActiveSensor() {
@@ -226,6 +232,50 @@ public class NightScoutUploadManager:NSObject {
             
         } else {
             trace("    no readings to upload", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .info)
+        }
+        
+    }
+    
+    /// upload latest calibrations to nightscout
+    /// - parameters:
+    ///     - siteURL : nightscout site url
+    ///     - apiKey : nightscout api key
+    private func uploadCalibrationsToNightScout(siteURL:String, apiKey:String) {
+        
+        trace("in uploadCalibrationsToNightScout", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .info)
+        
+        // get the calibrations from the last maxDaysToUpload days
+        let calibrations = calibrationsAccessor.getLatestCalibrations(howManyDays: ConstantsNightScout.maxDaysToUpload, forSensor: nil)
+        
+        var calibrationsToUpload: [Calibration] = []
+        if let timeStampLatestNightScoutUploadedCalibration = UserDefaults.standard.timeStampLatestNightScoutUploadedCalibration {
+            // select calibrations that are more recent than the latest uploaded calibration
+            calibrationsToUpload = calibrations.filter({$0.timeStamp > timeStampLatestNightScoutUploadedCalibration })
+        }
+        else {
+            // or all calibrations if there is no previously uploaded calibration
+            calibrationsToUpload = calibrations
+        }
+        
+        if calibrationsToUpload.count > 0 {
+            trace("    number of calibrations to upload : %{public}@", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .info, calibrationsToUpload.count.description)
+            
+            // map calibrations to dictionaryRepresentation
+            // 2 records are uploaded to nightscout for each calibration: a cal record and a mbg record
+            let calibrationsDictionaryRepresentation = calibrationsToUpload.map({$0.dictionaryRepresentationForCalRecordNightScoutUpload}) + calibrationsToUpload.map({$0.dictionaryRepresentationForMbgRecordNightScoutUpload})
+            
+            uploadData(dataToUpload: calibrationsDictionaryRepresentation, traceString: "uploadCalibrationsToNightScout", siteURL: siteURL, path: nightScoutEntriesPath, apiKey: apiKey, completionHandler: {
+                
+                // change timeStampLatestNightScoutUploadedCalibration
+                if let lastCalibration = calibrationsToUpload.first {
+                    trace("    in uploadCalibrationsToNightScout, upload succeeded, setting timeStampLatestNightScoutUploadedCalibration to %{public}@", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .info, lastCalibration.timeStamp.description(with: .current))
+                    UserDefaults.standard.timeStampLatestNightScoutUploadedCalibration = lastCalibration.timeStamp
+                }
+                
+            })
+            
+        } else {
+            trace("    no calibrations to upload", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .info)
         }
         
     }


### PR DESCRIPTION
Addresses issue #117 

For each calibration 2 records are uploaded to Nightscout: a `cal` record, which holds calibration information such as slope and intercept and an `mbg` record which holds the bg value used for calibration.

The calibration slopes can be seen in the Nightscout calibration charts:
 
![Calibrations table](https://user-images.githubusercontent.com/16063287/86026915-f1b6c780-ba27-11ea-8946-ed4f0a281d9b.PNG)

![Calibrations chart](https://user-images.githubusercontent.com/16063287/86026922-f4192180-ba27-11ea-8c4e-6450254e2701.PNG)


The raw values appear as undefined due to a bug in Nightscout (v13.0.1). With the bug fixed they appear correctly (will open a pr for Nightscout);

![Calibrations table](https://user-images.githubusercontent.com/16063287/86026205-09418080-ba27-11ea-9a57-2bfb533c25a8.PNG)

![Calibrations chart](https://user-images.githubusercontent.com/16063287/86026221-0e063480-ba27-11ea-8155-539d1cb5ab5e.PNG)

The calibration values can also be seen in the chart:

![mbg1](https://user-images.githubusercontent.com/16063287/86028095-6b02ea00-ba29-11ea-944b-3d77f62ce0f6.png) 

