### PR TITLE
Add non-fixed calibration slopes for Libre transmitters

### DIFF
--- a/xdrip.xcodeproj/project.pbxproj
+++ b/xdrip.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		470CE1FC246802EB00D5CB74 /* BluetoothPeripheralsView.strings in Resources */ = {isa = PBXBuildFile; fileRef = 470CE1FE246802EB00D5CB74 /* BluetoothPeripheralsView.strings */; };
 		47503382247420A200D2260B /* BluetoothPeripheralView.strings in Resources */ = {isa = PBXBuildFile; fileRef = 47503384247420A200D2260B /* BluetoothPeripheralView.strings */; };
 		A48D2DE552F4A356AA32746A /* Pods_xdrip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 662BEA7F7991B9BD2E7D3EA4 /* Pods_xdrip.framework */; };
+		F51B9F7D24B216CD00FC0643 /* Libre1NonFixedSlopeCalibrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51B9F7C24B216CD00FC0643 /* Libre1NonFixedSlopeCalibrator.swift */; };
 		F8025C0A21D94FD700ECF0C0 /* CBManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8025C0921D94FD700ECF0C0 /* CBManagerState.swift */; };
 		F8025C1321DA683400ECF0C0 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8025C1221DA683400ECF0C0 /* Data.swift */; };
 		F8025E4E21ED450300ECF0C0 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8025E4D21ED450300ECF0C0 /* Double.swift */; };
@@ -348,6 +349,7 @@
 		475DED96244AF92A00F78473 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Alerts.strings; sourceTree = "<group>"; };
 		662BEA7F7991B9BD2E7D3EA4 /* Pods_xdrip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_xdrip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2648F65F347D56D7DFFFAB7 /* Pods-xdrip.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xdrip.release.xcconfig"; path = "Target Support Files/Pods-xdrip/Pods-xdrip.release.xcconfig"; sourceTree = "<group>"; };
+		F51B9F7C24B216CD00FC0643 /* Libre1NonFixedSlopeCalibrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Libre1NonFixedSlopeCalibrator.swift; sourceTree = "<group>"; };
 		F8025C0921D94FD700ECF0C0 /* CBManagerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBManagerState.swift; sourceTree = "<group>"; };
 		F8025C1221DA683400ECF0C0 /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		F8025E4D21ED450300ECF0C0 /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
@@ -1677,6 +1679,7 @@
 				F8EEDD6323020FAD00D2D610 /* NoCalibrator.swift */,
 				F8025E5221EE8CE500ECF0C0 /* Protocol */,
 				F8A54AAC22D6859200934E7A /* SlopeParameters.swift */,
+				F51B9F7C24B216CD00FC0643 /* Libre1NonFixedSlopeCalibrator.swift */,
 			);
 			path = Calibration;
 			sourceTree = "<group>";
@@ -2270,6 +2273,7 @@
 				F8C9785B242ABD9800A09483 /* BluetoothPeripheralManager+CGMMiaoMiaoTransmitterDelegate.swift in Sources */,
 				F8F9723523A5915900C3F17D /* BluetoothTransmitter.swift in Sources */,
 				F8F9721323A5915900C3F17D /* BatteryStatusRxMessage.swift in Sources */,
+				F51B9F7D24B216CD00FC0643 /* Libre1NonFixedSlopeCalibrator.swift in Sources */,
 				F8E51D612448E695001C9E5A /* Bundle.swift in Sources */,
 				F821CF61229BF4A2005C1E43 /* NightScoutUploadManager.swift in Sources */,
 				F8F9721023A5915900C3F17D /* TransmitterVersionRxMessage.swift in Sources */,

--- a/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
+++ b/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
@@ -258,4 +258,19 @@ enum BluetoothPeripheralType: String, CaseIterable {
         
     }
     
+    /// can use non fixed slopes or not
+    func canUseNonFixedSlope() -> Bool {
+       
+       switch self {
+           
+       case .M5StackType, .M5StickCType, .DexcomG4Type, .DexcomG5Type, .DexcomG6Type:
+           return false
+           
+       case .BubbleType, .MiaoMiaoType, .WatlaaType, .BluconType, .BlueReaderType, .DropletType , .GNSentryType:
+           return true
+                       
+       }
+       
+    }
+    
 }

--- a/xdrip/BluetoothTransmitter/CGM/Dexcom/G4/CGMG4xDripTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Dexcom/G4/CGMG4xDripTransmitter.swift
@@ -157,6 +157,10 @@ final class CGMG4xDripTransmitter: BluetoothTransmitter, CGMTransmitter {
     
     // MARK: -CGMTransmitter protocol functions
     
+    // this transmitter does not support Libre non fixed slopes
+    func setNonFixedSlopeEnabled(enabled: Bool) {   
+    }
+    
     /// this transmitter does not support oopWeb
     func setWebOOPEnabled(enabled: Bool) {
     }
@@ -167,6 +171,10 @@ final class CGMG4xDripTransmitter: BluetoothTransmitter, CGMTransmitter {
 
     func cgmTransmitterType() -> CGMTransmitterType {
         return .dexcomG4
+    }
+
+    func isNonFixedSlopeEnabled() -> Bool {
+        return false
     }
     
     func isWebOOPEnabled() -> Bool {

--- a/xdrip/BluetoothTransmitter/CGM/Dexcom/G5/CGMG5Transmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Dexcom/G5/CGMG5Transmitter.swift
@@ -500,7 +500,11 @@ class CGMG5Transmitter:BluetoothTransmitter, CGMTransmitter {
     func reset(requested:Bool) {
         G5ResetRequested = requested
     }
-    
+
+    /// this transmitter does not support Libre non fixed slopes
+    func setNonFixedSlopeEnabled(enabled: Bool) {    
+    }
+
     /// this transmitter does not support oopWeb
     func setWebOOPEnabled(enabled: Bool) {
     }
@@ -511,6 +515,10 @@ class CGMG5Transmitter:BluetoothTransmitter, CGMTransmitter {
 
     func cgmTransmitterType() -> CGMTransmitterType {
         return .dexcomG5
+    }
+
+    func isNonFixedSlopeEnabled() -> Bool {
+        return false
     }
     
     func isWebOOPEnabled() -> Bool {

--- a/xdrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
@@ -4,6 +4,15 @@ import CoreBluetooth
 /// defines functions that every cgm transmitter should conform to
 protocol CGMTransmitter:AnyObject {
     
+    /// to set nonFixedSlopeEnabled - called when user changes the setting
+    ///
+    /// for transmitters who don't support non fixed slopes, there's no need to implemented this function<br>
+    /// ---  for transmitters who support non fixed (all Libre transmitters) this should be implemented
+    func setNonFixedSlopeEnabled(enabled:Bool)
+    
+    /// is the CGMTransmitter nonFixed enabled or not
+    func isNonFixedSlopeEnabled() -> Bool
+
     /// to set webOOPEnabled - called when user changes the setting
     ///
     /// for transmitters who don't support webOOP, there's no need to implemented this function<br>

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Blucon/CGMBluconTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Blucon/CGMBluconTransmitter.swift
@@ -24,6 +24,9 @@ class CGMBluconTransmitter: BluetoothTransmitter {
     /// if value starts with this string, then it's assume that a battery low indication is sent by the Blucon
     private let unknownCommand2BatteryLowIndicator = "8bda02"
     
+    /// is nonFixed enabled for the transmitter or not
+    private var nonFixedSlopeEnabled: Bool
+    
     /// for trace
     private let log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryBlucon)
     
@@ -76,7 +79,7 @@ class CGMBluconTransmitter: BluetoothTransmitter {
     ///     - sensorSerialNumber : is needed to allow detection of a new sensor.
     ///     - bluetoothTransmitterDelegate : a NluetoothTransmitterDelegate
     ///     - cGMTransmitterDelegate : a CGMTransmitterDelegate
-    init(address:String?, name: String?, transmitterID:String, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMBluconTransmitterDelegate: CGMBluconTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate, timeStampLastBgReading:Date?, sensorSerialNumber:String?) {
+    init(address:String?, name: String?, transmitterID:String, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMBluconTransmitterDelegate: CGMBluconTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate, timeStampLastBgReading:Date?, sensorSerialNumber:String?, nonFixedSlopeEnabled: Bool?) {
         
         // assign addressname and name or expected devicename
         // start by using expected device name
@@ -97,6 +100,9 @@ class CGMBluconTransmitter: BluetoothTransmitter {
         
         // initialize rxbuffer
         rxBuffer = Data()
+        
+        // initialize nonFixedSlopeEnabled
+        self.nonFixedSlopeEnabled = nonFixedSlopeEnabled ?? false
 
         // initialize
         super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: nil, servicesCBUUIDs: [CBUUID(string: CBUUID_BluconService)], CBUUID_ReceiveCharacteristic: CBUUID_ReceiveCharacteristic_Blucon, CBUUID_WriteCharacteristic: CBUUID_WriteCharacteristic_Blucon, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
@@ -559,6 +565,10 @@ extension CGMBluconTransmitter: CGMTransmitter {
     func requestNewReading() {
         // not supported for blucon
     }
+
+    func setNonFixedSlopeEnabled(enabled: Bool) {
+        nonFixedSlopeEnabled = enabled
+    }
     
     /// this transmitter does not support oopWeb
     func setWebOOPEnabled(enabled: Bool) {
@@ -570,6 +580,10 @@ extension CGMBluconTransmitter: CGMTransmitter {
     
     func cgmTransmitterType() -> CGMTransmitterType {
         return .Blucon
+    }
+
+    func isNonFixedSlopeEnabled() -> Bool {
+        return nonFixedSlopeEnabled
     }
     
     func isWebOOPEnabled() -> Bool {

--- a/xdrip/BluetoothTransmitter/CGM/Libre/BlueReader/CGMBlueReaderTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/BlueReader/CGMBlueReaderTransmitter.swift
@@ -21,6 +21,9 @@ class CGMBlueReaderTransmitter:BluetoothTransmitter, CGMTransmitter {
     /// CGMBlueReaderTransmitterDelegate - not used used as there's no specific settings saved nor displayed for BlueReader
     public weak var cGMBlueReaderTransmitterDelegate: CGMBlueReaderTransmitterDelegate?
     
+    /// is nonFixed enabled for the transmitter or not
+    private var nonFixedSlopeEnabled: Bool
+    
     /// for trace
     private let log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryCGMBlueReader)
     
@@ -34,7 +37,7 @@ class CGMBlueReaderTransmitter:BluetoothTransmitter, CGMTransmitter {
     ///     - bluetoothTransmitterDelegate : a BluetoothTransmitterDelegate
     ///     - cGMTransmitterDelegate : a CGMTransmitterDelegate
     ///     - cGMBlueReaderTransmitterDelegate : a CGMBlueReaderTransmitterDelegate
-    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMBlueReaderTransmitterDelegate : CGMBlueReaderTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate) {
+    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMBlueReaderTransmitterDelegate : CGMBlueReaderTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate, nonFixedSlopeEnabled: Bool?) {
         
         // assign addressname and name or expected devicename
         var newAddressAndName:BluetoothTransmitter.DeviceAddressAndName = BluetoothTransmitter.DeviceAddressAndName.notYetConnected(expectedName: "blueReader")
@@ -47,6 +50,9 @@ class CGMBlueReaderTransmitter:BluetoothTransmitter, CGMTransmitter {
         
         // assign cGMBlueReaderTransmitterDelegate
         self.cGMBlueReaderTransmitterDelegate = cGMBlueReaderTransmitterDelegate
+        
+        // initialize nonFixedSlopeEnabled
+        self.nonFixedSlopeEnabled = nonFixedSlopeEnabled ?? false
 
         super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: nil, servicesCBUUIDs: [CBUUID(string: CBUUID_Service_BlueReader)], CBUUID_ReceiveCharacteristic: CBUUID_ReceiveCharacteristic_BlueReader, CBUUID_WriteCharacteristic: CBUUID_WriteCharacteristic_BlueReader, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
         
@@ -118,6 +124,10 @@ class CGMBlueReaderTransmitter:BluetoothTransmitter, CGMTransmitter {
     
     // MARK: CGMTransmitter protocol functions
     
+    func setNonFixedSlopeEnabled(enabled: Bool) {
+        nonFixedSlopeEnabled = enabled
+    }
+
     /// this transmitter does not support oopWeb
     func setWebOOPEnabled(enabled: Bool) {}
     
@@ -127,6 +137,10 @@ class CGMBlueReaderTransmitter:BluetoothTransmitter, CGMTransmitter {
     
     func cgmTransmitterType() -> CGMTransmitterType {
         return .blueReader
+    }
+
+    func isNonFixedSlopeEnabled() -> Bool {
+        return nonFixedSlopeEnabled
     }
     
     func isWebOOPEnabled() -> Bool {

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Bubble/CGMBubbleTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Bubble/CGMBubbleTransmitter.swift
@@ -39,6 +39,9 @@ class CGMBubbleTransmitter:BluetoothTransmitter, CGMTransmitter {
    
     /// is the transmitter oop web enabled or not
     private var webOOPEnabled: Bool
+
+    /// is nonFixed enabled for the transmitter or not
+    private var nonFixedSlopeEnabled: Bool
     
     /// used as parameter in call to cgmTransmitterDelegate.cgmTransmitterInfoReceived, when there's no glucosedata to send
     var emptyArray: [GlucoseData] = []
@@ -68,7 +71,7 @@ class CGMBubbleTransmitter:BluetoothTransmitter, CGMTransmitter {
     ///     - bluetoothTransmitterDelegate : a BluetoothTransmitterDelegate
     ///     - cGMTransmitterDelegate : a CGMTransmitterDelegate
     ///     - cGMBubbleTransmitterDelegate : a CGMBubbleTransmitterDelegate
-    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMBubbleTransmitterDelegate: CGMBubbleTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate, timeStampLastBgReading:Date?, sensorSerialNumber:String?, webOOPEnabled: Bool?, oopWebSite: String?, oopWebToken: String?) {
+    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMBubbleTransmitterDelegate: CGMBubbleTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate, timeStampLastBgReading:Date?, sensorSerialNumber:String?, webOOPEnabled: Bool?, oopWebSite: String?, oopWebToken: String?, nonFixedSlopeEnabled: Bool?) {
         
         // assign addressname and name or expected devicename
         var newAddressAndName:BluetoothTransmitter.DeviceAddressAndName = BluetoothTransmitter.DeviceAddressAndName.notYetConnected(expectedName: expectedDeviceNameBubble)
@@ -91,6 +94,9 @@ class CGMBubbleTransmitter:BluetoothTransmitter, CGMTransmitter {
         
         // initialize timeStampLastBgReading
         self.timeStampLastBgReading = timeStampLastBgReading ?? Date(timeIntervalSince1970: 0)
+        
+        // initialize nonFixedSlopeEnabled
+        self.nonFixedSlopeEnabled = nonFixedSlopeEnabled ?? false
         
         // initialize webOOPEnabled
         self.webOOPEnabled = webOOPEnabled ?? false
@@ -264,6 +270,17 @@ class CGMBubbleTransmitter:BluetoothTransmitter, CGMTransmitter {
         
     // MARK: CGMTransmitter protocol functions
     
+    func setNonFixedSlopeEnabled(enabled: Bool) {
+        if nonFixedSlopeEnabled != enabled {
+            
+            nonFixedSlopeEnabled = enabled
+            
+            // nonFixed value changed, reset timeStampLastBgReading so that all glucose values will be sent to delegate. This is simply to ensure at least one reading will be sent to the delegate immediately.
+            timeStampLastBgReading = Date(timeIntervalSince1970: 0)
+            
+        }
+    }
+    
     /// set webOOPEnabled value
     func setWebOOPEnabled(enabled: Bool) {
         
@@ -289,7 +306,11 @@ class CGMBubbleTransmitter:BluetoothTransmitter, CGMTransmitter {
     func cgmTransmitterType() -> CGMTransmitterType {
         return .Bubble
     }
-    
+
+    func isNonFixedSlopeEnabled() -> Bool {
+        return nonFixedSlopeEnabled
+    }
+
     func isWebOOPEnabled() -> Bool {
         return webOOPEnabled
     }

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Droplet/CGMDroplet1Transmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Droplet/CGMDroplet1Transmitter.swift
@@ -21,6 +21,9 @@ class CGMDroplet1Transmitter:BluetoothTransmitter, CGMTransmitter {
     /// CGMDropletTransmitterDelegate
     public weak var cGMDropletTransmitterDelegate: CGMDropletTransmitterDelegate?
     
+    /// is nonFixed enabled for the transmitter or not
+    private var nonFixedSlopeEnabled: Bool
+    
     /// for trace
     private let log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryCGMDroplet1)
     
@@ -33,7 +36,7 @@ class CGMDroplet1Transmitter:BluetoothTransmitter, CGMTransmitter {
     ///     - name : if already connected before, then give here the name that was received during previous connect, if not give nil
     ///     - bluetoothTransmitterDelegate : a NluetoothTransmitterDelegate
     ///     - cGMTransmitterDelegate : a CGMTransmitterDelegate
-    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMDropletTransmitterDelegate : CGMDropletTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate) {
+    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMDropletTransmitterDelegate : CGMDropletTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate, nonFixedSlopeEnabled: Bool?) {
         
         // assign addressname and name or expected devicename
         var newAddressAndName:BluetoothTransmitter.DeviceAddressAndName = BluetoothTransmitter.DeviceAddressAndName.notYetConnected(expectedName: "limitter")
@@ -46,6 +49,9 @@ class CGMDroplet1Transmitter:BluetoothTransmitter, CGMTransmitter {
         
         // assign cGMDropletTransmitterDelegate
         self.cGMDropletTransmitterDelegate = cGMDropletTransmitterDelegate
+        
+        // initialize nonFixedSlopeEnabled
+        self.nonFixedSlopeEnabled = nonFixedSlopeEnabled ?? false
         
         super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: nil, servicesCBUUIDs: [CBUUID(string: CBUUID_Service_Droplet)], CBUUID_ReceiveCharacteristic: CBUUID_ReceiveCharacteristic_Droplet, CBUUID_WriteCharacteristic: CBUUID_WriteCharacteristic_Droplet, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
         
@@ -122,6 +128,10 @@ class CGMDroplet1Transmitter:BluetoothTransmitter, CGMTransmitter {
     
     // MARK: CGMTransmitter protocol functions
     
+    func setNonFixedSlopeEnabled(enabled: Bool) {
+        nonFixedSlopeEnabled = enabled
+    }
+
     /// this transmitter does not support oopWeb
     func setWebOOPEnabled(enabled: Bool) {
     }
@@ -136,6 +146,10 @@ class CGMDroplet1Transmitter:BluetoothTransmitter, CGMTransmitter {
     
     func isWebOOPEnabled() -> Bool {
         return false
+    }
+
+    func isNonFixedSlopeEnabled() -> Bool {
+        return nonFixedSlopeEnabled
     }
 
     func requestNewReading() {

--- a/xdrip/BluetoothTransmitter/CGM/Libre/GNSEntry/CGMGNSEntryTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/GNSEntry/CGMGNSEntryTransmitter.swift
@@ -68,6 +68,9 @@ class CGMGNSEntryTransmitter:BluetoothTransmitter, CGMTransmitter {
     
     /// CGMGNSEntryTransmitterDelegate
     public weak var cGMGNSEntryTransmitterDelegate: CGMGNSEntryTransmitterDelegate?
+    
+    /// is nonFixed enabled for the transmitter or not
+    public var nonFixedSlopeEnabled: Bool
 
     /// for trace
     private let log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryCGMGNSEntry)
@@ -99,7 +102,7 @@ class CGMGNSEntryTransmitter:BluetoothTransmitter, CGMTransmitter {
     ///     - bluetoothTransmitterDelegate : a BluetoothTransmitterDelegate
     ///     - cGMTransmitterDelegate : a CGMTransmitterDelegate
     ///     - cGMGNSEntryTransmitterDelegate : a CGMGNSEntryTransmitterDelegate
-    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMGNSEntryTransmitterDelegate : CGMGNSEntryTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate, timeStampLastBgReading: Date?) {
+    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMGNSEntryTransmitterDelegate : CGMGNSEntryTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate, timeStampLastBgReading: Date?, nonFixedSlopeEnabled: Bool?) {
         
         // assign addressname and name or expected devicename
         var newAddressAndName:BluetoothTransmitter.DeviceAddressAndName = BluetoothTransmitter.DeviceAddressAndName.notYetConnected(expectedName: "GNSentry")
@@ -110,6 +113,9 @@ class CGMGNSEntryTransmitter:BluetoothTransmitter, CGMTransmitter {
         //initialize timeStampLastBgReading
         self.timeStampLastBgReadingInMinutes = timeStampLastBgReading != nil ? timeStampLastBgReading!.toMillisecondsAsDouble()/1000/60 : Date(timeIntervalSince1970: 0).toMillisecondsAsDouble()/1000/60
         
+        // initialize nonFixedSlopeEnabled
+        self.nonFixedSlopeEnabled = nonFixedSlopeEnabled ?? false
+        
         // initialize
         super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: nil, servicesCBUUIDs: [CBUUID(string: CBUUID_GNWService), CBUUID(string: CBUUID_BatteryService), CBUUID(string: CBUUID_DeviceInformationService)], CBUUID_ReceiveCharacteristic: CBUUID_Characteristic_UUID.CBUUID_GNW_Notify.rawValue, CBUUID_WriteCharacteristic: CBUUID_Characteristic_UUID.CBUUID_GNW_Write.rawValue, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
         
@@ -118,6 +124,7 @@ class CGMGNSEntryTransmitter:BluetoothTransmitter, CGMTransmitter {
         
         // assign cGMGNSEntryTransmitterDelegate
         self.cGMGNSEntryTransmitterDelegate = cGMGNSEntryTransmitterDelegate
+        
         
     }
     
@@ -251,6 +258,10 @@ class CGMGNSEntryTransmitter:BluetoothTransmitter, CGMTransmitter {
     
     func setWebOOPEnabled(enabled: Bool) {
     }
+
+    func setNonFixedSlopeEnabled(enabled: Bool) {
+        nonFixedSlopeEnabled = enabled
+    }
     
     func setWebOOPSite(oopWebSite: String) {}
     
@@ -262,6 +273,10 @@ class CGMGNSEntryTransmitter:BluetoothTransmitter, CGMTransmitter {
     
     func isWebOOPEnabled() -> Bool {
         return false
+    }
+
+    func isNonFixedSlopeEnabled() -> Bool {
+        return nonFixedSlopeEnabled
     }
     
     func requestNewReading() {

--- a/xdrip/BluetoothTransmitter/CGM/Libre/MiaoMiao/CGMMiaoMiaoTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/MiaoMiao/CGMMiaoMiaoTransmitter.swift
@@ -49,6 +49,9 @@ class CGMMiaoMiaoTransmitter:BluetoothTransmitter, CGMTransmitter {
     /// is the transmitter oop web enabled or not
     private var webOOPEnabled: Bool
     
+    /// is nonFixed enabled for the transmitter or not
+    private var nonFixedSlopeEnabled: Bool
+    
     /// oop website url to use in case oop web would be enabled
     private var oopWebSite: String
     
@@ -72,7 +75,7 @@ class CGMMiaoMiaoTransmitter:BluetoothTransmitter, CGMTransmitter {
     ///     - bluetoothTransmitterDelegate : a BluetoothTransmitterDelegate
     ///     - cGMTransmitterDelegate : a CGMTransmitterDelegate
     ///     - cGMMiaoMiaoTransmitterDelegate : a CGMMiaoMiaoTransmitterDelegate
-    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMMiaoMiaoTransmitterDelegate : CGMMiaoMiaoTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate, timeStampLastBgReading: Date?, sensorSerialNumber:String?, webOOPEnabled: Bool?, oopWebSite: String?, oopWebToken: String?) {
+    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMMiaoMiaoTransmitterDelegate : CGMMiaoMiaoTransmitterDelegate, cGMTransmitterDelegate:CGMTransmitterDelegate, timeStampLastBgReading: Date?, sensorSerialNumber:String?, webOOPEnabled: Bool?, oopWebSite: String?, oopWebToken: String?, nonFixedSlopeEnabled: Bool?) {
         
         // assign addressname and name or expected devicename
         var newAddressAndName:BluetoothTransmitter.DeviceAddressAndName = BluetoothTransmitter.DeviceAddressAndName.notYetConnected(expectedName: expectedDeviceNameMiaoMiao)
@@ -102,6 +105,9 @@ class CGMMiaoMiaoTransmitter:BluetoothTransmitter, CGMTransmitter {
         // initialize oopWebToken and oopWebSite
         self.oopWebToken = oopWebToken ?? ConstantsLibre.token
         self.oopWebSite = oopWebSite ?? ConstantsLibre.site
+        
+        // initialize nonFixedSlopeEnabled
+        self.nonFixedSlopeEnabled = nonFixedSlopeEnabled ?? false
 
         super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: nil, servicesCBUUIDs: [CBUUID(string: CBUUID_Service_MiaoMiao)], CBUUID_ReceiveCharacteristic: CBUUID_ReceiveCharacteristic_MiaoMiao, CBUUID_WriteCharacteristic: CBUUID_WriteCharacteristic_MiaoMiao, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
         
@@ -305,6 +311,18 @@ class CGMMiaoMiaoTransmitter:BluetoothTransmitter, CGMTransmitter {
     
     func isWebOOPEnabled() -> Bool {
         return webOOPEnabled
+    }
+    
+    func setNonFixedSlopeEnabled(enabled: Bool) {
+        nonFixedSlopeEnabled = enabled
+        
+        // immediately request a new reading
+        // there's no check here to see if peripheral, characteristic, connection, etc.. exists, but that's no issue. If anything's missing, write will simply fail,
+       _ = sendStartReadingCommand()
+    }
+    
+    func isNonFixedSlopeEnabled() -> Bool {
+        return nonFixedSlopeEnabled
     }
     
     func setWebOOPSite(oopWebSite: String) {

--- a/xdrip/BluetoothTransmitter/watlaa/WatlaaBluetoothTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/watlaa/WatlaaBluetoothTransmitter.swift
@@ -78,6 +78,9 @@ final class WatlaaBluetoothTransmitter: BluetoothTransmitter {
     /// is the transmitter oop web enabled or not
     public var webOOPEnabled: Bool
     
+    /// is nonFixed enabled for the transmitter or not
+    public var nonFixedSlopeEnabled: Bool
+    
     /// oop website url to use in case oop web would be enabled
     public var oopWebSite: String
     
@@ -130,7 +133,7 @@ final class WatlaaBluetoothTransmitter: BluetoothTransmitter {
     ///     - cgmTransmitterDelegate : CGMTransmitterDelegate
     ///     - watlaaBluetoothTransmitterDelegate : the WatlaaBluetoothTransmitterDelegate
     ///     - bluetoothTransmitterDelegate : BluetoothTransmitterDelegate
-    init(address:String?, name: String?, cgmTransmitterDelegate:CGMTransmitterDelegate?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, watlaaBluetoothTransmitterDelegate: WatlaaBluetoothTransmitterDelegate, timeStampLastBgReading: Date?, sensorSerialNumber:String?, webOOPEnabled: Bool?, oopWebSite: String?, oopWebToken: String?) {
+    init(address:String?, name: String?, cgmTransmitterDelegate:CGMTransmitterDelegate?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, watlaaBluetoothTransmitterDelegate: WatlaaBluetoothTransmitterDelegate, timeStampLastBgReading: Date?, sensorSerialNumber:String?, webOOPEnabled: Bool?, oopWebSite: String?, oopWebToken: String?, nonFixedSlopeEnabled: Bool?) {
         
         // assign addressname and name or expected devicename
         var newAddressAndName:BluetoothTransmitter.DeviceAddressAndName = BluetoothTransmitter.DeviceAddressAndName.notYetConnected(expectedName: "watlaa")
@@ -153,6 +156,9 @@ final class WatlaaBluetoothTransmitter: BluetoothTransmitter {
         
         // initialize webOOPEnabled
         self.webOOPEnabled = webOOPEnabled ?? false
+
+        // initialize nonFixedSlopeEnabled
+        self.nonFixedSlopeEnabled = nonFixedSlopeEnabled ?? false
         
         // initialize oopWebToken and oopWebSite
         self.oopWebToken = oopWebToken ?? ConstantsLibre.token

--- a/xdrip/BluetoothTransmitter/watlaa/WatlaaBluetoothTransmitterMaster+CGMTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/watlaa/WatlaaBluetoothTransmitterMaster+CGMTransmitter.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension WatlaaBluetoothTransmitter: CGMTransmitter {
-
+ 
     func setWebOOPSite(oopWebSite: String) {
         
         self.oopWebSite = oopWebSite
@@ -23,6 +23,14 @@ extension WatlaaBluetoothTransmitter: CGMTransmitter {
         _ = sendStartReadingCommand()
         
     }
+
+    func setNonFixedSlopeEnabled(enabled: Bool) {
+        nonFixedSlopeEnabled = enabled
+        
+        // immediately request a new reading
+        // there's no check here to see if peripheral, characteristic, connection, etc.. exists, but that's no issue. If anything's missing, write will simply fail,
+        _ = sendStartReadingCommand()
+    }
     
     func cgmTransmitterType() -> CGMTransmitterType {
         return .watlaa
@@ -30,6 +38,10 @@ extension WatlaaBluetoothTransmitter: CGMTransmitter {
     
     func isWebOOPEnabled() -> Bool {
         return webOOPEnabled
+    }
+
+        func isNonFixedSlopeEnabled() -> Bool {
+        return nonFixedSlopeEnabled
     }
 
     func requestNewReading() {

--- a/xdrip/Calibration/Libre1NonFixedSlopeCalibrator.swift
+++ b/xdrip/Calibration/Libre1NonFixedSlopeCalibrator.swift
@@ -1,0 +1,15 @@
+//
+//  Libre1NonFixedSlopeCalibrator.swift
+//  xdrip
+//
+//  Created by Tudor-Andrei Vrabie on 05/07/2020.
+//  Copyright © 2020 Johan Degraeve. All rights reserved.
+//
+
+import Foundation
+
+class Libre1NonFixedSlopeCalibrator:Calibrator {
+    let sParams: SlopeParameters = SlopeParameters(LOW_SLOPE_1: 0.55, LOW_SLOPE_2: 0.50, HIGH_SLOPE_1: 1.5, HIGH_SLOPE_2: 1.6, DEFAULT_LOW_SLOPE_LOW: 0.55, DEFAULT_LOW_SLOPE_HIGH: 0.50, DEFAULT_SLOPE: 1, DEFAULT_HIGH_SLOPE_HIGH: 1.5, DEFAUL_HIGH_SLOPE_LOW: 1.4)
+    
+    let ageAdjustMentNeeded: Bool = false
+}

--- a/xdrip/Constants/ConstantsLibre.swift
+++ b/xdrip/Constants/ConstantsLibre.swift
@@ -1,6 +1,9 @@
 /// constants related to Libre OOP
 enum ConstantsLibre {
 
+    /// is nonFixed enabled by default yes or no
+    static let defaultNonFixedSlopeEnabled = false
+    
     /// is web oop enabled by default yes or no
     static let defaultWebOOPEnabled = false
     

--- a/xdrip/Core Data/classes/BLEPeripheral+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/BLEPeripheral+CoreDataClass.swift
@@ -24,6 +24,7 @@ public class BLEPeripheral: NSManagedObject {
         self.parameterUpdateNeededAtNextConnect = false
      
         webOOPEnabled = ConstantsLibre.defaultWebOOPEnabled
+        nonFixedSlopeEnabled = ConstantsLibre.defaultNonFixedSlopeEnabled
         
     }
     

--- a/xdrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
@@ -24,10 +24,13 @@ extension BLEPeripheral {
 
     /// typical for M5Stack but can also be applicable for other device types. If app is connected, and user makes an update to one of the attributes, then the new value can immediately be sent. If app is not connected, then the sending must happen as soon as reconnect occurs. Then parameterUpdateNeededAtNextConnect will be set to true
     @NSManaged public var parameterUpdateNeededAtNextConnect: Bool
-    
+        
+    /// should non fixed slopes be used or not - defined here to make it easier for coding, although not every type of bluetoothperipheral needs this
+    @NSManaged public var nonFixedSlopeEnabled: Bool
+
     /// should weboop be used or not - defined here to make it easier for coding, although not every type of bluetoothperipheral needs this
     @NSManaged public var webOOPEnabled: Bool
-    
+
     /// web oop site - defined here to make it easier for coding, although not every type of bluetoothperipheral needs this
     @NSManaged public var oopWebSite: String?
     

--- a/xdrip/Core Data/xdrip.xcdatamodeld/xdrip v11.xcdatamodel/contents
+++ b/xdrip/Core Data/xdrip.xcdatamodeld/xdrip v11.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19C57" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19F101" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AlertEntry" representedClassName=".AlertEntry" syncable="YES">
         <attribute name="alertkind" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="start" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
@@ -42,6 +42,7 @@
         <attribute name="alias" optional="YES" attributeType="String"/>
         <attribute name="lastConnectionStatusChangeTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
+        <attribute name="nonFixedSlopeEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="oopWebSite" optional="YES" attributeType="String"/>
         <attribute name="oopWebToken" optional="YES" attributeType="String"/>
         <attribute name="parameterUpdateNeededAtNextConnect" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -150,7 +151,7 @@
         <element name="AlertEntry" positionX="-648" positionY="189" width="128" height="105"/>
         <element name="AlertType" positionX="-657" positionY="180" width="128" height="165"/>
         <element name="BgReading" positionX="-285.87109375" positionY="31.9921875" width="128" height="330"/>
-        <element name="BLEPeripheral" positionX="-630" positionY="216" width="128" height="358"/>
+        <element name="BLEPeripheral" positionX="-630" positionY="216" width="128" height="373"/>
         <element name="Blucon" positionX="-657" positionY="189" width="128" height="73"/>
         <element name="BlueReader" positionX="-639" positionY="207" width="128" height="58"/>
         <element name="Bubble" positionX="-657" positionY="189" width="128" height="103"/>

--- a/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
+++ b/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
@@ -133,7 +133,7 @@ class BluetoothPeripheralManager: NSObject {
                             
                             // create an instance of WatlaaBluetoothTransmitter, WatlaaBluetoothTransmitter will automatically try to connect to the watlaa with the address that is stored in watlaa
                             // add it to the array of bluetoothTransmitters
-                            bluetoothTransmitters.insert(WatlaaBluetoothTransmitter(address: watlaa.blePeripheral.address, name: watlaa.blePeripheral.name, cgmTransmitterDelegate: cgmTransmitterDelegate, bluetoothTransmitterDelegate: self, watlaaBluetoothTransmitterDelegate: self, timeStampLastBgReading: watlaa.timeStampLastBgReading, sensorSerialNumber: watlaa.blePeripheral.sensorSerialNumber, webOOPEnabled: watlaa.blePeripheral.webOOPEnabled, oopWebSite: watlaa.blePeripheral.oopWebSite, oopWebToken: watlaa.blePeripheral.oopWebToken), at: index)
+                            bluetoothTransmitters.insert(WatlaaBluetoothTransmitter(address: watlaa.blePeripheral.address, name: watlaa.blePeripheral.name, cgmTransmitterDelegate: cgmTransmitterDelegate, bluetoothTransmitterDelegate: self, watlaaBluetoothTransmitterDelegate: self, timeStampLastBgReading: watlaa.timeStampLastBgReading, sensorSerialNumber: watlaa.blePeripheral.sensorSerialNumber, webOOPEnabled: watlaa.blePeripheral.webOOPEnabled, oopWebSite: watlaa.blePeripheral.oopWebSite, oopWebToken: watlaa.blePeripheral.oopWebToken, nonFixedSlopeEnabled: watlaa.blePeripheral.nonFixedSlopeEnabled), at: index)
                             
                             // if watlaa is of type CGM, then assign the address to currentCgmTransmitterAddress, there shouldn't be any other bluetoothPeripherals of type .CGM with shouldconnect = true
                             if bluetoothPeripheralType.category() == .CGM {
@@ -204,7 +204,7 @@ class BluetoothPeripheralManager: NSObject {
                             
                             // create an instance of BubbleBluetoothTransmitter, BubbleBluetoothTransmitter will automatically try to connect to the Bubble with the address that is stored in bubble
                             // add it to the array of bluetoothTransmitters
-                            bluetoothTransmitters.insert(CGMBubbleTransmitter(address: bubble.blePeripheral.address, name: bubble.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMBubbleTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: bubble.timeStampLastBgReading, sensorSerialNumber: bubble.blePeripheral.sensorSerialNumber, webOOPEnabled: bubble.blePeripheral.webOOPEnabled, oopWebSite: bubble.blePeripheral.oopWebSite, oopWebToken: bubble.blePeripheral.oopWebToken), at: index)
+                            bluetoothTransmitters.insert(CGMBubbleTransmitter(address: bubble.blePeripheral.address, name: bubble.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMBubbleTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: bubble.timeStampLastBgReading, sensorSerialNumber: bubble.blePeripheral.sensorSerialNumber, webOOPEnabled: bubble.blePeripheral.webOOPEnabled, oopWebSite: bubble.blePeripheral.oopWebSite, oopWebToken: bubble.blePeripheral.oopWebToken, nonFixedSlopeEnabled: bubble.blePeripheral.nonFixedSlopeEnabled), at: index)
                             
                             // if BubbleType is of type CGM, then assign the address to currentCgmTransmitterAddress, there shouldn't be any other bluetoothPeripherals of type .CGM with shouldconnect = true
                             if bluetoothPeripheralType.category() == .CGM {
@@ -231,7 +231,7 @@ class BluetoothPeripheralManager: NSObject {
                             
                             // create an instance of CGMMiaoMiaoTransmitter, CGMMiaoMiaoTransmitter will automatically try to connect to the Bubble with the address that is stored in bubble
                             // add it to the array of bluetoothTransmitters
-                            bluetoothTransmitters.insert(CGMMiaoMiaoTransmitter(address: miaoMiao.blePeripheral.address, name: miaoMiao.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMMiaoMiaoTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: miaoMiao.timeStampLastBgReading, sensorSerialNumber: miaoMiao.blePeripheral.sensorSerialNumber, webOOPEnabled: miaoMiao.blePeripheral.webOOPEnabled, oopWebSite: miaoMiao.blePeripheral.oopWebSite, oopWebToken: miaoMiao.blePeripheral.oopWebToken), at: index)
+                            bluetoothTransmitters.insert(CGMMiaoMiaoTransmitter(address: miaoMiao.blePeripheral.address, name: miaoMiao.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMMiaoMiaoTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: miaoMiao.timeStampLastBgReading, sensorSerialNumber: miaoMiao.blePeripheral.sensorSerialNumber, webOOPEnabled: miaoMiao.blePeripheral.webOOPEnabled, oopWebSite: miaoMiao.blePeripheral.oopWebSite, oopWebToken: miaoMiao.blePeripheral.oopWebToken, nonFixedSlopeEnabled: miaoMiao.blePeripheral.nonFixedSlopeEnabled), at: index)
                             
                             // if MiaoMiaoType is of type CGM, then assign the address to currentCgmTransmitterAddress, there shouldn't be any other bluetoothPeripherals of type .CGM with shouldconnect = true
                             if bluetoothPeripheralType.category() == .CGM {
@@ -289,7 +289,7 @@ class BluetoothPeripheralManager: NSObject {
                             
                             // create an instance of CGMDropletTransmitter, CGMDropletTransmitter will automatically try to connect to the Bubble with the address that is stored in bubble
                             // add it to the array of bluetoothTransmitters
-                            bluetoothTransmitters.insert(CGMDroplet1Transmitter(address: droplet.blePeripheral.address, name: droplet.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMDropletTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate), at: index)
+                            bluetoothTransmitters.insert(CGMDroplet1Transmitter(address: droplet.blePeripheral.address, name: droplet.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMDropletTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, nonFixedSlopeEnabled: droplet.blePeripheral.nonFixedSlopeEnabled), at: index)
                             
                             // if DropletType is of type CGM, then assign the address to currentCgmTransmitterAddress, there shouldn't be any other bluetoothPeripherals of type .CGM with shouldconnect = true
                             if bluetoothPeripheralType.category() == .CGM {
@@ -316,7 +316,7 @@ class BluetoothPeripheralManager: NSObject {
                             
                             // create an instance of CGMBlueReaderTransmitter, CGMBlueReaderTransmitter will automatically try to connect to the Bubble with the address that is stored in bubble
                             // add it to the array of bluetoothTransmitters
-                            bluetoothTransmitters.insert(CGMBlueReaderTransmitter(address: blueReader.blePeripheral.address, name: blueReader.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMBlueReaderTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate), at: index)
+                            bluetoothTransmitters.insert(CGMBlueReaderTransmitter(address: blueReader.blePeripheral.address, name: blueReader.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMBlueReaderTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, nonFixedSlopeEnabled: blueReader.blePeripheral.nonFixedSlopeEnabled), at: index)
                             
                             // if BlueReaderType is of type CGM, then assign the address to currentCgmTransmitterAddress, there shouldn't be any other bluetoothPeripherals of type .CGM with shouldconnect = true
                             if bluetoothPeripheralType.category() == .CGM {
@@ -343,7 +343,7 @@ class BluetoothPeripheralManager: NSObject {
                             
                             // create an instance of CGMGNSEntryTransmitter, CGMGNSEntryTransmitter will automatically try to connect to the Bubble with the address that is stored in bubble
                             // add it to the array of bluetoothTransmitters
-                            bluetoothTransmitters.insert(CGMGNSEntryTransmitter(address: gNSEntry.blePeripheral.address, name: gNSEntry.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMGNSEntryTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: gNSEntry.timeStampLastBgReading), at: index)
+                            bluetoothTransmitters.insert(CGMGNSEntryTransmitter(address: gNSEntry.blePeripheral.address, name: gNSEntry.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMGNSEntryTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: gNSEntry.timeStampLastBgReading, nonFixedSlopeEnabled: gNSEntry.blePeripheral.nonFixedSlopeEnabled), at: index)
                             
                             // if GNSentryType is of type CGM, then assign the address to currentCgmTransmitterAddress, there shouldn't be any other bluetoothPeripherals of type .CGM with shouldconnect = true
                             if bluetoothPeripheralType.category() == .CGM {
@@ -372,7 +372,7 @@ class BluetoothPeripheralManager: NSObject {
                                 
                                 // create an instance of CGMBluconTransmitter, CGMBluconTransmitter will automatically try to connect to the Bluon with the address that is stored in blucon
                                 // add it to the array of bluetoothTransmitters
-                                bluetoothTransmitters.insert(CGMBluconTransmitter(address: blucon.blePeripheral.address, name: blucon.blePeripheral.name, transmitterID: transmitterId, bluetoothTransmitterDelegate: self, cGMBluconTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: blucon.timeStampLastBgReading, sensorSerialNumber: blucon.blePeripheral.sensorSerialNumber), at: index)
+                                bluetoothTransmitters.insert(CGMBluconTransmitter(address: blucon.blePeripheral.address, name: blucon.blePeripheral.name, transmitterID: transmitterId, bluetoothTransmitterDelegate: self, cGMBluconTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: blucon.timeStampLastBgReading, sensorSerialNumber: blucon.blePeripheral.sensorSerialNumber, nonFixedSlopeEnabled: blucon.blePeripheral.nonFixedSlopeEnabled), at: index)
                                 
                                 // if bluconType is of type CGM, then assign the address to currentCgmTransmitterAddress, there shouldn't be any other bluetoothPeripherals of type .CGM with shouldconnect = true
                                 if bluetoothPeripheralType.category() == .CGM {
@@ -521,7 +521,7 @@ class BluetoothPeripheralManager: NSObject {
                     
                     if let watlaa = bluetoothPeripheral as? Watlaa {
                         
-                        newTransmitter = WatlaaBluetoothTransmitter(address: watlaa.blePeripheral.address, name: watlaa.blePeripheral.name, cgmTransmitterDelegate: cgmTransmitterDelegate, bluetoothTransmitterDelegate: self, watlaaBluetoothTransmitterDelegate: self, timeStampLastBgReading: nil, sensorSerialNumber: watlaa.blePeripheral.sensorSerialNumber, webOOPEnabled: watlaa.blePeripheral.webOOPEnabled, oopWebSite: watlaa.blePeripheral.oopWebSite, oopWebToken: watlaa.blePeripheral.oopWebToken)
+                        newTransmitter = WatlaaBluetoothTransmitter(address: watlaa.blePeripheral.address, name: watlaa.blePeripheral.name, cgmTransmitterDelegate: cgmTransmitterDelegate, bluetoothTransmitterDelegate: self, watlaaBluetoothTransmitterDelegate: self, timeStampLastBgReading: nil, sensorSerialNumber: watlaa.blePeripheral.sensorSerialNumber, webOOPEnabled: watlaa.blePeripheral.webOOPEnabled, oopWebSite: watlaa.blePeripheral.oopWebSite, oopWebToken: watlaa.blePeripheral.oopWebSite, nonFixedSlopeEnabled: watlaa.blePeripheral.nonFixedSlopeEnabled)
                         
                     }
                     
@@ -570,7 +570,7 @@ class BluetoothPeripheralManager: NSObject {
                     
                         if let cgmTransmitterDelegate = cgmTransmitterDelegate  {
                             
-                            newTransmitter = CGMBubbleTransmitter(address: bubble.blePeripheral.address, name: bubble.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMBubbleTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: bubble.blePeripheral.sensorSerialNumber, webOOPEnabled: bubble.blePeripheral.webOOPEnabled, oopWebSite: bubble.blePeripheral.oopWebSite, oopWebToken: bubble.blePeripheral.oopWebToken)
+                            newTransmitter = CGMBubbleTransmitter(address: bubble.blePeripheral.address, name: bubble.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMBubbleTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: bubble.blePeripheral.sensorSerialNumber, webOOPEnabled: bubble.blePeripheral.webOOPEnabled, oopWebSite: bubble.blePeripheral.oopWebSite, oopWebToken: bubble.blePeripheral.oopWebSite, nonFixedSlopeEnabled: bubble.blePeripheral.nonFixedSlopeEnabled)
                             
                         } else {
                             
@@ -585,7 +585,7 @@ class BluetoothPeripheralManager: NSObject {
                         
                         if let cgmTransmitterDelegate = cgmTransmitterDelegate  {
                             
-                            newTransmitter = CGMMiaoMiaoTransmitter(address: miaoMiao.blePeripheral.address, name: miaoMiao.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMMiaoMiaoTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: miaoMiao.blePeripheral.sensorSerialNumber, webOOPEnabled: miaoMiao.blePeripheral.webOOPEnabled, oopWebSite: miaoMiao.blePeripheral.oopWebSite, oopWebToken: miaoMiao.blePeripheral.oopWebToken)
+                            newTransmitter = CGMMiaoMiaoTransmitter(address: miaoMiao.blePeripheral.address, name: miaoMiao.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMMiaoMiaoTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: miaoMiao.blePeripheral.sensorSerialNumber, webOOPEnabled: miaoMiao.blePeripheral.webOOPEnabled, oopWebSite: miaoMiao.blePeripheral.oopWebSite, oopWebToken: miaoMiao.blePeripheral.oopWebSite, nonFixedSlopeEnabled: miaoMiao.blePeripheral.nonFixedSlopeEnabled)
                             
                         } else {
                             
@@ -600,7 +600,7 @@ class BluetoothPeripheralManager: NSObject {
                         
                         if let cgmTransmitterDelegate = cgmTransmitterDelegate  {
                             
-                            newTransmitter = CGMDroplet1Transmitter(address: droplet.blePeripheral.address, name: droplet.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMDropletTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate)
+                            newTransmitter = CGMDroplet1Transmitter(address: droplet.blePeripheral.address, name: droplet.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMDropletTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, nonFixedSlopeEnabled: droplet.blePeripheral.nonFixedSlopeEnabled)
                             
                         } else {
                             
@@ -615,7 +615,7 @@ class BluetoothPeripheralManager: NSObject {
                         
                         if let cgmTransmitterDelegate = cgmTransmitterDelegate  {
                             
-                            newTransmitter = CGMGNSEntryTransmitter(address: gNSEntry.blePeripheral.address, name: gNSEntry.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMGNSEntryTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil)
+                            newTransmitter = CGMGNSEntryTransmitter(address: gNSEntry.blePeripheral.address, name: gNSEntry.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMGNSEntryTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, nonFixedSlopeEnabled: gNSEntry.blePeripheral.nonFixedSlopeEnabled)
                             
                         } else {
                             
@@ -630,7 +630,7 @@ class BluetoothPeripheralManager: NSObject {
                         
                         if let cgmTransmitterDelegate = cgmTransmitterDelegate  {
                             
-                            newTransmitter = CGMBlueReaderTransmitter(address: blueReader.blePeripheral.address, name: blueReader.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMBlueReaderTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate)
+                            newTransmitter = CGMBlueReaderTransmitter(address: blueReader.blePeripheral.address, name: blueReader.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMBlueReaderTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, nonFixedSlopeEnabled: blueReader.blePeripheral.nonFixedSlopeEnabled)
                             
                         } else {
                             
@@ -645,7 +645,7 @@ class BluetoothPeripheralManager: NSObject {
                         
                         if let transmitterId = blucon.blePeripheral.transmitterId, let cgmTransmitterDelegate = cgmTransmitterDelegate {
                             
-                            newTransmitter = CGMBluconTransmitter(address: blucon.blePeripheral.address, name: blucon.blePeripheral.name, transmitterID: transmitterId, bluetoothTransmitterDelegate: self, cGMBluconTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: blucon.blePeripheral.sensorSerialNumber)
+                            newTransmitter = CGMBluconTransmitter(address: blucon.blePeripheral.address, name: blucon.blePeripheral.name, transmitterID: transmitterId, bluetoothTransmitterDelegate: self, cGMBluconTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: blucon.blePeripheral.sensorSerialNumber, nonFixedSlopeEnabled: blucon.blePeripheral.nonFixedSlopeEnabled)
                             
                         } else {
                             
@@ -754,7 +754,7 @@ class BluetoothPeripheralManager: NSObject {
             
         case .WatlaaType:
             
-            return WatlaaBluetoothTransmitter(address: nil, name: nil, cgmTransmitterDelegate: cgmTransmitterDelegate, bluetoothTransmitterDelegate: self, watlaaBluetoothTransmitterDelegate: self, timeStampLastBgReading: nil, sensorSerialNumber: nil, webOOPEnabled: nil, oopWebSite: nil, oopWebToken: nil )
+            return WatlaaBluetoothTransmitter(address: nil, name: nil, cgmTransmitterDelegate: cgmTransmitterDelegate, bluetoothTransmitterDelegate: self, watlaaBluetoothTransmitterDelegate: self, timeStampLastBgReading: nil, sensorSerialNumber: nil, webOOPEnabled: nil, oopWebSite: nil, oopWebToken: nil, nonFixedSlopeEnabled: nil)
             
         case .DexcomG5Type:
             
@@ -778,7 +778,7 @@ class BluetoothPeripheralManager: NSObject {
                 fatalError("in createNewTransmitter, type DexcomG5Type, cgmTransmitterDelegate is nil")
             }
             
-            return CGMBubbleTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: self, cGMBubbleTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: nil, webOOPEnabled: nil, oopWebSite: nil, oopWebToken: nil)
+            return CGMBubbleTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: self, cGMBubbleTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: nil, webOOPEnabled: nil, oopWebSite: nil, oopWebToken: nil, nonFixedSlopeEnabled: nil)
             
         case .MiaoMiaoType:
             
@@ -786,7 +786,7 @@ class BluetoothPeripheralManager: NSObject {
                 fatalError("in createNewTransmitter, MiaoMiaoType, cgmTransmitterDelegate is nil")
             }
             
-            return CGMMiaoMiaoTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: self, cGMMiaoMiaoTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: nil, webOOPEnabled: nil, oopWebSite: nil, oopWebToken: nil)
+            return CGMMiaoMiaoTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: self, cGMMiaoMiaoTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: nil, webOOPEnabled: nil, oopWebSite: nil, oopWebToken: nil, nonFixedSlopeEnabled: nil)
             
         case .DropletType:
             
@@ -794,7 +794,7 @@ class BluetoothPeripheralManager: NSObject {
                 fatalError("in createNewTransmitter, DropletType, cgmTransmitterDelegate is nil")
             }
             
-            return CGMDroplet1Transmitter(address: nil, name: nil, bluetoothTransmitterDelegate: self, cGMDropletTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate)
+            return CGMDroplet1Transmitter(address: nil, name: nil, bluetoothTransmitterDelegate: self, cGMDropletTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, nonFixedSlopeEnabled: nil)
             
         case .GNSentryType:
             
@@ -802,7 +802,7 @@ class BluetoothPeripheralManager: NSObject {
                 fatalError("in createNewTransmitter, GNSEntryType, cgmTransmitterDelegate is nil")
             }
             
-            return CGMGNSEntryTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: self, cGMGNSEntryTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil)
+            return CGMGNSEntryTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: self, cGMGNSEntryTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, nonFixedSlopeEnabled: nil)
             
         case .BlueReaderType:
             
@@ -811,7 +811,7 @@ class BluetoothPeripheralManager: NSObject {
             }
             
             
-            return CGMBlueReaderTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: self, cGMBlueReaderTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate)
+            return CGMBlueReaderTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: self, cGMBlueReaderTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, nonFixedSlopeEnabled: nil)
             
         case .BluconType:
             
@@ -819,7 +819,7 @@ class BluetoothPeripheralManager: NSObject {
                 fatalError("in createNewTransmitter, type BluconType, transmitterId is nil or cgmTransmitterDelegate is nil")
             }
             
-            return CGMBluconTransmitter(address: nil, name: nil, transmitterID: transmitterId, bluetoothTransmitterDelegate: self, cGMBluconTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: nil)
+            return CGMBluconTransmitter(address: nil, name: nil, transmitterID: transmitterId, bluetoothTransmitterDelegate: self, cGMBluconTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate, timeStampLastBgReading: nil, sensorSerialNumber: nil, nonFixedSlopeEnabled: nil)
 
         case .DexcomG4Type:
             
@@ -1109,6 +1109,22 @@ extension BluetoothPeripheralManager: BluetoothPeripheralManaging {
         }
         
         return nil
+        
+    }
+    
+    func receivedNewValue(nonFixedSlopeEnabled: Bool, for bluetoothPeripheral: BluetoothPeripheral) {
+        
+        if let cgmTransmitter = getCGMTransmitter(for: bluetoothPeripheral) {
+
+            cgmTransmitter.setNonFixedSlopeEnabled(enabled: nonFixedSlopeEnabled)
+            
+            // nonFixedSlopeEnabled changed, initate a reading immediately should user gets either a new value or a calibration request, depending on value of nonFixedSlopeEnabled
+            cgmTransmitter.requestNewReading()
+            
+            // call cgmTransmitterInfoChanged
+            cgmTransmitterInfoChanged()
+
+        }
         
     }
     

--- a/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManaging.swift
+++ b/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManaging.swift
@@ -45,6 +45,11 @@ protocol BluetoothPeripheralManaging: BluetoothTransmitterDelegate {
     
     /// bluetoothtransmitter may need pairing, but app is in background. Notification will be sent to user, user will open the app, at that moment initiatePairing will be called
     func initiatePairing()
+    
+    /// to pass new value off nonFixedSlopeEnabled
+    ///
+    /// when user changes the nonFixed value in BluetoothPeripheralViewController, this function will be called
+    func receivedNewValue(nonFixedSlopeEnabled: Bool, for bluetoothPeripheral: BluetoothPeripheral)
 
     /// to pass new value off webOOPEnabled
     ///

--- a/xdrip/Storyboards/en.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/en.lproj/SettingsViews.strings
@@ -15,6 +15,8 @@
 "settingsviews_givetransmitterid" = "Enter Transmitter ID";
 "settingsviews_resettransmitter" = "Reset Transmitter";
 "settingsviews_webooptransmitter" = "Use the OOPWeb Algorithm?";
+"settingsviews_nonfixedtransmitter" = "Use non-fixed slopes?";
+"settingsviews_labelNonFixed" = "Non-fixed calibration slopes";
 "settingsviews_labelWebOOPSite" = "OOPWeb Site URL:";
 "settingsviews_labelWebOOPtoken" = "OOPWeb Token:";
 "settingsviews_labelWebOOPSiteExplainingText" = "OPWeb Site URL (optional):";

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -98,6 +98,14 @@ class Texts_SettingsView {
         return NSLocalizedString("settingsviews_labelWebOOP", tableName: filename, bundle: Bundle.main, value: "OOPWeb Algorithm", comment: "weboop settings, title of the dialogs where site and token are asked - also used when viewing bluetoothperipheral settings, the title of the section")
     }()
     
+    static let labelNonFixedTransmitter:String = {
+        return NSLocalizedString("settingsviews_nonfixedtransmitter", tableName: filename, bundle: Bundle.main, value: "Use non-fixed slopes?", comment: "non fixed calibration slopes settings in bluetooth peripheral view : enabled or not")
+    }()
+    
+    static let labelNonFixed:String = {
+        return NSLocalizedString("settingsviews_labelNonFixed", tableName: filename, bundle: Bundle.main, value: "Non-fixed calibration slopes", comment: "non fixed settings, title of the section")
+    }()
+    
     static let transmitterId8OrHigherNotSupported: String = {
         return NSLocalizedString("transmitterId8OrHigherNotSupported", tableName: filename, bundle: Bundle.main, value: "Transmitters with ID 8Gxxxx or newer are not currently supported!", comment: "User sets a transmitter id with id 8G or higher. This is not supported")
     }()

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -213,6 +213,10 @@ final class RootViewController: UIViewController {
     /// current value of webOPEnabled, default false
     /// - used to detect changes in the value
     private var webOOPEnabled = ConstantsLibre.defaultWebOOPEnabled
+
+    /// current value of nonFixedSlopeEnabled, default false
+    /// - used to detect changes in the value
+    private var nonFixedSlopeEnabled = ConstantsLibre.defaultNonFixedSlopeEnabled
     
     // MARK: - View Life Cycle
     
@@ -440,6 +444,12 @@ final class RootViewController: UIViewController {
                     self.stopSensor()
                     
                 }
+                
+                if self.nonFixedSlopeEnabled != cgmTransmitter.isNonFixedSlopeEnabled() {
+                    
+                    self.stopSensor()
+                    
+                }
 
                 // check if the type of sensor supported by the cgmTransmitterType  has changed, if yes stop the sensor
                 if let currentTransmitterType = UserDefaults.standard.cgmTransmitterType, currentTransmitterType.sensorType() != cgmTransmitter.cgmTransmitterType().sensorType() {
@@ -450,6 +460,9 @@ final class RootViewController: UIViewController {
                 
                 // assign the new value of webOOPEnabled
                 self.webOOPEnabled = cgmTransmitter.isWebOOPEnabled()
+                
+                // assign the new value of nonFixedSlopeEnabled
+                self.nonFixedSlopeEnabled = cgmTransmitter.isNonFixedSlopeEnabled()
                 
                 // change value of UserDefaults.standard.transmitterTypeAsString
                 UserDefaults.standard.cgmTransmitterTypeAsString = cgmTransmitter.cgmTransmitterType().rawValue
@@ -849,6 +862,8 @@ final class RootViewController: UIViewController {
             
             if cgmTransmitter.isWebOOPEnabled() {
                 return NoCalibrator()
+            } else if cgmTransmitter.isNonFixedSlopeEnabled() {
+                return Libre1NonFixedSlopeCalibrator()
             } else {
                 return Libre1Calibrator()
             }

--- a/xdrip/xdrip.entitlements
+++ b/xdrip/xdrip.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.developer.healthkit.access</key>
 	<array/>
-	<key>com.apple.security.application-groups</key>
+    <key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.RNX44PP998.loopkit.LoopGroup</string>
 	</array>


### PR DESCRIPTION
Add an option in the transmitter menu to enable non-fixed calibration slopes for Libre sensors. The slope parameters are taken from Spike/xDrip+. Tested with MM2 + Libre 1, and simulated other transmitters by enabling and disabling canUseNonFixed/canWebOOP for the Miaomiao.

The transmitter menu will look like this for a Libre transmitter that doesn't support web oop (Blucon, Droplet, etc):

<img src="https://user-images.githubusercontent.com/16063287/86542852-65b60b80-bf11-11ea-9901-c1b3a0d713f5.jpg" width="400">

<img src="https://user-images.githubusercontent.com/16063287/86542854-66e73880-bf11-11ea-89e1-1c20fd40365c.jpg" width="400">
<br>

This is for a transmitter that supports both web oop and non fixed slopes (Miaomiao, Bubble):

<img src="https://user-images.githubusercontent.com/16063287/86542859-69e22900-bf11-11ea-9a98-799f9c9e7856.jpg" width="400">

<img src="https://user-images.githubusercontent.com/16063287/86542860-6a7abf80-bf11-11ea-8393-5cee6d0e567e.jpg" width="400">
 