### PR TITLE
Change alarm trigger from arbitrary VoltageA to relevant VoltageB

### DIFF
--- a/xdrip/Constants/ConstantsDefaultAlertLevels.swift
+++ b/xdrip/Constants/ConstantsDefaultAlertLevels.swift
@@ -1,7 +1,7 @@
 /// default alert levels to be used when creating defalt alert entries
 enum ConstantsDefaultAlertLevels {
     // default battery alert level, below this level an alert should be generated - this default value will be used when changing transmittertype
-    static let defaultBatteryAlertLevelDexcomG5 = 300
+    static let defaultBatteryAlertLevelDexcomG5 = 260
     static let defaultBatteryAlertLevelDexcomG4 = 210
     static let defaultBatteryAlertLevelMiaoMiao = 20
     static let defaultBatteryAlertLevelBubble = 20

--- a/xdrip/Managers/Alerts/AlertKind.swift
+++ b/xdrip/Managers/Alerts/AlertKind.swift
@@ -359,8 +359,8 @@ public enum AlertKind:Int, CaseIterable {
                 switch transmitterBatteryInfo {
                 case .percentage(let percentage):
                     batteryLevelToCheck = percentage
-                case .DexcomG5(let voltageA, _, _, _, _):
-                    batteryLevelToCheck = voltageA
+                case .DexcomG5(let voltageB, _, _, _, _):
+                    batteryLevelToCheck = voltageB
                 case .DexcomG4(let level):
                     batteryLevelToCheck = level
                 }


### PR DESCRIPTION
Dexcom uses Voltage B to determine whether or not the battery is degraded too far. (2.6 low limit, 2.4 critical and EOL) This pull request seeks to implement the changes by removing the trigger for Voltage A, replace it for Voltage B and change the default alert level. 