### PR TITLE
Remove coloured objectives lines

### DIFF
--- a/xdrip/Constants/ConstantsGlucoseChart.swift
+++ b/xdrip/Constants/ConstantsGlucoseChart.swift
@@ -47,17 +47,11 @@ enum ConstantsGlucoseChart {
     // objective/target range guidelines. Will use either standard gray or colored lines
     // make use alpha components to make the perceived brightness of each line be the same to the user (otherwise red appears washed out)
     
-    /// color for urgent high and urgent low line, if showColoredObjectives is not enabled
+    /// color for urgent high and urgent low line
     static let guidelineUrgentHighLow = UIColor.lightGray.withAlphaComponent(0.8)
     
-    /// color for urgent high and urgent low line, if showColoredObjectives is not enabled
+    /// color for urgent high and urgent low line
     static let guidelineHighLow = UIColor.lightGray.withAlphaComponent(1)
-    
-    /// color for urgent high and urgent low line, if showColoredObjectives is enabled
-    static let guidelineUrgentHighLowColor = UIColor.red.withAlphaComponent(0.8)
-    
-    /// color for high and low line, if showColoredObjectives is enabled
-    static let guidelineHighLowColor = UIColor.yellow.withAlphaComponent(0.7)
     
     /// color for target line
     static let guidelineTargetColor = UIColor.green.withAlphaComponent(0.5)

--- a/xdrip/Extensions/UserDefaults.swift
+++ b/xdrip/Extensions/UserDefaults.swift
@@ -44,8 +44,6 @@ extension UserDefaults {
         case lowMarkValue = "lowMarkValue"
         /// urgent low value
         case urgentLowMarkValue = "urgentLowMarkValue"
-        /// master or follower
-        case showColoredObjectives = "showColoredObjectives"
         /// show the target line or hide it?
         case showTarget = "showTarget"
         /// target value
@@ -592,17 +590,6 @@ extension UserDefaults {
         }
         set {
             set(!newValue, forKey: Key.useObjectives.rawValue)
-        }
-    }
-    
-    /// should the Guidelines be shown in color (yellow/red) on the graph?
-    @objc dynamic var showColoredObjectives: Bool {
-        // default value for bool in userdefaults is false, by default we want the guidelines to be shown in grey as per Nightscout
-        get {
-            return !bool(forKey: Key.showColoredObjectives.rawValue)
-        }
-        set {
-            set(!newValue, forKey: Key.showColoredObjectives.rawValue)
         }
     }
     

--- a/xdrip/Managers/Charts/GlucoseChartManager.swift
+++ b/xdrip/Managers/Charts/GlucoseChartManager.swift
@@ -534,9 +534,9 @@ public final class GlucoseChartManager {
         let gridLayer = ChartGuideLinesForValuesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, settings: data().chartGuideLinesLayerSettings, axisValuesX: Array(xAxisValues.dropFirst().dropLast()), axisValuesY: yAxisValues)
         
         // high/low/target guideline layer settings and styles
-        let urgentHighLowLineLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: UserDefaults.standard.showColoredObjectives ? ConstantsGlucoseChart.guidelineUrgentHighLowColor : ConstantsGlucoseChart.guidelineUrgentHighLow, linesWidth: UserDefaults.standard.useObjectives ? 1 : 0, dotWidth: 2, dotSpacing: 5)
+        let urgentHighLowLineLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: ConstantsGlucoseChart.guidelineUrgentHighLow, linesWidth: UserDefaults.standard.useObjectives ? 1 : 0, dotWidth: 2, dotSpacing: 5)
         
-        let highLowLineLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: UserDefaults.standard.showColoredObjectives ? ConstantsGlucoseChart.guidelineHighLowColor : ConstantsGlucoseChart.guidelineHighLow, linesWidth: UserDefaults.standard.useObjectives ? 1 : 0, dotWidth: 4, dotSpacing: 2)
+        let highLowLineLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: ConstantsGlucoseChart.guidelineHighLow, linesWidth: UserDefaults.standard.useObjectives ? 1 : 0, dotWidth: 4, dotSpacing: 2)
         
         let targetLineLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: ConstantsGlucoseChart.guidelineTargetColor, linesWidth: UserDefaults.standard.useObjectives ? (UserDefaults.standard.showTarget ? 1 : 0) : 0, dotWidth: 4, dotSpacing: 0)
         

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -78,10 +78,6 @@ class Texts_SettingsView {
         return NSLocalizedString("settingsviews_urgentlowValue", tableName: filename, bundle: Bundle.main, value: "Urgent Low Value:", comment: "home screen settings, urgent low value")
     }()
     
-    static let labelShowColoredObjectives: String = {
-        return NSLocalizedString("settingsviews_showcoloredobjectives", tableName: filename, bundle: Bundle.main, value: "Show Colored Lines?", comment: "home screen settings, show colored objectives lines")
-    }()
-    
     static let labelShowTarget: String = {
         return NSLocalizedString("settingsviews_showtarget", tableName: filename, bundle: Bundle.main, value: "Show Target Line?", comment: "home screen settings, show target line")
     }()

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewHomeScreenSettingsViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewHomeScreenSettingsViewModel.swift
@@ -25,14 +25,11 @@ fileprivate enum Setting:Int, CaseIterable {
     //use objectives in graph?
     case useObjectives = 4
     
-    //show colored objective lines?
-    case showColoredObjectives = 5
-    
     //show target line?
-    case showTarget = 6
+    case showTarget = 5
     
     //target value
-    case targetMarkValue = 7
+    case targetMarkValue = 6
     
 }
 
@@ -47,10 +44,7 @@ struct SettingsViewHomeScreenSettingsViewModel:SettingsViewModelProtocol {
 
         case .useObjectives:
             return UISwitch(isOn: UserDefaults.standard.useObjectives, action: {(isOn:Bool) in UserDefaults.standard.useObjectives = isOn})
-            
-        case .showColoredObjectives:
-            return UISwitch(isOn: UserDefaults.standard.showColoredObjectives, action: {(isOn:Bool) in UserDefaults.standard.showColoredObjectives = isOn})
-            
+                        
         case .showTarget :
             return UISwitch(isOn: UserDefaults.standard.showTarget, action: {(isOn:Bool) in UserDefaults.standard.showTarget = isOn})
             
@@ -102,15 +96,6 @@ struct SettingsViewHomeScreenSettingsViewModel:SettingsViewModelProtocol {
                         UserDefaults.standard.useObjectives = true
                     }
                 })
-
-            case .showColoredObjectives:
-                return SettingsSelectedRowAction.callFunction(function: {
-                    if UserDefaults.standard.showColoredObjectives {
-                        UserDefaults.standard.showColoredObjectives = false
-                    } else {
-                        UserDefaults.standard.showColoredObjectives = true
-                    }
-                })
             
             case .showTarget:
                 return SettingsSelectedRowAction.callFunction(function: {
@@ -138,7 +123,7 @@ struct SettingsViewHomeScreenSettingsViewModel:SettingsViewModelProtocol {
         } else if UserDefaults.standard.useObjectives && !UserDefaults.standard.showTarget {
             return Setting.allCases.count - 1
         } else {
-            return Setting.allCases.count - 3
+            return Setting.allCases.count - 2
         }
     }
     
@@ -161,9 +146,6 @@ struct SettingsViewHomeScreenSettingsViewModel:SettingsViewModelProtocol {
                 
             case .useObjectives:
                 return Texts_SettingsView.labelUseObjectives
-            
-            case .showColoredObjectives:
-                return Texts_SettingsView.labelShowColoredObjectives
             
             case .showTarget:
                 return Texts_SettingsView.labelShowTarget
@@ -191,9 +173,6 @@ struct SettingsViewHomeScreenSettingsViewModel:SettingsViewModelProtocol {
             return UITableViewCell.AccessoryType.disclosureIndicator
 
         case .useObjectives:
-            return UITableViewCell.AccessoryType.disclosureIndicator
-
-        case .showColoredObjectives:
             return UITableViewCell.AccessoryType.disclosureIndicator
 
         case .showTarget:
@@ -225,7 +204,7 @@ struct SettingsViewHomeScreenSettingsViewModel:SettingsViewModelProtocol {
         case .targetMarkValue:
             return UserDefaults.standard.targetMarkValueInUserChosenUnit.bgValuetoString(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl)
             
-        case .useObjectives, .showColoredObjectives, .showTarget:
+        case .useObjectives, .showTarget:
             return nil
             
         }


### PR DESCRIPTION
With coloured glucose points, the coloured objective lines are no longer needed and are distracting.

This change will remove the option and revert all users back to grey objective/threshold lines as per Nightscout web view.