### PR TITLE
Nightscout Follower improvements

### DIFF
--- a/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
+++ b/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
@@ -969,6 +969,7 @@ class BluetoothPeripheralManager: NSObject {
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.bloodGlucoseUnitIsMgDl.rawValue, options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.nightScoutUrl.rawValue, options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.nightScoutAPIKey.rawValue, options: .new, context: nil)
+        UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.nightscoutToken.rawValue, options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.isMaster.rawValue, options: .new, context: nil)
 
     }

--- a/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
+++ b/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
@@ -969,7 +969,6 @@ class BluetoothPeripheralManager: NSObject {
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.bloodGlucoseUnitIsMgDl.rawValue, options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.nightScoutUrl.rawValue, options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.nightScoutAPIKey.rawValue, options: .new, context: nil)
-        UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.nightscoutToken.rawValue, options: .new, context: nil)
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.isMaster.rawValue, options: .new, context: nil)
 
     }

--- a/xdrip/Managers/NightScout/Endpoint+NightScout.swift
+++ b/xdrip/Managers/NightScout/Endpoint+NightScout.swift
@@ -9,8 +9,7 @@ extension Endpoint {
     /// - parameters:
     ///     - hostAndScheme : hostname, eg http://www.mysite.com or https://www.mysite.com - must include the scheme - IF HOST DOESN'T START WITH A KNOWN SCHEME, THEN A FATAL ERROR WILL BE THROWN - known scheme's can be found in type EndPointScheme
     ///     - count : maximum number of readings to get
-    ///     - olderThan : only readings with timestamp > olderThan
-    static func getEndpointForLatestNSEntries(hostAndScheme:String, count: Int, olderThan timeStamp:Date, token: String?) -> Endpoint {
+    static func getEndpointForLatestNSEntries(hostAndScheme:String, count: Int, token: String?) -> Endpoint {
         
         // split hostAndScheme in host and scheme
         let (host, scheme) = EndPointScheme.getHostAndScheme(hostAndScheme: hostAndScheme)
@@ -22,10 +21,8 @@ extension Endpoint {
             fatalError("in getEndpointForLatestNSEntries, hostAndScheme doesn't start with a known scheme name")
         }
         
-        // create quertyItems
-        var queryItems = [
-            URLQueryItem(name: "count", value: count.description),
-        URLQueryItem(name: "find[dateString][$gte]", value: timeStamp.ISOStringFromDate())]
+        // create queryItems
+        var queryItems = [URLQueryItem(name: "count", value: count.description)]
         
         // if token not nil, then add also the token
         if let token = token {

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewNightScoutSettingsViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewNightScoutSettingsViewModel.swift
@@ -143,7 +143,7 @@ class SettingsViewNightScoutSettingsViewModel {
                             
                             trace("in testNightScoutCredentials, URL responds OK but authentication method is missing and cannot be checked", log: self.log, category: ConstantsLog.categoryNightScoutSettingsViewModel, type: .info)
                             
-                            self.callMessageHandlerInMainThread(title: UserDefaults.standard.isMaster ? Texts_NightScoutTestResult.verificationErrorAlertTitle : Texts_NightScoutTestResult.verificationSuccessfulAlertTitle, message:  UserDefaults.standard.isMaster ? "URL responds OK but authentication method is missing\n\nAuthentication by API_SECRET or Token is necessary for Master mode!" : "URL responds OK for Follower mode without needing authentication")
+                            self.callMessageHandlerInMainThread(title: UserDefaults.standard.isMaster ? Texts_NightScoutTestResult.verificationErrorAlertTitle : Texts_NightScoutTestResult.verificationSuccessfulAlertTitle, message:  UserDefaults.standard.isMaster ? "URL responds OK but authentication method is missing\n\nAuthentication by API_SECRET or Token is necessary for Master mode!" : "URL exists and responds OK\n\nAuthentication is missing so hasn't been tested")
                             
                         }
                     


### PR DESCRIPTION
GET request modified to use only count - this ensures compatibility with Nightscout sites populated by Tomato

API_SECRET and Token authentication for Follower mode. This allows read-only sites to work. (e.g. if AUTH_DEFAULT_ROLES = denied)

Add Observers to also trigger a fresh download attempt when API_SECRET or Token is modified in the Settings