### PR TITLE
Working Nightscout treatments synchronization.

### DIFF
--- a/xdrip.xcodeproj/project.pbxproj
+++ b/xdrip.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		D40C3DA62775438F00111B73 /* TreatmentEntry+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40C3DA52775438F00111B73 /* TreatmentEntry+CoreDataProperties.swift */; };
 		D482BD942776153F003C4FB2 /* TreatmentsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D482BD932776153F003C4FB2 /* TreatmentsNavigationController.swift */; };
 		D484BC292774F783008490E9 /* TreatmentsInsertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D484BC282774F783008490E9 /* TreatmentsInsertViewController.swift */; };
+		D48E8F78278E49B300CCEE08 /* TreatmentNSResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48E8F77278E49B300CCEE08 /* TreatmentNSResponse.swift */; };
 		D4AC54502778C82C0097FF10 /* Treatments.strings in Resources */ = {isa = PBXBuildFile; fileRef = D4AC54412778C82B0097FF10 /* Treatments.strings */; };
 		D4BAF37627769B38009D3465 /* TreatmentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BAF37527769B38009D3465 /* TreatmentTableViewCell.swift */; };
 		D4E499AB277B43E3000F8CBA /* TreatmentCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E499AA277B43E3000F8CBA /* TreatmentCollection.swift */; };
@@ -694,6 +695,7 @@
 		D40C3DA52775438F00111B73 /* TreatmentEntry+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TreatmentEntry+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D482BD932776153F003C4FB2 /* TreatmentsNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreatmentsNavigationController.swift; sourceTree = "<group>"; };
 		D484BC282774F783008490E9 /* TreatmentsInsertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreatmentsInsertViewController.swift; sourceTree = "<group>"; };
+		D48E8F77278E49B300CCEE08 /* TreatmentNSResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreatmentNSResponse.swift; sourceTree = "<group>"; };
 		D4AC54422778C82B0097FF10 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Treatments.strings; sourceTree = "<group>"; };
 		D4AC54432778C82B0097FF10 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Treatments.strings; sourceTree = "<group>"; };
 		D4AC54442778C82B0097FF10 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Treatments.strings; sourceTree = "<group>"; };
@@ -1558,6 +1560,7 @@
 			children = (
 				D4E499AA277B43E3000F8CBA /* TreatmentCollection.swift */,
 				D4E499AC277B4CE7000F8CBA /* DateOnly.swift */,
+				D48E8F77278E49B300CCEE08 /* TreatmentNSResponse.swift */,
 			);
 			path = Treatments;
 			sourceTree = "<group>";
@@ -3724,6 +3727,7 @@
 				F8A2BC2D25DB0D6D001D1E78 /* BluetoothPeripheralManager+CGMG5TransmitterDelegate.swift in Sources */,
 				F8FDFEA9260DE1A70047597D /* DTCustomColoredAccessory.m in Sources */,
 				F8B3A7DF226E48C1004BA588 /* SoundPlayer.swift in Sources */,
+				D48E8F78278E49B300CCEE08 /* TreatmentNSResponse.swift in Sources */,
 				F816E12C2439DFBA009EE65B /* DexcomG4+CoreDataProperties.swift in Sources */,
 				F8A2BC3425DB0D6D001D1E78 /* BluetoothPeripheralManager+WatlaaBluetoothTransmitterDelegate.swift in Sources */,
 				F8B3A820227DEC92004BA588 /* AlertTypesAccessor.swift in Sources */,

--- a/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
+++ b/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
@@ -120,7 +120,7 @@ class TreatmentEntryAccessor {
 			let predicate = NSPredicate(format: "date < %@", to as NSDate)
 			fetchRequest.predicate = predicate
 		} else if let to = to, let from = from {
-			let predicate = NSPredicate(format: "date < %@ AND date > %@", to as CVarArg, from as NSDate)
+			let predicate = NSPredicate(format: "date < %@ AND date > %@", to as NSDate, from as NSDate)
 			fetchRequest.predicate = predicate
 		}
 		

--- a/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
+++ b/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
@@ -85,9 +85,7 @@ class TreatmentEntryAccessor {
 	/// - returns: an array with treatments, can be empty array.
 	///     Order by timestamp, descending meaning the treatment at index 0 is the youngest
    func getLatestTreatments(limit:Int?, fromDate:Date?) -> [TreatmentEntry] {
-		
 		return fetchTreatments(limit: limit, fromDate: fromDate)
-		
 	}
 	
 	/// gets last treatment
@@ -98,45 +96,6 @@ class TreatmentEntryAccessor {
 		} else {
 			return nil
 		}
-	}
-	
-	/// gets treatments, synchronously, in the managedObjectContext's thread
-	/// - returns:
-	///        treatments sorted by timestamp, ascending (ie first is oldest)
-	/// - parameters:
-	///     - to : if specified, only return treatments with timestamp  smaller than fromDate (not equal to)
-	///     - from : if specified, only return treatments with timestamp greater than fromDate (not equal to)
-	///     - managedObjectContext : the ManagedObjectContext to use
-	func getTreatments(from: Date?, to: Date?, on managedObjectContext: NSManagedObjectContext) -> [TreatmentEntry] {
-		
-		let fetchRequest: NSFetchRequest<TreatmentEntry> = TreatmentEntry.fetchRequest()
-		fetchRequest.sortDescriptors = [NSSortDescriptor(key: #keyPath(TreatmentEntry.date), ascending: true)]
-		
-		// create predicate
-		if let from = from, to == nil {
-			let predicate = NSPredicate(format: "date > %@", from as NSDate)
-			fetchRequest.predicate = predicate
-		} else if let to = to, from == nil {
-			let predicate = NSPredicate(format: "date < %@", to as NSDate)
-			fetchRequest.predicate = predicate
-		} else if let to = to, let from = from {
-			let predicate = NSPredicate(format: "date < %@ AND date > %@", to as NSDate, from as NSDate)
-			fetchRequest.predicate = predicate
-		}
-		
-		var treatments: [TreatmentEntry] = []
-		
-		managedObjectContext.performAndWait {
-			do {
-				// Execute Fetch Request
-				treatments = try fetchRequest.execute()
-			} catch {
-				let fetchError = error as NSError
-				trace("in getTreatments, Unable to Execute BgReading Fetch Request : %{public}@", log: self.log, category: ConstantsLog.categoryApplicationDataTreatments, type: .error, fetchError.localizedDescription)
-			}
-		}
-		
-		return treatments
 	}
 	
 	/// deletes treatmentEntry, synchronously, in the managedObjectContext's thread

--- a/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
+++ b/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
@@ -151,6 +151,18 @@ class TreatmentEntryAccessor {
 		return treatment
 	}
 	
+	public func newTreatmentsIfRequired(responses: [TreatmentNSResponse]) -> [TreatmentEntry] {
+		var newTreatments: [TreatmentEntry] = []
+		
+		for response in responses {
+			if !self.existsTreatmentWithId(response.id), let treatment = response.asNewTreatmentEntry(nsManagedObjectContext: coreDataManager.mainManagedObjectContext) {
+				newTreatments.append(treatment)
+			}
+		}
+		
+		return newTreatments
+	}
+	
 	// MARK: - private helper functions
 	
 	/// returnvalue can be empty array

--- a/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
+++ b/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
@@ -111,7 +111,7 @@ class TreatmentEntryAccessor {
 			do {
 				try managedObjectContext.save()
 			} catch {
-				trace("in delete bgReading,  Unable to Save Changes, error.localizedDescription  = %{public}@", log: self.log, category: ConstantsLog.categoryApplicationDataTreatments, type: .error, error.localizedDescription)
+				trace("in delete treatmentEntry,  Unable to Save Changes, error.localizedDescription  = %{public}@", log: self.log, category: ConstantsLog.categoryApplicationDataTreatments, type: .error, error.localizedDescription)
 			}
 		}
 	}
@@ -147,7 +147,7 @@ class TreatmentEntryAccessor {
 				treatments = try fetchRequest.execute()
 			} catch {
 				let fetchError = error as NSError
-				trace("in fetchTreatments, Unable to Execute BgReading Fetch Request : %{public}@", log: self.log, category: ConstantsLog.categoryApplicationDataTreatments, type: .error, fetchError.localizedDescription)
+				trace("in fetchTreatments, Unable to Execute fetchTreatments Fetch Request : %{public}@", log: self.log, category: ConstantsLog.categoryApplicationDataTreatments, type: .error, fetchError.localizedDescription)
 			}
 		}
 		

--- a/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
+++ b/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
@@ -116,6 +116,12 @@ class TreatmentEntryAccessor {
 		}
 	}
 	
+	/// Given an Id, returns if exists a treatment with that id.
+	///     - id : the id string
+	func existsTreatmentWithId(_ id: String) -> Bool {
+		return getTreatmentById(id) != nil
+	}
+	
 	/// Given an Id, returns the TreatmentEntry with that id, if it exists.
 	///     - id : the id string
 	func getTreatmentById(_ id: String) -> TreatmentEntry? {

--- a/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
+++ b/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
@@ -116,6 +116,35 @@ class TreatmentEntryAccessor {
 		}
 	}
 	
+	/// Given an Id, returns the TreatmentEntry with that id, if it exists.
+	///     - id : the id string
+	func getTreatmentById(_ id: String) -> TreatmentEntry? {
+		// EmptyId is not a valid id
+		guard id != TreatmentEntry.EmptyId else {
+			return nil
+		}
+		
+		let fetchRequest: NSFetchRequest<TreatmentEntry> = TreatmentEntry.fetchRequest()
+		// limit to 1, although there shouldn't be more than 1 with the same id.
+		fetchRequest.fetchLimit = 1
+		// Filter by id
+		fetchRequest.predicate = NSPredicate(format: "id == %@", id)
+		
+		var treatment: TreatmentEntry? = nil
+		coreDataManager.mainManagedObjectContext.performAndWait {
+			do {
+				// Execute Fetch Request
+				// Since it returns an array, get the first elem
+				treatment = (try fetchRequest.execute()).first
+			} catch {
+				let fetchError = error as NSError
+				trace("in fetchTreatments, Unable to Execute getTreatmentById Fetch Request : %{public}@", log: self.log, category: ConstantsLog.categoryApplicationDataTreatments, type: .error, fetchError.localizedDescription)
+			}
+		}
+
+		return treatment
+	}
+	
 	// MARK: - private helper functions
 	
 	/// returnvalue can be empty array

--- a/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
+++ b/xdrip/Core Data/accessors/TreatmentEntryAccessor.swift
@@ -29,15 +29,15 @@ class TreatmentEntryAccessor {
 	
 	// MARK: - public functions
 	
-	/// Gives the 50 latest treatments
+	/// Gives the 100 latest treatments
 	///
 	/// - returns: an array with treatments, can be empty array.
 	///     Order by timestamp, descending meaning the treatment at index 0 is the youngest
 	func getLatestTreatments() -> [TreatmentEntry] {
-		return getLatestTreatments(limit:50)
+		return getLatestTreatments(limit:100)
 	}
 	
-	/// Returns the treatments among the 50 latest
+	/// Returns the treatments among the latest
 	/// that have not yet been uploaded
 	///
 	/// - returns: an array with treatments not uploaded, can be empty array.

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
@@ -80,7 +80,7 @@ public class TreatmentEntry: NSManagedObject, Comparable {
 		self.date = date
 		self.value = value
 		self.treatmentType = treatmentType
-		self.id = ""  // defaults to empty
+		self.id = TreatmentEntry.EmptyId  // defaults to empty
 		self.uploaded = false  // tracks upload to nightscout
 	}
 

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
@@ -47,6 +47,19 @@ import CoreData
 			return Texts_TreatmentsView.questionMark
 		}
 	}
+	
+	public static func fromNightscoutString(_ string: String) -> TreatmentType? {
+		switch string {
+		case "Correction Bolus":
+			return .Insulin
+		case "Meal Bolus":
+			return .Carbs
+		case "Exercise":
+			return .Exercise
+		default:
+			return nil
+		}
+	}
 }
 
 
@@ -67,6 +80,7 @@ public class TreatmentEntry: NSManagedObject, Comparable {
 		self.date = date
 		self.value = value
 		self.treatmentType = treatmentType
+		self.id = ""  // defaults to empty
 		self.uploaded = false  // tracks upload to nightscout
 	}
 

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
@@ -76,12 +76,7 @@ public class TreatmentEntry: NSManagedObject, Comparable {
 	
 	/// Returns the displayValue: the .value with the proper unit.
 	public func displayValue() -> String {
-		var string = String(self.value)
-		// Checks prevents .0 from being displayed
-		if string.suffix(2) == ".0" {
-			string = String(string.dropLast(2))
-		}
-		return string + " " + self.treatmentType.unit()
+		return self.value.stringWithoutTrailingZeroes + " " + self.treatmentType.unit()
 	}
 	
 	/// Returns the dictionary representation required for nighscout post request.

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
@@ -69,10 +69,23 @@ import CoreData
 /// .value represents the amount (e.g. insulin units or carbs grams)
 /// the value unit is defined by the treatmentType.
 /// .treatmentType see TreatmentType
+/// .id is the Nightscout id, defaults to TreatmentEntry.EmptyId.
 /// .uploaded tells if entry has been uploaded for Nighscout or not.
 public class TreatmentEntry: NSManagedObject, Comparable {
 
-    init(date: Date, value: Double, treatmentType: TreatmentType, nsManagedObjectContext:NSManagedObjectContext) {
+    convenience init(date: Date, value: Double, treatmentType: TreatmentType, nsManagedObjectContext:NSManagedObjectContext) {
+		// Id defaults to Empty
+		self.init(id: TreatmentEntry.EmptyId, date: date, value: value, treatmentType: treatmentType, uploaded: false, nsManagedObjectContext: nsManagedObjectContext)
+	}
+	
+	convenience init(id: String, date: Date, value: Double, treatmentType: TreatmentType, nsManagedObjectContext:NSManagedObjectContext) {
+		
+		let uploaded = id != TreatmentEntry.EmptyId
+		
+		self.init(id: id, date: date, value: value, treatmentType: treatmentType, uploaded: uploaded, nsManagedObjectContext: nsManagedObjectContext)
+	}
+	
+	init(id: String, date: Date, value: Double, treatmentType: TreatmentType, uploaded: Bool, nsManagedObjectContext:NSManagedObjectContext) {
 		
 		let entity = NSEntityDescription.entity(forEntityName: "TreatmentEntry", in: nsManagedObjectContext)!
 		super.init(entity: entity, insertInto: nsManagedObjectContext)
@@ -80,8 +93,8 @@ public class TreatmentEntry: NSManagedObject, Comparable {
 		self.date = date
 		self.value = value
 		self.treatmentType = treatmentType
-		self.id = TreatmentEntry.EmptyId  // defaults to empty
-		self.uploaded = false  // tracks upload to nightscout
+		self.id = id
+		self.uploaded = uploaded  // tracks upload to nightscout
 	}
 
 	private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataProperties.swift
@@ -16,6 +16,8 @@ extension TreatmentEntry {
 	@nonobjc public class func fetchRequest() -> NSFetchRequest<TreatmentEntry> {
 		return NSFetchRequest<TreatmentEntry>(entityName: "TreatmentEntry")
 	}
+	
+	public static let EmptyId: String = ""
 
 	/// Date represents the date of the treatment, not the date of creation.
 	@NSManaged public var date: Date

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataProperties.swift
@@ -26,6 +26,9 @@ extension TreatmentEntry {
 	/// Enum TreatmentType defines which treatment this instance is.
 	@NSManaged public var treatmentType: TreatmentType
 	
+	/// Nightscout id, should be always generated at Nighscout and saved to core data when uploaded.
+	@NSManaged public var id: String
+	
 	/// Tells if this instance has been uploaded to Nightscout.
 	@NSManaged public var uploaded: Bool
 	

--- a/xdrip/Core Data/xdrip.xcdatamodeld/xdrip v16.xcdatamodel/contents
+++ b/xdrip/Core Data/xdrip.xcdatamodeld/xdrip v16.xcdatamodel/contents
@@ -155,6 +155,7 @@
     </entity>
     <entity name="TreatmentEntry" representedClassName=".TreatmentEntry" syncable="YES">
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="treatmentType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="uploaded" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="value" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
@@ -183,7 +184,7 @@
         <element name="MiaoMiao" positionX="-657" positionY="189" width="128" height="88"/>
         <element name="Sensor" positionX="-603.0859375" positionY="482.2890625" width="128" height="133"/>
         <element name="SnoozeParameters" positionX="-648" positionY="198" width="128" height="28"/>
-        <element name="TreatmentEntry" positionX="-657" positionY="189" width="128" height="89"/>
+        <element name="TreatmentEntry" positionX="-657" positionY="189" width="128" height="104"/>
         <element name="Watlaa" positionX="-639" positionY="207" width="128" height="88"/>
     </elements>
 </model>

--- a/xdrip/Extensions/Date.swift
+++ b/xdrip/Extensions/Date.swift
@@ -37,7 +37,20 @@ extension Date {
         let timeInterval = TimeInterval(-Double(hour * 3600 + minute * 60 + seconds))
         return Date(timeInterval: timeInterval, since: self)
     }
+	
+	/// Given a date represented as a string, returns a Date object, the reverse of ISOStringFromDate.
+	/// Example string: "2022-01-12T23:04:17.190Z"
+	static func fromISOString(_ string: String) -> Date? {
+		let dateFormatter = DateFormatter()
+		dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+		dateFormatter.timeZone = TimeZone(abbreviation: "GMT")
+		dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+		
+		return dateFormatter.date(from: string)
+	}
     
+	/// Returns the date represented as a ISO string.
+	/// Example return: "2022-01-12T23:04:17.190Z"
     func ISOStringFromDate() -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")

--- a/xdrip/Extensions/Double.swift
+++ b/xdrip/Extensions/Double.swift
@@ -15,6 +15,16 @@ extension Double: RawRepresentable {
     }
     
     // MARK: - own code
+	
+	/// Converts to a string and removes trailing .0
+	public var stringWithoutTrailingZeroes: String {
+		var description = String(self.description)
+		// Checks if ends with .0 and removes if so
+		if description.suffix(2) == ".0" {
+			description = String(description.dropLast(2))
+		}
+		return description
+	}
     
     /// converts mgdl to mmol
     func mgdlToMmol() -> Double {

--- a/xdrip/Managers/NightScout/NightScoutUploadManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutUploadManager.swift
@@ -361,8 +361,8 @@ public class NightScoutUploadManager:NSObject {
 
     /// Upload treatments to nightscout, receives the JSON response with the asigned IDS and sets the ids in Core Data.
 	/// - parameters:
-	///     - sucessHandler : handler called after upload. Only called if upload was required.
-	public func uploadTreatmentsToNightScout(sucessHandler: (() -> Void)?) {
+	///     - successHandler : handler called after upload. Only called if upload was required.
+	public func uploadTreatmentsToNightScout(successHandler: (() -> Void)?) {
 		trace("in uploadTreatmentsToNightScout", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .info)
 		
 		// get the latest treatments from the last maxDaysToUpload days
@@ -371,8 +371,8 @@ public class NightScoutUploadManager:NSObject {
 		
 		guard treatmentsToUpload.count > 0 else {
 			trace("    no treatments to upload", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .info)
-			if let sucessHandler = sucessHandler {
-				sucessHandler()
+			if let successHandler = successHandler {
+				successHandler()
 			}
 			return
 		}
@@ -412,8 +412,8 @@ public class NightScoutUploadManager:NSObject {
 						self.coreDataManager.saveChanges()
 					}
 					
-					if let sucessHandler = sucessHandler {
-						sucessHandler()
+					if let successHandler = successHandler {
+						successHandler()
 					}
 				}
 			} catch let error {
@@ -503,7 +503,7 @@ public class NightScoutUploadManager:NSObject {
 	///     - path : the query path
 	///     - queries : an array of URLQueryItem (added after the '?' at the URL)
 	 ///     - traceString : trace will start with this string, to distinguish between different GETs that may be ongoing simultaneously
-	///     - responseHandler : will be executed with the response Data? if sucessfull
+	///     - responseHandler : will be executed with the response Data? if successfull
 	private func getRequest(path: String, queries: [URLQueryItem], traceString: String, responseHandler: ((Data?) -> Void)?) {
 		guard let url = URL(string: UserDefaults.standard.nightScoutUrl!), var uRLComponents = URLComponents(url: url.appendingPathComponent(path), resolvingAgainstBaseURL: false) else {
 			return
@@ -567,7 +567,7 @@ public class NightScoutUploadManager:NSObject {
 	/// - parameters:
 	///     - dataToUpload : data to upload
 	///     - traceString : trace will start with this string, to distinguish between different uploads that may be ongoing simultaneously
-	///     - responseHandler : will be executed with the response Data? if sucessfull
+	///     - responseHandler : will be executed with the response Data? if successfull
 	///     - siteURL : nightscout site url
 	///     - apiKey : nightscout api key
 	private func uploadDataAndGetResponse(dataToUpload: Any, traceString: String, path: String, responseHandler: ((Data?) -> Void)?) {

--- a/xdrip/Managers/NightScout/NightScoutUploadManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutUploadManager.swift
@@ -469,6 +469,81 @@ public class NightScoutUploadManager:NSObject {
         }
         
     }
+	
+	/// Gets the latest treatments from Nightscout
+	/// - parameters:
+	///     - count: the amount of treatments to return
+	///     - completionHandler: handler that will be caled with the result TreatmentNSResponse array
+	public func getLatestTreatmentsNSResponses(count: Int, completionHandler: @escaping (([TreatmentNSResponse]) -> Void)) {
+		let queries = [URLQueryItem(name: "count", value: String(count))]
+		getRequest(path: nightScoutTreatmentPath, queries: queries, traceString: "getLatestTreatmentsNSResponses") { (data: Data?) in
+			
+			guard let data = data else {
+				return
+			}
+			
+			do {
+				// Try to serialize the data
+				if let responses = try TreatmentNSResponse.arrayFromData(data) {
+					completionHandler(responses)
+				}
+			} catch let error {
+				trace("    getLatestTreatmentsNSResponses error at JSONSerialization : %{public}@", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .error, error.localizedDescription)
+			}
+		}
+	}
+	
+	
+	
+	/// common functionality to do a GET request to Nightscout and get response
+	/// - parameters:
+	///     - path : the query path
+	///     - queries : an array of URLQueryItem (added after the '?' at the URL)
+	 ///     - traceString : trace will start with this string, to distinguish between different GETs that may be ongoing simultaneously
+	///     - responseHandler : will be executed with the response Data? if sucessfull
+	private func getRequest(path: String, queries: [URLQueryItem], traceString: String, responseHandler: ((Data?) -> Void)?) {
+		guard let url = URL(string: UserDefaults.standard.nightScoutUrl!), var uRLComponents = URLComponents(url: url.appendingPathComponent(path), resolvingAgainstBaseURL: false) else {
+			return
+		}
+
+		if UserDefaults.standard.nightScoutPort != 0 {
+			uRLComponents.port = UserDefaults.standard.nightScoutPort
+		}
+			
+		// Mutable copy used to add token if defined.
+		var queryItems = queries
+		// if token not nil, then add also the token
+		if let token = UserDefaults.standard.nightscoutToken {
+			queryItems.append(URLQueryItem(name: "token", value: token))
+		}
+		uRLComponents.queryItems = queryItems
+		
+		if let url = uRLComponents.url {
+			// Create Request
+			var request = URLRequest(url: url)
+			request.httpMethod = "GET"
+			request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+			request.setValue("application/json", forHTTPHeaderField: "Accept")
+			
+			if let apiKey = UserDefaults.standard.nightScoutAPIKey {
+				request.setValue(apiKey.sha1(), forHTTPHeaderField:"api-secret")
+			}
+			
+			let task = URLSession.shared.dataTask(with: request) { (data: Data?, urlResponse: URLResponse?, error: Error?) in
+				
+				// error cases
+				if let error = error {
+					trace("    in getRequest, %{public}@, failed to upload, error = %{public}@", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .error, traceString, error.localizedDescription)
+				} else {
+					// TODO: Check the HTTPURLResponse response code, unsure how to.
+					if let responseHandler = responseHandler {
+						responseHandler(data)
+					}
+				}
+			}
+			task.resume()
+		}
+	}
     
     /// common functionality to upload data to nightscout
     /// - parameters:

--- a/xdrip/Managers/NightScout/NightScoutUploadManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutUploadManager.swift
@@ -371,6 +371,9 @@ public class NightScoutUploadManager:NSObject {
 		
 		guard treatmentsToUpload.count > 0 else {
 			trace("    no treatments to upload", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .info)
+			if let sucessHandler = sucessHandler {
+				sucessHandler()
+			}
 			return
 		}
 	

--- a/xdrip/Storyboards/Base.lproj/Main.storyboard
+++ b/xdrip/Storyboards/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -236,7 +236,7 @@
                         <barButtonItem key="leftBarButtonItem" image="arrow.clockwise.icloud" catalog="system" id="eLq-m9-bla">
                             <color key="tintColor" red="0.96848052740000001" green="0.89723356880000005" blue="0.24125458929999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <connections>
-                                <action selector="uploadButtonTapped:" destination="01q-Jv-AjA" id="9Uc-T9-pkd"/>
+                                <action selector="syncButtonTapped:" destination="01q-Jv-AjA" id="EeF-H4-ZK3"/>
                             </connections>
                         </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="iA1-b8-F3J">

--- a/xdrip/Storyboards/ar.lproj/Treatments.strings
+++ b/xdrip/Storyboards/ar.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/de.lproj/Treatments.strings
+++ b/xdrip/Storyboards/de.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/en.lproj/Treatments.strings
+++ b/xdrip/Storyboards/en.lproj/Treatments.strings
@@ -12,4 +12,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/es.lproj/Treatments.strings
+++ b/xdrip/Storyboards/es.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/fi.lproj/Treatments.strings
+++ b/xdrip/Storyboards/fi.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/fr.lproj/Treatments.strings
+++ b/xdrip/Storyboards/fr.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/it.lproj/Treatments.strings
+++ b/xdrip/Storyboards/it.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/nl.lproj/Treatments.strings
+++ b/xdrip/Storyboards/nl.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/pl-PL.lproj/Treatments.strings
+++ b/xdrip/Storyboards/pl-PL.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/pt.lproj/Treatments.strings
+++ b/xdrip/Storyboards/pt.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/ru.lproj/Treatments.strings
+++ b/xdrip/Storyboards/ru.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/sl.lproj/Treatments.strings
+++ b/xdrip/Storyboards/sl.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/sv.lproj/Treatments.strings
+++ b/xdrip/Storyboards/sv.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/zh.lproj/Treatments.strings
+++ b/xdrip/Storyboards/zh.lproj/Treatments.strings
@@ -16,4 +16,4 @@
 "treatments_exercise" = "Exercise";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
-"treatments_upload_complete" = "Upload complete.";
+"treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Texts/TextsTreatmentsView.swift
+++ b/xdrip/Texts/TextsTreatmentsView.swift
@@ -60,8 +60,8 @@ enum Texts_TreatmentsView {
 		return NSLocalizedString("treatments_success", tableName: filename, bundle: Bundle.main, value: "Success", comment: "Success.")
 	}()
 
-	static let uploadCompleted:String = {
-		return NSLocalizedString("treatments_upload_complete", tableName: filename, bundle: Bundle.main, value: "Upload completed.", comment: "Upload completed.")
+	static let syncCompleted:String = {
+		return NSLocalizedString("treatments_sync_complete", tableName: filename, bundle: Bundle.main, value: "Sync completed.", comment: "Sync completed.")
 	}()
 	
 }

--- a/xdrip/Treatments/TreatmentNSResponse.swift
+++ b/xdrip/Treatments/TreatmentNSResponse.swift
@@ -1,0 +1,74 @@
+//
+//  TreatmentNSResponse.swift
+//  xdrip
+//
+//  Created by Eduardo Pietre on 11/01/22.
+//  Copyright © 2022 Johan Degraeve. All rights reserved.
+//
+
+import Foundation
+
+/// Class that represents the Nightscout response for adding a single new treatment.
+/// NS API docs states:
+/// "The client should not create the identifier, the server automatically assigns it when the document is inserted."
+public struct TreatmentNSResponse {
+	public let id: String
+	public let createdAt: String
+	public let eventType: TreatmentType
+	public let value: Double
+	
+	
+	/// Takes a NSDictionary from nightscout response and returns a TreatmentNSResponse, if fields are valid.
+	public static func fromNighscout(dictionary: NSDictionary) -> TreatmentNSResponse? {
+		if let id = dictionary["_id"] as? String,
+		   let createdAt = dictionary["created_at"] as? String,
+		   let eventTypeStr = dictionary["eventType"] as? String,
+		   let eventType = TreatmentType.fromNightscoutString(eventTypeStr) {
+			
+			var value: Double?
+			switch eventType {
+			case .Insulin:
+				value = dictionary["insulin"] as? Double
+			case .Carbs:
+				value = dictionary["carbs"] as? Double
+			case .Exercise:
+				value = dictionary["duration"] as? Double
+			}
+			
+			if let value = value {
+				return TreatmentNSResponse(id: id, createdAt: createdAt, eventType: eventType, value: value)
+			}
+		}
+		return nil
+	}
+	
+	/// Instantiates multiples TreatmentNSResponse from a NSArray of NSDictionary.
+	public static func arrayFromNSArray(_ array: NSArray) -> [TreatmentNSResponse] {
+		var responses: [TreatmentNSResponse] = []
+
+		for element in array {
+			if let dicionary = element as? NSDictionary, let treatmentNSResponse = TreatmentNSResponse.fromNighscout(dictionary: dicionary) {
+				responses.append(treatmentNSResponse)
+			}
+		}
+		
+		return responses
+	}
+	
+	/// Instantiates multiples TreatmentNSResponse from Data response.
+	/// JSONSerialization may throw an exception.
+	public static func arrayFromData(_ data: Data?) throws -> [TreatmentNSResponse]? {
+		if let data = data, let array = try JSONSerialization.jsonObject(with: data, options: []) as? NSArray {
+			
+			return TreatmentNSResponse.arrayFromNSArray(array)
+		}
+		
+		return nil
+	}
+	
+	/// Compares this TreatmentNSResponse to a given TreatmentEntry
+	public func matchesTreatmentEntry(_ entry: TreatmentEntry) -> Bool {
+		return entry.date.ISOStringFromDate() == self.createdAt && entry.treatmentType == self.eventType && entry.value == self.value
+	}
+	
+}

--- a/xdrip/Treatments/TreatmentNSResponse.swift
+++ b/xdrip/Treatments/TreatmentNSResponse.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreData
 
 /// Class that represents the Nightscout response for adding a single new treatment.
 /// NS API docs states:
@@ -69,6 +70,19 @@ public struct TreatmentNSResponse {
 	/// Compares this TreatmentNSResponse to a given TreatmentEntry
 	public func matchesTreatmentEntry(_ entry: TreatmentEntry) -> Bool {
 		return entry.date.ISOStringFromDate() == self.createdAt && entry.treatmentType == self.eventType && entry.value == self.value
+	}
+	
+	// Converts self (TreatmentNSResponse) to TreatmentEntry.
+	// Be extra carefull when creating new TreatmentEntry, will impact core data.
+	public func asNewTreatmentEntry(nsManagedObjectContext: NSManagedObjectContext) -> TreatmentEntry? {
+		guard let date = Date.fromISOString(createdAt) else {
+			return nil
+		}
+		
+		var treatment = TreatmentEntry(date: date, value: value, treatmentType: eventType, nsManagedObjectContext: nsManagedObjectContext)
+		// Since this entry originated at nightscout, set uploaded as true.
+		treatment.uploaded = true
+		return treatment
 	}
 	
 }

--- a/xdrip/Treatments/TreatmentNSResponse.swift
+++ b/xdrip/Treatments/TreatmentNSResponse.swift
@@ -79,10 +79,7 @@ public struct TreatmentNSResponse {
 			return nil
 		}
 		
-		var treatment = TreatmentEntry(date: date, value: value, treatmentType: eventType, nsManagedObjectContext: nsManagedObjectContext)
-		// Since this entry originated at nightscout, set uploaded as true.
-		treatment.uploaded = true
-		return treatment
+		return TreatmentEntry(id: id, date: date, value: value, treatmentType: eventType, nsManagedObjectContext: nsManagedObjectContext)
 	}
 	
 }

--- a/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
@@ -81,13 +81,13 @@ class TreatmentsInsertViewController : UIViewController {
             switch treatMentEntryToUpdate.treatmentType {
                 
             case .Carbs:
-                carbsTextField.text = treatMentEntryToUpdate.value.description
+                carbsTextField.text = treatMentEntryToUpdate.value.stringWithoutTrailingZeroes
                 
             case .Exercise:
-                exerciseTextField.text = treatMentEntryToUpdate.value.description
+                exerciseTextField.text = treatMentEntryToUpdate.value.stringWithoutTrailingZeroes
                 
             case .Insulin:
-                insulinTextField.text = treatMentEntryToUpdate.value.description
+                insulinTextField.text = treatMentEntryToUpdate.value.stringWithoutTrailingZeroes
                 
             }
             

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -36,7 +36,7 @@ class TreatmentsViewController : UIViewController {
 			return
 		}
 		
-		let alertSucessHandler: (() -> Void) = {
+		let alertsuccessHandler: (() -> Void) = {
 			// Make sure to run alert in the correct thread.
 			DispatchQueue.main.async {
 				let alert = UIAlertController(title: Texts_TreatmentsView.success, message: Texts_TreatmentsView.syncCompleted, actionHandler: nil)
@@ -64,8 +64,8 @@ class TreatmentsViewController : UIViewController {
 				DispatchQueue.main.async {
 					self.reload()
 					
-					// Uploads to nighscout and if sucess display an alert.
-					nightScoutUploadManager.uploadTreatmentsToNightScout(sucessHandler:alertSucessHandler)
+					// Uploads to nighscout and if success display an alert.
+					nightScoutUploadManager.uploadTreatmentsToNightScout(successHandler:alertsuccessHandler)
 				}
 			}
 		}

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -39,7 +39,7 @@ class TreatmentsViewController : UIViewController {
 		let alertSucessHandler: (() -> Void) = {
 			// Make sure to run alert in the correct thread.
 			DispatchQueue.main.async {
-				let alert = UIAlertController(title: Texts_TreatmentsView.success, message: Texts_TreatmentsView.uploadCompleted, actionHandler: nil)
+				let alert = UIAlertController(title: Texts_TreatmentsView.success, message: Texts_TreatmentsView.syncCompleted, actionHandler: nil)
 
 				self.present(alert, animated: true, completion: nil)
 			}

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -32,8 +32,34 @@ class TreatmentsViewController : UIViewController {
 	
 	/// Sync button action.
 	@IBAction func syncButtonTapped(_ sender: UIBarButtonItem) {
+		guard let nightScoutUploadManager = nightScoutUploadManager else {
+			return
+		}
+
+		// Fetches new treatments from Nightscout
+		// TODO: for some reason if count > 52 NS only returns 52 entries. Why?
+		nightScoutUploadManager.getLatestTreatmentsNSResponses(count: 50) { (responses: [TreatmentNSResponse]) in
+
+			guard let treatmentEntryAccessor = self.treatmentEntryAccessor, let coreDataManager = self.coreDataManager else {
+				return
+			}
+
+			// Be sure to use the correct thread.
+			// Running in the completionHandler thread will
+			// result in issues.
+			coreDataManager.mainManagedObjectContext.performAndWait {
+				let _ = treatmentEntryAccessor.newTreatmentsIfRequired(responses: responses)
+				coreDataManager.saveChanges()
+
+				// Update UI, run at main thread
+				DispatchQueue.main.async {
+					self.reload()
+				}
+			}
+		}
+
 		// Uploads to nighscout and if sucess display an alert.
-		nightScoutUploadManager?.uploadTreatmentsToNightScout(sucessHandler: {
+		nightScoutUploadManager.uploadTreatmentsToNightScout(sucessHandler: {
 			// Make sure to run alert in the correct thread.
 			DispatchQueue.main.async {
 				let alert = UIAlertController(title: Texts_TreatmentsView.success, message: Texts_TreatmentsView.uploadCompleted, actionHandler: nil)

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -30,8 +30,8 @@ class TreatmentsViewController : UIViewController {
 	@IBOutlet weak var titleNavigation: UINavigationItem!
 	@IBOutlet weak var tableView: UITableView!
 	
-	/// Upload button action.
-	@IBAction func uploadButtonTapped(_ sender: UIBarButtonItem) {
+	/// Sync button action.
+	@IBAction func syncButtonTapped(_ sender: UIBarButtonItem) {
 		// Uploads to nighscout and if sucess display an alert.
 		nightScoutUploadManager?.uploadTreatmentsToNightScout(sucessHandler: {
 			// Make sure to run alert in the correct thread.

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -46,7 +46,7 @@ class TreatmentsViewController : UIViewController {
 		}
 
 		// Fetches new treatments from Nightscout
-		// TODO: for some reason if count > 52 NS only returns 52 entries. Why?
+		// TODO: set optimal value for getLatestTreatmentsNSResponses count.
 		nightScoutUploadManager.getLatestTreatmentsNSResponses(count: 50) { (responses: [TreatmentNSResponse]) in
 
 			guard let treatmentEntryAccessor = self.treatmentEntryAccessor, let coreDataManager = self.coreDataManager else {

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -35,6 +35,15 @@ class TreatmentsViewController : UIViewController {
 		guard let nightScoutUploadManager = nightScoutUploadManager else {
 			return
 		}
+		
+		let alertSucessHandler: (() -> Void) = {
+			// Make sure to run alert in the correct thread.
+			DispatchQueue.main.async {
+				let alert = UIAlertController(title: Texts_TreatmentsView.success, message: Texts_TreatmentsView.uploadCompleted, actionHandler: nil)
+
+				self.present(alert, animated: true, completion: nil)
+			}
+		}
 
 		// Fetches new treatments from Nightscout
 		// TODO: for some reason if count > 52 NS only returns 52 entries. Why?
@@ -54,19 +63,12 @@ class TreatmentsViewController : UIViewController {
 				// Update UI, run at main thread
 				DispatchQueue.main.async {
 					self.reload()
+					
+					// Uploads to nighscout and if sucess display an alert.
+					nightScoutUploadManager.uploadTreatmentsToNightScout(sucessHandler:alertSucessHandler)
 				}
 			}
 		}
-
-		// Uploads to nighscout and if sucess display an alert.
-		nightScoutUploadManager.uploadTreatmentsToNightScout(sucessHandler: {
-			// Make sure to run alert in the correct thread.
-			DispatchQueue.main.async {
-				let alert = UIAlertController(title: Texts_TreatmentsView.success, message: Texts_TreatmentsView.uploadCompleted, actionHandler: nil)
-
-				self.present(alert, animated: true, completion: nil)
-			}
-		})
 	}
 	
     // MARK: - View Life Cycle


### PR DESCRIPTION
Features:
- When uploaded, treatments get their id assigned from Nightscout response.
- On sync action (cloud button), gets the latest treatments from NS.
- Treatments are only created at CoreData if they do not previously exist.

Missing:
- Button press is still required for sync.
- Deletes and updates are not sent to NS yet.

This pull includes two TODO annotations:
1. At NightScoutUploadManager getRequest: TODO: Check the HTTPURLResponse response code, unsure how to.
2. At TreatmentsViewController syncButtonTapped TODO: set optimal value for getLatestTreatmentsNSResponses count.