### PR TITLE
implement toolbar help icon

### DIFF
--- a/xdrip/Extensions/UserDefaults.swift
+++ b/xdrip/Extensions/UserDefaults.swift
@@ -19,14 +19,19 @@ extension UserDefaults {
     public enum Key: String {
         // User configurable Settings
         
+        // Online Help
+        
+        /// should the online help by automatically translated?
+        case translateOnlineHelp = "translateOnlineHelp"
+        /// should the main screen help icon be shown?
+        case showHelpIcon = "showHelpIcon"
+        
         // General
         
         /// bloodglucose unit
         case bloodGlucoseUnitIsMgDl = "bloodGlucoseUnit"
         /// urgent high value
         case isMaster = "isMaster"
-        /// should the online help by automatically translated?
-        case translateOnlineHelp = "translateOnlineHelp"
         /// should notification be shown with reading yes or no
         case showReadingInNotification = "showReadingInNotification"
         /// should readings be shown in app badge yes or no
@@ -302,6 +307,30 @@ extension UserDefaults {
     
     // MARK: - =====  User Configurable Settings ======
     
+    // MARK: Help
+    
+    /// should the app automatically show the translated version of the online help if English (en) is not the selected app locale?
+    @objc dynamic var translateOnlineHelp: Bool {
+        // default value for bool in userdefaults is false, as default we want the app to translate automatically
+        get {
+            return !bool(forKey: Key.translateOnlineHelp.rawValue)
+        }
+        set {
+            set(!newValue, forKey: Key.translateOnlineHelp.rawValue)
+        }
+    }
+    
+    /// should the app show the help icon on the main screen toolbar?
+    @objc dynamic var showHelpIcon: Bool {
+        // default value for bool in userdefaults is false, by default we want the app to show the help icon in the toolbar
+        get {
+            return !bool(forKey: Key.showHelpIcon.rawValue)
+        }
+        set {
+            set(!newValue, forKey: Key.showHelpIcon.rawValue)
+        }
+    }
+    
     // MARK: General
     
     /// true if unit is mgdl, false if mmol is used
@@ -327,17 +356,6 @@ extension UserDefaults {
         }
         set {
             set(!newValue, forKey: Key.isMaster.rawValue)
-        }
-    }
-    
-    /// should the app automatically show the translated version of the online help if English (en) is not the selected app locale?
-    @objc dynamic var translateOnlineHelp: Bool {
-        // default value for bool in userdefaults is false, as default we want the app to translate automatically
-        get {
-            return !bool(forKey: Key.translateOnlineHelp.rawValue)
-        }
-        set {
-            set(!newValue, forKey: Key.translateOnlineHelp.rawValue)
         }
     }
     

--- a/xdrip/Storyboards/Base.lproj/Main.storyboard
+++ b/xdrip/Storyboards/Base.lproj/Main.storyboard
@@ -177,7 +177,6 @@
                                                     <segue destination="NvR-Zh-2Zn" kind="show" identifier="RootViewToSnoozeView" id="VtQ-ZG-btn"/>
                                                 </connections>
                                             </barButtonItem>
-                                            <barButtonItem style="plain" systemItem="flexibleSpace" id="8MU-0O-ujy"/>
                                             <barButtonItem style="plain" systemItem="flexibleSpace" id="uM8-jT-s3T"/>
                                             <barButtonItem title="Sensor" image="ellipsis.circle" catalog="system" id="ZIM-Wf-bUy">
                                                 <connections>
@@ -191,10 +190,15 @@
                                                 </connections>
                                             </barButtonItem>
                                             <barButtonItem style="plain" systemItem="flexibleSpace" id="SlH-A4-F18"/>
-                                            <barButtonItem style="plain" systemItem="flexibleSpace" id="Bnf-FN-LqX"/>
                                             <barButtonItem title="Lock" image="lock" catalog="system" id="wfX-50-2w6">
                                                 <connections>
                                                     <action selector="screenLockToolbarButtonAction:" destination="9pv-A4-QxB" id="L14-hJ-4a9"/>
+                                                </connections>
+                                            </barButtonItem>
+                                            <barButtonItem style="plain" systemItem="flexibleSpace" id="a6G-aW-JeE"/>
+                                            <barButtonItem title="Help" image="questionmark.circle" catalog="system" id="DuN-xR-xYB">
+                                                <connections>
+                                                    <action selector="helpToolbarButtonAction:" destination="9pv-A4-QxB" id="DGg-9c-TqQ"/>
                                                 </connections>
                                             </barButtonItem>
                                         </items>
@@ -261,10 +265,10 @@
                                                 <rect key="frame" x="10" y="4.6666666666666856" width="370" height="25"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qG7-Ub-mzA">
-                                                        <rect key="frame" x="0.0" y="0.0" width="199" height="25"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="194" height="25"/>
                                                         <subviews>
                                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" apportionsSegmentWidthsByContent="YES" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Xuy-hn-ozf">
-                                                                <rect key="frame" x="0.0" y="0.0" width="199" height="26"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="194" height="26"/>
                                                                 <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <segments>
                                                                     <segment title="Today"/>
@@ -287,7 +291,7 @@
                                                         </constraints>
                                                     </view>
                                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" apportionsSegmentWidthsByContent="YES" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="9LS-Vp-uGd">
-                                                        <rect key="frame" x="219" y="0.0" width="151" height="26"/>
+                                                        <rect key="frame" x="214" y="0.0" width="156" height="26"/>
                                                         <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <segments>
                                                             <segment title="3h"/>
@@ -599,6 +603,7 @@
                         <outlet property="clockView" destination="ETk-QH-u1x" id="XuQ-dY-93L"/>
                         <outlet property="cvTitleLabelOutlet" destination="PZI-Ln-kfh" id="IKV-zy-dNM"/>
                         <outlet property="diffLabelOutlet" destination="7Wo-wd-80o" id="nnn-w9-1sX"/>
+                        <outlet property="helpToolbarButtonOutlet" destination="DuN-xR-xYB" id="TdW-5k-hgZ"/>
                         <outlet property="highLabelOutlet" destination="Xlz-6g-zzD" id="DyX-x0-PwZ"/>
                         <outlet property="highStatisticLabelOutlet" destination="EbR-T4-LIg" id="VZk-1K-BCq"/>
                         <outlet property="highTitleLabelOutlet" destination="bUK-pC-4bd" id="R8q-Q6-q9d"/>
@@ -620,6 +625,7 @@
                         <outlet property="sensorToolbarButtonOutlet" destination="ZIM-Wf-bUy" id="kjL-rX-6ZV"/>
                         <outlet property="statisticsView" destination="MtJ-rx-OB9" id="u5w-qN-5Tq"/>
                         <outlet property="timePeriodLabelOutlet" destination="On3-dy-RgB" id="hAe-Kx-vnM"/>
+                        <outlet property="toolbarOutlet" destination="tVG-ML-9xd" id="p1N-b3-pnD"/>
                         <outlet property="valueLabelOutlet" destination="We3-bN-ffR" id="wtY-sZ-mev"/>
                     </connections>
                 </viewController>
@@ -1716,6 +1722,7 @@
         <image name="ellipsis.circle" catalog="system" width="128" height="121"/>
         <image name="lock" catalog="system" width="128" height="128"/>
         <image name="moon.zzz" catalog="system" width="115" height="128"/>
+        <image name="questionmark.circle" catalog="system" width="128" height="121"/>
         <image name="scope" catalog="system" width="128" height="122"/>
         <image name="sensor14_14_alt" width="390" height="14"/>
         <systemColor name="systemGrayColor">

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -21,7 +21,15 @@ class Texts_SettingsView {
     }()
     
     static let translateOnlineHelp: String = {
-        return NSLocalizedString("settingsviews_translateOnlineHelp", tableName: filename, bundle: Bundle.main, value: "Translate Automatically?", comment: "general settings, should the online help be translated automatically if needed")
+        return NSLocalizedString("settingsviews_translateOnlineHelp", tableName: filename, bundle: Bundle.main, value: "Translate Automatically?", comment: "help settings, should the online help be translated automatically if needed")
+    }()
+    
+    static let showHelpIcon: String = {
+        return NSLocalizedString("settingsviews_showHelpIcon", tableName: filename, bundle: Bundle.main, value: "Show Help Icon?", comment: "help settings, should the help icon be shown on the toolbar")
+    }()
+    
+    static let restartNeeded: String = {
+        return NSLocalizedString("settingsviews_restartNeeded", tableName: filename, bundle: Bundle.main, value: "(Restart required)", comment: "help settings, restart needed")
     }()
     
     // MARK: - Section General

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -16,6 +16,10 @@ final class RootViewController: UIViewController {
     
     private var session: WCSession?
     
+    
+    @IBOutlet weak var toolbarOutlet: UIToolbar!
+    
+    
     @IBOutlet weak var preSnoozeToolbarButtonOutlet: UIBarButtonItem!
     
     @IBAction func preSnoozeToolbarButtonAction(_ sender: UIBarButtonItem) {
@@ -44,6 +48,33 @@ final class RootViewController: UIViewController {
             trace("calibration : user clicked the calibrate button", log: self.log, category: ConstantsLog.categoryRootView, type: .info)
             
             requestCalibration(userRequested: true)
+        }
+        
+    }
+    
+    
+    @IBOutlet weak var helpToolbarButtonOutlet: UIBarButtonItem!
+    
+    @IBAction func helpToolbarButtonAction(_ sender: UIBarButtonItem) {
+        
+        // get the 2 character language code for the App Locale (i.e. "en", "es", "nl", "fr")
+        let languageCode = NSLocale.current.languageCode
+            
+        // if the user has the app in a language other than English and they have the "auto translate" option selected, then load the help pages through Google Translate
+        // important to check the the URLs actually exist in ConstansHomeView before trying to open them
+        if languageCode != ConstantsHomeView.onlineHelpBaseLocale && UserDefaults.standard.translateOnlineHelp {
+            
+            guard let url = URL(string: ConstantsHomeView.onlineHelpURLTranslated1 + languageCode! + ConstantsHomeView.onlineHelpURLTranslated2) else { return }
+            
+            UIApplication.shared.open(url)
+            
+        } else {
+            
+            // so the user is running the app in English or they don't want to translate so let's just load it directly
+            guard let url = URL(string: ConstantsHomeView.onlineHelpURL) else { return }
+            
+            UIApplication.shared.open(url)
+        
         }
         
     }
@@ -417,6 +448,14 @@ final class RootViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureWatchKitSession()
+        
+        // if the user requested to hide the help icon on the main screen, then remove it (and the flexible space next to it)
+        // this is why we keep the help icon as the last one in the toolbar item array.
+        if !UserDefaults.standard.showHelpIcon {
+            
+            toolbarOutlet.items!.removeLast(2)
+            
+        }
         
         // set up the clock view
         clockDateFormatter.dateStyle = .none


### PR DESCRIPTION
This will add a help icon to the main toolbar. Too many users are not aware that they can access the help files from the Settings menu. This will make it very clear.

![image](https://user-images.githubusercontent.com/37302780/149506085-9e2614d8-c7d8-4de7-b537-343b3d5ba199.png)

For more advanced users, they can select to hide this icon permanently from the Settings -> Help menu. 

![image](https://user-images.githubusercontent.com/37302780/149506125-e07b0975-19d8-404c-8a17-41b5d94292b9.png)

The actual removal is done safely during viewDidLoad() of the RVC so a restart is needed for the change to be effective (the user will be notified of this when toggling the UISwitch). As this will generally only be used once in the app lifetime, it's not a problem.

![image](https://user-images.githubusercontent.com/37302780/149506156-84516d1d-4605-4be4-af79-282272db2bd9.png)
