### PR TITLE
implement BG Check treatments + layout improvements

### DIFF
--- a/xdrip.xcodeproj/xcshareddata/xcschemes/Watch App (Complication).xcscheme
+++ b/xdrip.xcodeproj/xcshareddata/xcschemes/Watch App (Complication).xcscheme
@@ -55,10 +55,8 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "32">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/(null)">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "470B6185270C448000561E56"
@@ -66,7 +64,7 @@
             BlueprintName = "Watch App"
             ReferencedContainer = "container:xdrip.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -75,10 +73,8 @@
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
       launchAutomaticallySubstyle = "32">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/(null)">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "470B6185270C448000561E56"
@@ -86,16 +82,7 @@
             BlueprintName = "Watch App"
             ReferencedContainer = "container:xdrip.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "470B6185270C448000561E56"
-            BuildableName = "xDrip4iO5.app"
-            BlueprintName = "Watch App"
-            ReferencedContainer = "container:xdrip.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/xdrip.xcodeproj/xcshareddata/xcschemes/Watch App.xcscheme
+++ b/xdrip.xcodeproj/xcshareddata/xcschemes/Watch App.xcscheme
@@ -54,10 +54,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/(null)">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "470B6185270C448000561E56"
@@ -65,7 +63,7 @@
             BlueprintName = "Watch App"
             ReferencedContainer = "container:xdrip.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -73,10 +71,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/(null)">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "470B6185270C448000561E56"
@@ -84,16 +80,7 @@
             BlueprintName = "Watch App"
             ReferencedContainer = "container:xdrip.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "470B6185270C448000561E56"
-            BuildableName = "xDrip4iO5.app"
-            BlueprintName = "Watch App"
-            ReferencedContainer = "container:xdrip.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/xdrip/Constants/ConstantsGlucoseChart.swift
+++ b/xdrip/Constants/ConstantsGlucoseChart.swift
@@ -68,6 +68,8 @@ enum ConstantsGlucoseChart {
     /// color for target line
     static let guidelineTargetColor = UIColor.green.withAlphaComponent(0.3)
     
+    // glucose circle/dot color and sizes
+    
     /// glucose colors - for values in range
     static let glucoseInRangeColor = UIColor.green
     
@@ -89,6 +91,8 @@ enum ConstantsGlucoseChart {
     /// diameter of the circle for blood glucose readings with a 24h chart width. The more hours on the chart, the smaller the circles should be
     static let glucoseCircleDiameter24h: CGFloat = 4
     
+    // calibration circle fill/border color/sizes
+    
     /// calibration inner circle color
     static let calibrationCircleColorInner = UIColor.red
     
@@ -100,6 +104,8 @@ enum ConstantsGlucoseChart {
     
     /// calibration inner circle scale factor compared to the chart glucose circle size
     static let calibrationCircleScaleInner: CGFloat = 1.4
+    
+    // bolus treatment marker color/sizes
     
     /// bolus treament marker colour
     static let bolusTreatmentColor = UIColor.systemBlue
@@ -131,6 +137,8 @@ enum ConstantsGlucoseChart {
     /// make the triangle height slightly less than the width to prevent it looking too "pointy"
     static let bolusTriangleHeightScale: CGFloat = 0.9
     
+    // carb treatment marker color/sizes
+    
     /// carbs treament marker colour
     static let carbsTreatmentColor = UIColor.systemOrange
     
@@ -154,6 +162,22 @@ enum ConstantsGlucoseChart {
     
     /// The scale will determine how big the veryLargeCarbs circle is scaled compared to the glucose point size)
     static let veryLargeCarbsTreamentScale: CGFloat = 6.6
+    
+    // bg check circle fill/border color/sizes
+    
+    /// bg check outer circle color
+    static let bgCheckTreatmentColorOuter = UIColor.gray
+    
+    /// bg check inner circle color
+    static let bgCheckTreatmentColorInner = UIColor.red
+    
+    /// bg check outer circle scale factor compared to the chart glucose circle size
+    static let bgCheckTreatmentScaleOuter: CGFloat = 1.9
+    
+    /// bg check inner circle scale factor compared to the chart glucose circle size
+    static let bgCheckTreatmentScaleInner: CGFloat = 1.4
+    
+    // treatment label font size/color/background
 
     /// default label settings for the treatments labels. These are set for 6hr chart width - they will be scaled accordingly as needed
     static let treatmentLabelFontSize: Double = 12
@@ -181,6 +205,8 @@ enum ConstantsGlucoseChart {
     
     /// how far should the label be separated from the veryLargeCarbs marker by default
     static let veryLargeCarbsLabelSeparation: Double = 12
+    
+    // chart format parameters
     
     /// labels width for vertical axis
     static let yAxisLabelsWidth: CGFloat = 30

--- a/xdrip/Constants/ConstantsNightScout.swift
+++ b/xdrip/Constants/ConstantsNightScout.swift
@@ -18,5 +18,11 @@ enum ConstantsNightScout {
     
     /// download treatments from nightscout, how manyhours
     static let maxHoursTreatmentsToDownload = 24.0
+    
+    /// the text used by Nightscout for the "unit" json attribute for BG Checks stored in mg/dl
+    static let mgDlNightscoutUnitString = "mg/dl"
+    
+    /// the text used by Nightscout for the "unit" json attribute for BG Checks stored in mmol/l
+    static let mmolNightscoutUnitString = "mmol"
 
 }

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import CoreData
+import UIKit
 
 
 // @objc and Int16 allows enums to work with CoreData
@@ -112,6 +113,56 @@ import CoreData
         }
         
     }
+    
+    /// Returns the displayUnit: the .unit as required by the treatment type and the user settings
+    public func iconColor() -> UIColor {
+        
+        switch self {
+            
+        case .Insulin:
+            return ConstantsGlucoseChart.bolusTreatmentColor
+            
+        case .Carbs:
+            return ConstantsGlucoseChart.carbsTreatmentColor
+            
+        case .Exercise:
+            return UIColor.magenta
+            
+        case .BgCheck:
+            return ConstantsGlucoseChart.bgCheckTreatmentColorInner
+            
+        }
+        
+    }
+    
+    /// Returns the displayUnit: the .unit as required by the treatment type and the user settings
+    public func iconImage() -> UIImage? {
+        
+        if #available(iOS 13.0, *) {
+            
+            switch self {
+                
+            case .Insulin:
+                return UIImage(systemName: "arrowtriangle.down.fill")!
+                
+            case .Carbs:
+                return UIImage(systemName: "circle.fill")!
+                
+            case .Exercise:
+                return UIImage(systemName: "heart.fill")!
+                
+            case .BgCheck:
+                return UIImage(systemName: "drop.fill")!
+                
+            }
+            
+        } else {
+            
+            return nil
+            
+        }
+        
+    }
 	
 }
 
@@ -163,10 +214,8 @@ public class TreatmentEntry: NSManagedObject, Comparable {
 		super.init(entity: entity, insertInto: context)
 	}
 	
-	/// Returns the displayValue: the .value with the proper unit.
+	/// Returns the displayValue: the .value in the correct value if any changes are required
 	public func displayValue() -> String {
-		
-        var displayValueString: String
         
         // if the treatmentType is a BG Check then convert the value to mmol/l if that is what the user is using. All BG checks are stored in coredata as mg/dl
         if self.treatmentType == .BgCheck {
@@ -175,16 +224,32 @@ public class TreatmentEntry: NSManagedObject, Comparable {
             let isMgDl: Bool = UserDefaults.standard.bloodGlucoseUnitIsMgDl
             
             // convert to mmol/l if needed, round accordingly and add the correct units
-            displayValueString = self.value.mgdlToMmol(mgdl: isMgDl).bgValueRounded(mgdl: isMgDl).stringWithoutTrailingZeroes + " " + String(isMgDl ? Texts_Common.mgdl : Texts_Common.mmol)
+            return self.value.mgdlToMmol(mgdl: isMgDl).bgValueRounded(mgdl: isMgDl).stringWithoutTrailingZeroes
             
         } else {
             
-            displayValueString = self.value.stringWithoutTrailingZeroes + " " + self.treatmentType.unit()
+            return self.value.stringWithoutTrailingZeroes
             
         }
         
-        return displayValueString
 	}
+    
+    /// Returns the displayUnit: the .unit as required by the treatment type and the user settings
+    public func displayUnit() -> String {
+        
+        // if the treatmentType is a BG Check then convert the value to mmol/l if that is what the user is using. All BG checks are stored in coredata as mg/dl
+        if self.treatmentType == .BgCheck {
+            
+            // convert to mmol/l if needed, round accordingly and add the correct units
+            return String(UserDefaults.standard.bloodGlucoseUnitIsMgDl ? Texts_Common.mgdl : Texts_Common.mmol)
+            
+        } else {
+            
+            return self.treatmentType.unit()
+            
+        }
+        
+    }
 	
 	/// - get the dictionary representation required for creating a new treatment @ NighScout using POST or updating an existing treatment @ NightScout using PUT
     /// - splits of "-carbs" "-insulin" or "-exercise" from the id

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import CoreData
-import UIKit
 
 
 // @objc and Int16 allows enums to work with CoreData
@@ -113,56 +112,6 @@ import UIKit
         }
         
     }
-    
-    /// Returns the displayUnit: the .unit as required by the treatment type and the user settings
-    public func iconColor() -> UIColor {
-        
-        switch self {
-            
-        case .Insulin:
-            return ConstantsGlucoseChart.bolusTreatmentColor
-            
-        case .Carbs:
-            return ConstantsGlucoseChart.carbsTreatmentColor
-            
-        case .Exercise:
-            return UIColor.magenta
-            
-        case .BgCheck:
-            return ConstantsGlucoseChart.bgCheckTreatmentColorInner
-            
-        }
-        
-    }
-    
-    /// Returns the displayUnit: the .unit as required by the treatment type and the user settings
-    public func iconImage() -> UIImage? {
-        
-        if #available(iOS 13.0, *) {
-            
-            switch self {
-                
-            case .Insulin:
-                return UIImage(systemName: "arrowtriangle.down.fill")!
-                
-            case .Carbs:
-                return UIImage(systemName: "circle.fill")!
-                
-            case .Exercise:
-                return UIImage(systemName: "heart.fill")!
-                
-            case .BgCheck:
-                return UIImage(systemName: "drop.fill")!
-                
-            }
-            
-        } else {
-            
-            return nil
-            
-        }
-        
-    }
 	
 }
 
@@ -213,43 +162,6 @@ public class TreatmentEntry: NSManagedObject, Comparable {
 	private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
 		super.init(entity: entity, insertInto: context)
 	}
-	
-	/// Returns the displayValue: the .value in the correct value if any changes are required
-	public func displayValue() -> String {
-        
-        // if the treatmentType is a BG Check then convert the value to mmol/l if that is what the user is using. All BG checks are stored in coredata as mg/dl
-        if self.treatmentType == .BgCheck {
-            
-            // save typing
-            let isMgDl: Bool = UserDefaults.standard.bloodGlucoseUnitIsMgDl
-            
-            // convert to mmol/l if needed, round accordingly and add the correct units
-            return self.value.mgdlToMmol(mgdl: isMgDl).bgValueRounded(mgdl: isMgDl).stringWithoutTrailingZeroes
-            
-        } else {
-            
-            return self.value.stringWithoutTrailingZeroes
-            
-        }
-        
-	}
-    
-    /// Returns the displayUnit: the .unit as required by the treatment type and the user settings
-    public func displayUnit() -> String {
-        
-        // if the treatmentType is a BG Check then convert the value to mmol/l if that is what the user is using. All BG checks are stored in coredata as mg/dl
-        if self.treatmentType == .BgCheck {
-            
-            // convert to mmol/l if needed, round accordingly and add the correct units
-            return String(UserDefaults.standard.bloodGlucoseUnitIsMgDl ? Texts_Common.mgdl : Texts_Common.mmol)
-            
-        } else {
-            
-            return self.treatmentType.unit()
-            
-        }
-        
-    }
 	
 	/// - get the dictionary representation required for creating a new treatment @ NighScout using POST or updating an existing treatment @ NightScout using PUT
     /// - splits of "-carbs" "-insulin" or "-exercise" from the id

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
@@ -282,7 +282,7 @@ public class TreatmentEntry: NSManagedObject, Comparable {
         case .BgCheck:
             dict["eventType"] = "BG Check" // maybe overwritten in next statement
             dict["glucose"] = self.value
-            dict["glucoseType"] = "Finger"
+            dict["glucoseType"] = "Finger" + String(!UserDefaults.standard.bloodGlucoseUnitIsMgDl ? ": " + self.value.mgdlToMmolAndToString(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl) + " " + Texts_Common.mmol : "")
             dict["units"] = ConstantsNightScout.mgDlNightscoutUnitString
 		default:
 			break

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataClass.swift
@@ -283,7 +283,7 @@ public class TreatmentEntry: NSManagedObject, Comparable {
             dict["eventType"] = "BG Check" // maybe overwritten in next statement
             dict["glucose"] = self.value
             dict["glucoseType"] = "Finger"
-            dict["units"] = String(UserDefaults.standard.bloodGlucoseUnitIsMgDl ? ConstantsNightScout.mgDlNightscoutUnitString : ConstantsNightScout.mmolNightscoutUnitString)
+            dict["units"] = ConstantsNightScout.mgDlNightscoutUnitString
 		default:
 			break
 		}

--- a/xdrip/Core Data/classes/TreatmentEntry+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/TreatmentEntry+CoreDataProperties.swift
@@ -23,7 +23,7 @@ extension TreatmentEntry {
 	/// Date represents the date of the treatment, not the date of creation.
 	@NSManaged public var date: Date
 
-	/// Value represents the amount (e.g. insulin units or carbs grams).
+	/// Value represents the amount (e.g. insulin units, carbs grams, BG check glucose value).
 	@NSManaged public var value: Double
 
 	/// Enum TreatmentType defines which treatment this instance is.

--- a/xdrip/Extensions/ChartPoint.swift
+++ b/xdrip/Extensions/ChartPoint.swift
@@ -33,6 +33,16 @@ extension ChartPoint {
 
     }
     
+    /// the bg check treatment value is always stored in mg/dl so needs to be converted/rounded as required to show correctly on the chart
+    convenience init(bgCheck: TreatmentEntry, formatter: DateFormatter, unitIsMgDl: Bool) {
+        
+            self.init(
+                x: ChartAxisValueDate(date: bgCheck.date, formatter: formatter),
+                y: ChartAxisValueDouble(bgCheck.value.mgdlToMmol(mgdl: unitIsMgDl).bgValueRounded(mgdl: unitIsMgDl))
+            )
+
+    }
+    
     /// the chartpoints defined for certain treatment entries (such as carbs) are positioned relative to other elements and need to be re-scaled to fit the y-axis values of the glucose chart points (and therefore avoid needing a secondary axis)
     convenience init(treatmentEntry: TreatmentEntry, formatter: DateFormatter, newYAxisValue: Double? = 0) {
         

--- a/xdrip/Extensions/UserDefaults.swift
+++ b/xdrip/Extensions/UserDefaults.swift
@@ -70,6 +70,12 @@ extension UserDefaults {
         /// micro-bolus threshold level in units
         case smallBolusTreatmentThreshold = "smallBolusTreatmentThreshold"
         
+        /// should the micro-boluses be shown on the main chart?
+        case showSmallBolusTreatmentsOnChart = "showSmallBolusTreatmentsOnChart"
+        
+        /// should the micro-boluses be listed in the treatment list/table?
+        case showSmallBolusTreatmentsInList = "showSmallBolusTreatmentsInList"
+        
         // Statistics settings
         
         /// show the statistics? How many days should we use for the calculations?
@@ -770,6 +776,28 @@ extension UserDefaults {
         set {
 
             set(newValue, forKey: Key.smallBolusTreatmentThreshold.rawValue)
+        }
+    }
+    
+    /// should the app show the micro-bolus treatments on the main chart?
+    @objc dynamic var showSmallBolusTreatmentsOnChart: Bool {
+        // default value for bool in userdefaults is false, by default we want the app to *show* the micro-bolus treatments on the chart
+        get {
+            return !bool(forKey: Key.showSmallBolusTreatmentsOnChart.rawValue)
+        }
+        set {
+            set(!newValue, forKey: Key.showSmallBolusTreatmentsOnChart.rawValue)
+        }
+    }
+    
+    /// should the app show the micro-bolus treatments in the treatments list/table?
+    @objc dynamic var showSmallBolusTreatmentsInList: Bool {
+        // default value for bool in userdefaults is false, by default we want the app to *hide* the micro-bolus treatments in the treatments table
+        get {
+            return bool(forKey: Key.showSmallBolusTreatmentsInList.rawValue)
+        }
+        set {
+            set(newValue, forKey: Key.showSmallBolusTreatmentsInList.rawValue)
         }
     }
     

--- a/xdrip/Managers/Charts/GlucoseChartManager.swift
+++ b/xdrip/Managers/Charts/GlucoseChartManager.swift
@@ -20,7 +20,8 @@ public class GlucoseChartManager {
     /// - smallBolus = bolus values below the micro-bolus threshold (usually around 1.0U or less)
     /// - mediumBolus = all boluses over the micro-bolus threshold ("normal" boluses and will be shown with a label)
     /// - smallCarbs / mediumCarbs / largeCarbs / veryLargeCarbs = groups of each aproximate size to be represented by a different size chart point. The exact carb size context is given using a label
-    typealias TreatmentChartPointsType = (smallBolus: [ChartPoint], mediumBolus: [ChartPoint], smallCarbs: [ChartPoint], mediumCarbs: [ChartPoint], largeCarbs: [ChartPoint], veryLargeCarbs: [ChartPoint])
+    /// - bgCheck = blood glucose (finger) checks
+    typealias TreatmentChartPointsType = (smallBolus: [ChartPoint], mediumBolus: [ChartPoint], smallCarbs: [ChartPoint], mediumCarbs: [ChartPoint], largeCarbs: [ChartPoint], veryLargeCarbs: [ChartPoint], bgChecks: [ChartPoint])
     
     // MARK: - private properties
     
@@ -37,7 +38,7 @@ public class GlucoseChartManager {
     private var calibrationChartPoints = [ChartPoint]()
         
     /// treatmentChartPoints to be shown on chart
-    private var treatmentChartPoints: TreatmentChartPointsType = ([ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint]())
+    private var treatmentChartPoints: TreatmentChartPointsType = ([ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint]())
         
     /// smallBolusTreatmentChartPoints to be shown on chart
     private var smallBolusTreatmentChartPoints = [ChartPoint]()
@@ -56,6 +57,9 @@ public class GlucoseChartManager {
     
     /// veryLargeCarbsTreatmentChartPoints to be shown on chart
     private var veryLargeCarbsTreatmentChartPoints = [ChartPoint]()
+    
+    /// bgCheckTreatmentChartPoints to be shown on chart
+    private var bgCheckTreatmentChartPoints = [ChartPoint]()
 
     /// ChartPoints to be shown on chart, processed only in main thread - urgent Range
     private var urgentRangeGlucoseChartPoints = [ChartPoint]()
@@ -314,6 +318,7 @@ public class GlucoseChartManager {
                 self.treatmentChartPoints.mediumCarbs = treatmentChartPoints.mediumCarbs
                 self.treatmentChartPoints.largeCarbs = treatmentChartPoints.largeCarbs
                 self.treatmentChartPoints.veryLargeCarbs = treatmentChartPoints.veryLargeCarbs
+                self.treatmentChartPoints.bgChecks = treatmentChartPoints.bgChecks
                 
             }
             
@@ -340,6 +345,9 @@ public class GlucoseChartManager {
                 self.mediumCarbsTreatmentChartPoints = self.treatmentChartPoints.mediumCarbs
                 self.largeCarbsTreatmentChartPoints = self.treatmentChartPoints.largeCarbs
                 self.veryLargeCarbsTreatmentChartPoints = self.treatmentChartPoints.veryLargeCarbs
+                
+                // assign the BG check treatment chart points
+                self.bgCheckTreatmentChartPoints = self.treatmentChartPoints.bgChecks
                     
                 // update the chart outlet
                 chartOutlet.reloadChart()
@@ -775,6 +783,11 @@ public class GlucoseChartManager {
         
         let calibrationCirclesInnerLayer = ChartPointsScatterCirclesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: calibrationChartPoints, displayDelay: 0, itemSize: CGSize(width: glucoseCircleDiameter * ConstantsGlucoseChart.calibrationCircleScaleInner, height: glucoseCircleDiameter * ConstantsGlucoseChart.calibrationCircleScaleInner), itemFillColor: ConstantsGlucoseChart.calibrationCircleColorInner, optimized: true)
         
+        // bg check treatment circle layers - we'll create two circles, one on top of the other to give a gray border as per Nightscout BG Checks. We'll make the inner circle UIColor.red to make it slightly different to the UIColor.systemRed used by the glucoseChartPoints. Both circles will be scaled as per the current glucoseCircleDiameter but bigger so that they stand out
+        let bgCheckCirclesOuterLayer = ChartPointsScatterCirclesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: bgCheckTreatmentChartPoints, displayDelay: 0, itemSize: CGSize(width: glucoseCircleDiameter * ConstantsGlucoseChart.bgCheckTreatmentScaleOuter , height: glucoseCircleDiameter * ConstantsGlucoseChart.bgCheckTreatmentScaleOuter), itemFillColor: ConstantsGlucoseChart.bgCheckTreatmentColorOuter, optimized: true)
+        
+        let bgCheckCirclesInnerLayer = ChartPointsScatterCirclesLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: bgCheckTreatmentChartPoints, displayDelay: 0, itemSize: CGSize(width: glucoseCircleDiameter * ConstantsGlucoseChart.bgCheckTreatmentScaleInner, height: glucoseCircleDiameter * ConstantsGlucoseChart.bgCheckTreatmentScaleInner), itemFillColor: ConstantsGlucoseChart.bgCheckTreatmentColorInner, optimized: true)
+        
         // bolus triangle layers
         let mediumBolusTriangleLayer = ChartPointsScatterDownTrianglesWithDropdownLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, chartPoints: mediumBolusTreatmentChartPoints, displayDelay: 0, itemSize: CGSize(width: bolusTriangleSize, height: bolusTriangleSize * ConstantsGlucoseChart.bolusTriangleHeightScale), itemFillColor: ConstantsGlucoseChart.bolusTreatmentColor)
         
@@ -840,13 +853,13 @@ public class GlucoseChartManager {
         }
         
         let layersGlucoseCircles: [ChartLayer?] = [
-            // calibrationPoint layers
-            calibrationCirclesOuterLayer,
-            calibrationCirclesInnerLayer,
             // glucosePoint layers
             inRangeGlucoseCirclesLayer,
             notUrgentRangeGlucoseCirclesLayer,
-            urgentRangeGlucoseCirclesLayer
+            urgentRangeGlucoseCirclesLayer,
+            // calibrationPoint layers
+            calibrationCirclesOuterLayer,
+            calibrationCirclesInnerLayer
         ]
         
         layers.append(contentsOf: layersGlucoseCircles)
@@ -854,6 +867,9 @@ public class GlucoseChartManager {
         if UserDefaults.standard.showTreatmentsOnChart {
             
             let layersTreatmentLabels: [ChartLayer?] = [
+                // bg check treatment layers
+                bgCheckCirclesOuterLayer,
+                bgCheckCirclesInnerLayer,
                 // treatment label layers
                 smallCarbsLabelsLayer,
                 mediumCarbsLabelsLayer,
@@ -1032,7 +1048,7 @@ public class GlucoseChartManager {
     ///     - bgReadingsAccessor : bg readings accessor object
     ///     - managedObjectContext : the ManagedObjectContext to use
     /// - returns: a tuple with chart point arrays for each classification of treatment type + size
-    private func getTreatmentEntryChartPoints(startDate: Date, endDate: Date, treatmentEntryAccessor: TreatmentEntryAccessor, bgReadingsAccessor: BgReadingsAccessor, on managedObjectContext: NSManagedObjectContext) -> ([ChartPoint], [ChartPoint], [ChartPoint], [ChartPoint], [ChartPoint], [ChartPoint]) {
+    private func getTreatmentEntryChartPoints(startDate: Date, endDate: Date, treatmentEntryAccessor: TreatmentEntryAccessor, bgReadingsAccessor: BgReadingsAccessor, on managedObjectContext: NSManagedObjectContext) -> ([ChartPoint], [ChartPoint], [ChartPoint], [ChartPoint], [ChartPoint], [ChartPoint], [ChartPoint]) {
         
         // get treaments between the two timestamps from coredata
         let treatmentEntries = treatmentEntryAccessor.getTreatments(fromDate: startDate, toDate: endDate, on: managedObjectContext)
@@ -1040,10 +1056,13 @@ public class GlucoseChartManager {
         // intialize the treatment chart point arrays
         var smallBolusTreatmentEntryChartPoints = [ChartPoint]()
         var mediumBolusTreatmentEntryChartPoints = [ChartPoint]()
+        
         var smallCarbsTreatmentEntryChartPoints = [ChartPoint]()
         var mediumCarbsTreatmentEntryChartPoints = [ChartPoint]()
         var largeCarbsTreatmentEntryChartPoints = [ChartPoint]()
         var veryLargeCarbsTreatmentEntryChartPoints = [ChartPoint]()
+        
+        var bgCheckTreatmentEntryChartPoints = [ChartPoint]()
         
         managedObjectContext.performAndWait {
             
@@ -1085,6 +1104,10 @@ public class GlucoseChartManager {
                         
                     }
                     
+                case .BgCheck:
+                    
+                    bgCheckTreatmentEntryChartPoints.append(ChartPoint(bgCheck: treatmentEntry, formatter: data().chartPointDateFormatter, unitIsMgDl: UserDefaults.standard.bloodGlucoseUnitIsMgDl))
+                    
                 default:
                     break
                     
@@ -1095,7 +1118,7 @@ public class GlucoseChartManager {
         }
         
         // return all treatment arrays based upon treatment type and size (as defined by the threshold values)
-        return (smallBolusTreatmentEntryChartPoints, mediumBolusTreatmentEntryChartPoints, smallCarbsTreatmentEntryChartPoints, mediumCarbsTreatmentEntryChartPoints, largeCarbsTreatmentEntryChartPoints, veryLargeCarbsTreatmentEntryChartPoints)
+        return (smallBolusTreatmentEntryChartPoints, mediumBolusTreatmentEntryChartPoints, smallCarbsTreatmentEntryChartPoints, mediumCarbsTreatmentEntryChartPoints, largeCarbsTreatmentEntryChartPoints, veryLargeCarbsTreatmentEntryChartPoints, bgCheckTreatmentEntryChartPoints)
         
     }
     
@@ -1285,7 +1308,7 @@ public class GlucoseChartManager {
         stopDeceleration()
         
         glucoseChartPoints = ([ChartPoint](), [ChartPoint](), [ChartPoint](), nil, nil, nil)
-        treatmentChartPoints = ([ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint]())
+        treatmentChartPoints = ([ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint](), [ChartPoint]())
         
         calibrationChartPoints = [ChartPoint]()
         
@@ -1295,6 +1318,8 @@ public class GlucoseChartManager {
         smallCarbsTreatmentChartPoints = [ChartPoint]()
         mediumCarbsTreatmentChartPoints = [ChartPoint]()
         largeCarbsTreatmentChartPoints = [ChartPoint]()
+        
+        bgCheckTreatmentChartPoints = [ChartPoint]()
         
         chartSettings = nil
         

--- a/xdrip/Managers/Charts/GlucoseChartManager.swift
+++ b/xdrip/Managers/Charts/GlucoseChartManager.swift
@@ -844,7 +844,16 @@ public class GlucoseChartManager {
                 mediumCarbsLayer,
                 smallCarbsLayer,
                 // bolus treatment layers
-                mediumBolusTriangleLayer,
+                mediumBolusTriangleLayer
+            ]
+            
+            layers.append(contentsOf: layersTreatments)
+            
+        }
+        
+        if UserDefaults.standard.showTreatmentsOnChart && UserDefaults.standard.showSmallBolusTreatmentsOnChart {
+            
+            let layersTreatments: [ChartLayer?] = [
                 smallBolusTriangleLayer
             ]
             

--- a/xdrip/Managers/NightScout/NightScoutUploadManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutUploadManager.swift
@@ -604,6 +604,7 @@ public class NightScoutUploadManager: NSObject {
                 case .BgCheck:
                     treatmentToUploadToNightscoutAsDictionary["glucose"] = otherTreatmentEntry.value
                     treatmentToUploadToNightscoutAsDictionary["units"] = ConstantsNightScout.mgDlNightscoutUnitString
+                    treatmentToUploadToNightscoutAsDictionary["glucoseType"] = "Finger" + String(!UserDefaults.standard.bloodGlucoseUnitIsMgDl ? ": " + otherTreatmentEntry.value.mgdlToMmolAndToString(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl) + " " + Texts_Common.mmol : "")
                     
                 default:
                     break

--- a/xdrip/Managers/NightScout/NightScoutUploadManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutUploadManager.swift
@@ -602,8 +602,8 @@ public class NightScoutUploadManager: NSObject {
                     treatmentToUploadToNightscoutAsDictionary["duration"] = otherTreatmentEntry.value
                     
                 case .BgCheck:
-                    treatmentToUploadToNightscoutAsDictionary["glucose"] = otherTreatmentEntry.value.mgdlToMmol(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl).bgValueRounded(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl)
-                    treatmentToUploadToNightscoutAsDictionary["units"] = String(UserDefaults.standard.bloodGlucoseUnitIsMgDl ? ConstantsNightScout.mgDlNightscoutUnitString : ConstantsNightScout.mmolNightscoutUnitString)
+                    treatmentToUploadToNightscoutAsDictionary["glucose"] = otherTreatmentEntry.value
+                    treatmentToUploadToNightscoutAsDictionary["units"] = ConstantsNightScout.mgDlNightscoutUnitString
                     
                 default:
                     break

--- a/xdrip/Managers/NightScout/NightScoutUploadManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutUploadManager.swift
@@ -601,6 +601,10 @@ public class NightScoutUploadManager: NSObject {
                 case .Exercise:
                     treatmentToUploadToNightscoutAsDictionary["duration"] = otherTreatmentEntry.value
                     
+                case .BgCheck:
+                    treatmentToUploadToNightscoutAsDictionary["glucose"] = otherTreatmentEntry.value.mgdlToMmol(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl).bgValueRounded(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl)
+                    treatmentToUploadToNightscoutAsDictionary["units"] = String(UserDefaults.standard.bloodGlucoseUnitIsMgDl ? ConstantsNightScout.mgDlNightscoutUnitString : ConstantsNightScout.mmolNightscoutUnitString)
+                    
                 default:
                     break
                     

--- a/xdrip/Storyboards/Base.lproj/Main.storyboard
+++ b/xdrip/Storyboards/Base.lproj/Main.storyboard
@@ -1834,16 +1834,16 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="Ltu-UO-Ypa">
-                                <rect key="frame" x="35" y="168" width="320" height="378"/>
+                                <rect key="frame" x="35" y="168" width="320" height="422"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="lph-Ca-ZpH">
-                                        <rect key="frame" x="36" y="0.0" width="248" height="122"/>
+                                        <rect key="frame" x="30.333333333333343" y="0.0" width="259.33333333333326" height="166"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ZDj-72-yiq" userLabel="Carbs Stack">
-                                                <rect key="frame" x="0.0" y="0.0" width="248" height="34"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="259.33333333333331" height="34"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs (g):" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fvP-G8-Gxk">
-                                                        <rect key="frame" x="0.0" y="5.6666666666666572" width="140" height="23"/>
+                                                        <rect key="frame" x="0.0" y="5.6666666666666572" width="151.33333333333334" height="23"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="XcQ-AC-RqE"/>
                                                         </constraints>
@@ -1852,7 +1852,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="saY-fP-EEW">
-                                                        <rect key="frame" x="148" y="0.0" width="100" height="34"/>
+                                                        <rect key="frame" x="159.33333333333331" y="0.0" width="100" height="34"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="100" id="o92-Cd-7bP"/>
                                                         </constraints>
@@ -1862,10 +1862,10 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="4G8-c0-IhJ" userLabel="Insulin Stack">
-                                                <rect key="frame" x="0.0" y="44" width="248" height="34"/>
+                                                <rect key="frame" x="0.0" y="44" width="259.33333333333331" height="34"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin (U):" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="agq-m8-HZ9">
-                                                        <rect key="frame" x="0.0" y="0.0" width="140" height="34"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="151.33333333333334" height="34"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="PIM-iN-dt1"/>
                                                         </constraints>
@@ -1874,7 +1874,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0.0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ggq-1D-Pj6">
-                                                        <rect key="frame" x="148" y="0.0" width="100" height="34"/>
+                                                        <rect key="frame" x="159.33333333333331" y="0.0" width="100" height="34"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="100" id="KId-Tf-1aj"/>
                                                         </constraints>
@@ -1884,10 +1884,10 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="OJv-t7-QLZ" userLabel="Exercise Stack">
-                                                <rect key="frame" x="0.0" y="88" width="248" height="34"/>
+                                                <rect key="frame" x="0.0" y="88" width="259.33333333333331" height="34"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Exercise (min):" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9tx-02-GXf">
-                                                        <rect key="frame" x="0.0" y="0.0" width="140" height="34"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="151.33333333333334" height="34"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="c4f-TH-tJq"/>
                                                         </constraints>
@@ -1896,7 +1896,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="kl9-iM-MlH">
-                                                        <rect key="frame" x="148" y="0.0" width="100" height="34"/>
+                                                        <rect key="frame" x="159.33333333333331" y="0.0" width="100" height="34"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="100" id="1kf-sW-mbf"/>
                                                         </constraints>
@@ -1905,10 +1905,29 @@
                                                     </textField>
                                                 </subviews>
                                             </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6xP-xO-cse">
+                                                <rect key="frame" x="0.0" y="132" width="259.33333333333331" height="34"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BG Check (mg/dl):" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gju-y6-ier">
+                                                        <rect key="frame" x="0.0" y="0.0" width="159.33333333333334" height="34"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
+                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="3jm-to-PhE">
+                                                        <rect key="frame" x="159.33333333333331" y="0.0" width="100" height="34"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="100" id="xoy-M1-gJY"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                    </textField>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
                                     </stackView>
                                     <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" style="wheels" translatesAutoresizingMaskIntoConstraints="NO" id="M5l-qV-xjH">
-                                        <rect key="frame" x="0.0" y="162" width="320" height="216"/>
+                                        <rect key="frame" x="0.0" y="206" width="320" height="216"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="color" keyPath="textColor">
                                                 <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1938,6 +1957,9 @@
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="bgCheckLabel" destination="Gju-y6-ier" id="IIt-rx-jiD"/>
+                        <outlet property="bgCheckStackView" destination="6xP-xO-cse" id="B9Q-UA-Ant"/>
+                        <outlet property="bgCheckTextField" destination="3jm-to-PhE" id="gBA-zV-4F2"/>
                         <outlet property="carbsLabel" destination="fvP-G8-Gxk" id="d2b-CN-IK4"/>
                         <outlet property="carbsStackView" destination="ZDj-72-yiq" id="HEu-wA-BlI"/>
                         <outlet property="carbsTextField" destination="saY-fP-EEW" id="4DV-cC-8cz"/>

--- a/xdrip/Storyboards/Base.lproj/Main.storyboard
+++ b/xdrip/Storyboards/Base.lproj/Main.storyboard
@@ -6,7 +6,6 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1851,17 +1850,18 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Ltu-UO-Ypa">
-                                <rect key="frame" x="35" y="216" width="320" height="412"/>
+                                <rect key="frame" x="57" y="216" width="276" height="412"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="lph-Ca-ZpH">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="166"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="276" height="166"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ZDj-72-yiq" userLabel="Carbs Stack">
-                                                <rect key="frame" x="0.0" y="0.0" width="320" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ZDj-72-yiq" userLabel="Carbs Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="276" height="34"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fvP-G8-Gxk">
-                                                        <rect key="frame" x="0.0" y="0.0" width="156" height="34"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="120" height="34"/>
                                                         <constraints>
+                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="120" id="Fqw-Of-Irf"/>
                                                             <constraint firstAttribute="height" constant="34" id="aUb-ck-1k7"/>
                                                         </constraints>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
@@ -1869,21 +1869,18 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fCq-zr-tpJ">
-                                                        <rect key="frame" x="164" y="0.0" width="156" height="34"/>
+                                                        <rect key="frame" x="128" y="0.0" width="148" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="14" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="saY-fP-EEW">
-                                                                <rect key="frame" x="0.0" y="0.0" width="74" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="o92-Cd-7bP"/>
+                                                                    <constraint firstAttribute="width" constant="70" id="o92-Cd-7bP"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="g" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qyu-wZ-l4Q">
-                                                                <rect key="frame" x="82" y="0.0" width="74" height="34"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="txt-Ig-4H7"/>
-                                                                </constraints>
+                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
@@ -1895,28 +1892,31 @@
                                                     <constraint firstItem="fCq-zr-tpJ" firstAttribute="centerY" secondItem="fvP-G8-Gxk" secondAttribute="centerY" id="Adp-k2-96x"/>
                                                 </constraints>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="4G8-c0-IhJ" userLabel="Insulin Stack">
-                                                <rect key="frame" x="0.0" y="44" width="320" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="4G8-c0-IhJ" userLabel="Insulin Stack">
+                                                <rect key="frame" x="0.0" y="44" width="276" height="34"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="agq-m8-HZ9">
-                                                        <rect key="frame" x="0.0" y="0.0" width="156" height="34"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="120" height="34"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="120" id="fau-sX-pQ8"/>
+                                                        </constraints>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Mur-mt-d6N">
-                                                        <rect key="frame" x="164" y="0.0" width="156" height="34"/>
+                                                        <rect key="frame" x="128" y="0.0" width="148" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0.0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ggq-1D-Pj6">
-                                                                <rect key="frame" x="0.0" y="0.0" width="74" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="70" id="12x-eq-WUs"/>
+                                                                </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="U" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sb5-Wd-8Ra">
-                                                                <rect key="frame" x="82" y="0.0" width="74" height="34"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="Rsc-c6-Z0w"/>
-                                                                </constraints>
+                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
@@ -1925,31 +1925,31 @@
                                                     </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="OJv-t7-QLZ" userLabel="Exercise Stack">
-                                                <rect key="frame" x="0.0" y="88" width="320" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="OJv-t7-QLZ" userLabel="Exercise Stack">
+                                                <rect key="frame" x="0.0" y="88" width="276" height="34"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Exercise:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9tx-02-GXf">
-                                                        <rect key="frame" x="0.0" y="0.0" width="156" height="34"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="120" height="34"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="120" id="ffG-3a-Pi0"/>
+                                                        </constraints>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="TtC-Eo-Vt4">
-                                                        <rect key="frame" x="164" y="0.0" width="156" height="34"/>
+                                                        <rect key="frame" x="128" y="0.0" width="148" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="kl9-iM-MlH">
-                                                                <rect key="frame" x="0.0" y="0.0" width="74" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="1kf-sW-mbf"/>
+                                                                    <constraint firstAttribute="width" constant="70" id="1kf-sW-mbf"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mins" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xyz-4w-lz5">
-                                                                <rect key="frame" x="82" y="0.0" width="74" height="34"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="hsJ-Uv-7Hq"/>
-                                                                </constraints>
+                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
@@ -1958,31 +1958,31 @@
                                                     </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="6xP-xO-cse">
-                                                <rect key="frame" x="0.0" y="132" width="320" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6xP-xO-cse">
+                                                <rect key="frame" x="0.0" y="132" width="276" height="34"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="BG Check:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Gju-y6-ier">
-                                                        <rect key="frame" x="0.0" y="0.0" width="156" height="34"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="120" height="34"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="120" id="ESn-SJ-7xh"/>
+                                                        </constraints>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Int-v5-ymt">
-                                                        <rect key="frame" x="164" y="0.0" width="156" height="34"/>
+                                                        <rect key="frame" x="128" y="0.0" width="148" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="3jm-to-PhE">
-                                                                <rect key="frame" x="0.0" y="0.0" width="74" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="xoy-M1-gJY"/>
+                                                                    <constraint firstAttribute="width" constant="70" id="xoy-M1-gJY"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mg/dl" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iho-Ag-dJP">
-                                                                <rect key="frame" x="82" y="0.0" width="74" height="34"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="2Xx-qh-kkF"/>
-                                                                </constraints>
+                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
@@ -1998,7 +1998,7 @@
                                         </constraints>
                                     </stackView>
                                     <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" style="wheels" translatesAutoresizingMaskIntoConstraints="NO" id="M5l-qV-xjH">
-                                        <rect key="frame" x="0.0" y="196" width="320" height="216"/>
+                                        <rect key="frame" x="0.0" y="196" width="276" height="216"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="color" keyPath="textColor">
                                                 <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/xdrip/Storyboards/Base.lproj/Main.storyboard
+++ b/xdrip/Storyboards/Base.lproj/Main.storyboard
@@ -1850,17 +1850,17 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Ltu-UO-Ypa">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Ltu-UO-Ypa">
                                 <rect key="frame" x="35" y="216" width="320" height="412"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="lph-Ca-ZpH">
-                                        <rect key="frame" x="8" y="0.0" width="304" height="166"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="166"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ZDj-72-yiq" userLabel="Carbs Stack">
-                                                <rect key="frame" x="0.0" y="0.0" width="304" height="34"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="320" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="fvP-G8-Gxk">
-                                                        <rect key="frame" x="0.0" y="0.0" width="148" height="34"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fvP-G8-Gxk">
+                                                        <rect key="frame" x="0.0" y="0.0" width="156" height="34"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="34" id="aUb-ck-1k7"/>
                                                         </constraints>
@@ -1869,18 +1869,18 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fCq-zr-tpJ">
-                                                        <rect key="frame" x="156" y="0.0" width="148" height="34"/>
+                                                        <rect key="frame" x="164" y="0.0" width="156" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="14" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="saY-fP-EEW">
-                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="74" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="o92-Cd-7bP"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="g" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="qyu-wZ-l4Q">
-                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="g" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qyu-wZ-l4Q">
+                                                                <rect key="frame" x="82" y="0.0" width="74" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="txt-Ig-4H7"/>
                                                                 </constraints>
@@ -1896,24 +1896,24 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="4G8-c0-IhJ" userLabel="Insulin Stack">
-                                                <rect key="frame" x="0.0" y="44" width="304" height="34"/>
+                                                <rect key="frame" x="0.0" y="44" width="320" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="agq-m8-HZ9">
-                                                        <rect key="frame" x="0.0" y="0.0" width="148" height="34"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="agq-m8-HZ9">
+                                                        <rect key="frame" x="0.0" y="0.0" width="156" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Mur-mt-d6N">
-                                                        <rect key="frame" x="156" y="0.0" width="148" height="34"/>
+                                                        <rect key="frame" x="164" y="0.0" width="156" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0.0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ggq-1D-Pj6">
-                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="74" height="34"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="U" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Sb5-Wd-8Ra">
-                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="U" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sb5-Wd-8Ra">
+                                                                <rect key="frame" x="82" y="0.0" width="74" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="Rsc-c6-Z0w"/>
                                                                 </constraints>
@@ -1926,27 +1926,27 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="OJv-t7-QLZ" userLabel="Exercise Stack">
-                                                <rect key="frame" x="0.0" y="88" width="304" height="34"/>
+                                                <rect key="frame" x="0.0" y="88" width="320" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Exercise:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="9tx-02-GXf">
-                                                        <rect key="frame" x="0.0" y="0.0" width="148" height="34"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Exercise:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9tx-02-GXf">
+                                                        <rect key="frame" x="0.0" y="0.0" width="156" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="TtC-Eo-Vt4">
-                                                        <rect key="frame" x="156" y="0.0" width="148" height="34"/>
+                                                        <rect key="frame" x="164" y="0.0" width="156" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="kl9-iM-MlH">
-                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="74" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="1kf-sW-mbf"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mins" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Xyz-4w-lz5">
-                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mins" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xyz-4w-lz5">
+                                                                <rect key="frame" x="82" y="0.0" width="74" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="hsJ-Uv-7Hq"/>
                                                                 </constraints>
@@ -1959,27 +1959,27 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="6xP-xO-cse">
-                                                <rect key="frame" x="0.0" y="132" width="304" height="34"/>
+                                                <rect key="frame" x="0.0" y="132" width="320" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="BG Check:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Gju-y6-ier">
-                                                        <rect key="frame" x="0.0" y="0.0" width="148" height="34"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="BG Check:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Gju-y6-ier">
+                                                        <rect key="frame" x="0.0" y="0.0" width="156" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Int-v5-ymt">
-                                                        <rect key="frame" x="156" y="0.0" width="148" height="34"/>
+                                                        <rect key="frame" x="164" y="0.0" width="156" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="3jm-to-PhE">
-                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="74" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="xoy-M1-gJY"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mg/dl" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="iho-Ag-dJP">
-                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mg/dl" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iho-Ag-dJP">
+                                                                <rect key="frame" x="82" y="0.0" width="74" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="2Xx-qh-kkF"/>
                                                                 </constraints>

--- a/xdrip/Storyboards/Base.lproj/Main.storyboard
+++ b/xdrip/Storyboards/Base.lproj/Main.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -162,55 +163,70 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="XPB-uN-uCA">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="24" estimatedSectionHeaderHeight="-1" sectionFooterHeight="24" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="XPB-uN-uCA">
                                 <rect key="frame" x="0.0" y="88" width="390" height="673"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="0.0" shouldIndentWhileEditing="NO" reuseIdentifier="TreatmentsCell" id="Gwu-WR-xta" customClass="TreatmentTableViewCell" customModule="xdrip" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.666666030883789" width="390" height="40.333332061767578"/>
+                                        <rect key="frame" x="0.0" y="44.666666030883789" width="390" height="43"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Gwu-WR-xta" id="DBW-d4-0o5">
-                                            <rect key="frame" x="0.0" y="0.0" width="390" height="40.333332061767578"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="390" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="3X4-8k-4dp">
-                                                    <rect key="frame" x="30" y="9.9999999999999982" width="330" height="20.333333333333329"/>
-                                                    <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JuE-mg-S0t">
-                                                            <rect key="frame" x="0.0" y="1.6666666666666661" width="39" height="17"/>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        </label>
-                                                        <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U6e-jp-cms">
-                                                            <rect key="frame" x="155.33333333333334" y="1.6666666666666661" width="41.666666666666657" height="17"/>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8u" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0na-qZ-kDB">
-                                                            <rect key="frame" x="313" y="1.6666666666666661" width="17" height="17"/>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        </label>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="20" id="hTe-PH-KmG"/>
-                                                    </constraints>
-                                                </stackView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JuE-mg-S0t">
+                                                    <rect key="frame" x="29.999999999999996" y="11.333333333333334" width="43.666666666666657" height="20.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </label>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.80000000000000004" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="v0f-JH-O27">
+                                                    <rect key="frame" x="100" y="14.666666666666668" width="14" height="14"/>
+                                                    <imageReference key="image" image="circle.fill" catalog="system" symbolScale="small"/>
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font">
+                                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    </preferredSymbolConfiguration>
+                                                </imageView>
+                                                <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U6e-jp-cms">
+                                                    <rect key="frame" x="130" y="12.333333333333334" width="46.666666666666657" height="19.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0na-qZ-kDB">
+                                                    <rect key="frame" x="305" y="11.333333333333334" width="10" height="20.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="g" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ACN-iY-zpP">
+                                                    <rect key="frame" x="320" y="11.333333333333334" width="9" height="20.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="3X4-8k-4dp" firstAttribute="top" secondItem="DBW-d4-0o5" secondAttribute="top" constant="10" id="7vl-wW-HHy"/>
-                                                <constraint firstItem="3X4-8k-4dp" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leading" constant="30" id="Jqk-mh-mGZ"/>
-                                                <constraint firstAttribute="bottom" secondItem="3X4-8k-4dp" secondAttribute="bottom" constant="10" id="hTk-XK-vN6"/>
-                                                <constraint firstAttribute="trailing" secondItem="3X4-8k-4dp" secondAttribute="trailing" constant="30" id="m5c-aQ-ZYB"/>
+                                                <constraint firstItem="JuE-mg-S0t" firstAttribute="centerY" secondItem="DBW-d4-0o5" secondAttribute="centerY" id="84R-oM-joS"/>
+                                                <constraint firstItem="0na-qZ-kDB" firstAttribute="top" secondItem="DBW-d4-0o5" secondAttribute="topMargin" constant="0.33333396911621094" id="9Bs-6Y-KoA"/>
+                                                <constraint firstItem="v0f-JH-O27" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leading" constant="100" id="FgJ-Op-Uvh"/>
+                                                <constraint firstItem="v0f-JH-O27" firstAttribute="centerY" secondItem="DBW-d4-0o5" secondAttribute="centerY" id="X4l-JC-GWN"/>
+                                                <constraint firstItem="ACN-iY-zpP" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leadingMargin" constant="300" id="arA-ZJ-NI8"/>
+                                                <constraint firstItem="ACN-iY-zpP" firstAttribute="centerY" secondItem="DBW-d4-0o5" secondAttribute="centerY" id="ctq-Os-Q9z"/>
+                                                <constraint firstItem="ACN-iY-zpP" firstAttribute="top" secondItem="DBW-d4-0o5" secondAttribute="topMargin" constant="0.33333396911621094" id="hVc-39-Abc"/>
+                                                <constraint firstItem="JuE-mg-S0t" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leadingMargin" constant="10" id="je8-Tg-HZP"/>
+                                                <constraint firstItem="U6e-jp-cms" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leadingMargin" constant="110" id="jun-UY-ULN"/>
+                                                <constraint firstItem="0na-qZ-kDB" firstAttribute="baseline" secondItem="U6e-jp-cms" secondAttribute="baseline" id="msL-Ny-DNX"/>
+                                                <constraint firstItem="0na-qZ-kDB" firstAttribute="baseline" secondItem="JuE-mg-S0t" secondAttribute="baseline" id="oc4-P3-VQ8"/>
+                                                <constraint firstItem="ACN-iY-zpP" firstAttribute="leading" secondItem="0na-qZ-kDB" secondAttribute="trailing" constant="5" id="ysQ-u2-2AH"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" white="0.17999999999999999" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <connections>
                                             <outlet property="dateLabel" destination="JuE-mg-S0t" id="03N-y2-Umh"/>
+                                            <outlet property="iconImageView" destination="v0f-JH-O27" id="gTh-vl-GM0"/>
                                             <outlet property="typeLabel" destination="U6e-jp-cms" id="uqQ-L0-k60"/>
+                                            <outlet property="unitLabel" destination="ACN-iY-zpP" id="Giv-bY-1u2"/>
                                             <outlet property="valueLabel" destination="0na-qZ-kDB" id="DRt-MD-law"/>
                                         </connections>
                                     </tableViewCell>
@@ -1833,101 +1849,160 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="Ltu-UO-Ypa">
-                                <rect key="frame" x="35" y="168" width="320" height="422"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="60" translatesAutoresizingMaskIntoConstraints="NO" id="Ltu-UO-Ypa">
+                                <rect key="frame" x="31" y="148" width="328" height="436"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="lph-Ca-ZpH">
-                                        <rect key="frame" x="30.333333333333343" y="0.0" width="259.33333333333326" height="166"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="lph-Ca-ZpH">
+                                        <rect key="frame" x="0.0" y="0.0" width="328" height="160"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ZDj-72-yiq" userLabel="Carbs Stack">
-                                                <rect key="frame" x="0.0" y="0.0" width="259.33333333333331" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="ZDj-72-yiq" userLabel="Carbs Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="328" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs (g):" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fvP-G8-Gxk">
-                                                        <rect key="frame" x="0.0" y="5.6666666666666572" width="151.33333333333334" height="23"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fvP-G8-Gxk">
+                                                        <rect key="frame" x="0.0" y="0.0" width="140" height="34"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="XcQ-AC-RqE"/>
                                                         </constraints>
-                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="saY-fP-EEW">
-                                                        <rect key="frame" x="159.33333333333331" y="0.0" width="100" height="34"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="100" id="o92-Cd-7bP"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" smartInsertDeleteType="no" smartQuotesType="no"/>
-                                                    </textField>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fCq-zr-tpJ">
+                                                        <rect key="frame" x="180" y="0.0" width="148" height="34"/>
+                                                        <subviews>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="14" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="saY-fP-EEW">
+                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="70" id="o92-Cd-7bP"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                            </textField>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="g" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qyu-wZ-l4Q">
+                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="txt-Ig-4H7"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="4G8-c0-IhJ" userLabel="Insulin Stack">
-                                                <rect key="frame" x="0.0" y="44" width="259.33333333333331" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="4G8-c0-IhJ" userLabel="Insulin Stack">
+                                                <rect key="frame" x="0.0" y="42" width="328" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin (U):" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="agq-m8-HZ9">
-                                                        <rect key="frame" x="0.0" y="0.0" width="151.33333333333334" height="34"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="agq-m8-HZ9">
+                                                        <rect key="frame" x="0.0" y="0.0" width="140" height="34"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="PIM-iN-dt1"/>
                                                         </constraints>
-                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0.0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ggq-1D-Pj6">
-                                                        <rect key="frame" x="159.33333333333331" y="0.0" width="100" height="34"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="100" id="KId-Tf-1aj"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
-                                                    </textField>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Mur-mt-d6N">
+                                                        <rect key="frame" x="180" y="0.0" width="148" height="34"/>
+                                                        <subviews>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0.0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ggq-1D-Pj6">
+                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="70" id="KId-Tf-1aj"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                            </textField>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="U" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sb5-Wd-8Ra">
+                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="Rsc-c6-Z0w"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="OJv-t7-QLZ" userLabel="Exercise Stack">
-                                                <rect key="frame" x="0.0" y="88" width="259.33333333333331" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="OJv-t7-QLZ" userLabel="Exercise Stack">
+                                                <rect key="frame" x="0.0" y="84" width="328" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Exercise (min):" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9tx-02-GXf">
-                                                        <rect key="frame" x="0.0" y="0.0" width="151.33333333333334" height="34"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Exercise:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9tx-02-GXf">
+                                                        <rect key="frame" x="0.0" y="0.0" width="140" height="34"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="c4f-TH-tJq"/>
                                                         </constraints>
-                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="kl9-iM-MlH">
-                                                        <rect key="frame" x="159.33333333333331" y="0.0" width="100" height="34"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="100" id="1kf-sW-mbf"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" smartInsertDeleteType="no" smartQuotesType="no"/>
-                                                    </textField>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="TtC-Eo-Vt4">
+                                                        <rect key="frame" x="180" y="0.0" width="148" height="34"/>
+                                                        <subviews>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="kl9-iM-MlH">
+                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="70" id="1kf-sW-mbf"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                            </textField>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mins" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xyz-4w-lz5">
+                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="hsJ-Uv-7Hq"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6xP-xO-cse">
-                                                <rect key="frame" x="0.0" y="132" width="259.33333333333331" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="6xP-xO-cse">
+                                                <rect key="frame" x="0.0" y="126" width="328" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BG Check (mg/dl):" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gju-y6-ier">
-                                                        <rect key="frame" x="0.0" y="0.0" width="159.33333333333334" height="34"/>
-                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="19"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="BG Check:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gju-y6-ier">
+                                                        <rect key="frame" x="0.0" y="0.0" width="140" height="34"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="Hmx-Cz-ud6"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="3jm-to-PhE">
-                                                        <rect key="frame" x="159.33333333333331" y="0.0" width="100" height="34"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="100" id="xoy-M1-gJY"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
-                                                    </textField>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Int-v5-ymt">
+                                                        <rect key="frame" x="180" y="0.0" width="148" height="34"/>
+                                                        <subviews>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="3jm-to-PhE">
+                                                                <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="70" id="xoy-M1-gJY"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                            </textField>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mg/dl" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iho-Ag-dJP">
+                                                                <rect key="frame" x="78" y="0.0" width="70" height="34"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="2Xx-qh-kkF"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
                                     </stackView>
                                     <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" style="wheels" translatesAutoresizingMaskIntoConstraints="NO" id="M5l-qV-xjH">
-                                        <rect key="frame" x="0.0" y="206" width="320" height="216"/>
+                                        <rect key="frame" x="4" y="220" width="320" height="216"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="color" keyPath="textColor">
                                                 <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1942,7 +2017,7 @@
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Ltu-UO-Ypa" firstAttribute="centerX" secondItem="u0y-ki-EPd" secondAttribute="centerX" id="0AB-vn-joB"/>
-                            <constraint firstItem="Ltu-UO-Ypa" firstAttribute="top" secondItem="mwU-Tw-d7Q" secondAttribute="top" constant="80" id="T43-7U-ObG"/>
+                            <constraint firstItem="Ltu-UO-Ypa" firstAttribute="top" secondItem="mwU-Tw-d7Q" secondAttribute="top" constant="60" id="T43-7U-ObG"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Treatments" image="Home" id="ucH-hI-fdv"/>
@@ -1960,17 +2035,21 @@
                         <outlet property="bgCheckLabel" destination="Gju-y6-ier" id="IIt-rx-jiD"/>
                         <outlet property="bgCheckStackView" destination="6xP-xO-cse" id="B9Q-UA-Ant"/>
                         <outlet property="bgCheckTextField" destination="3jm-to-PhE" id="gBA-zV-4F2"/>
+                        <outlet property="bgCheckUnitLabel" destination="iho-Ag-dJP" id="b2v-ij-8kg"/>
                         <outlet property="carbsLabel" destination="fvP-G8-Gxk" id="d2b-CN-IK4"/>
                         <outlet property="carbsStackView" destination="ZDj-72-yiq" id="HEu-wA-BlI"/>
                         <outlet property="carbsTextField" destination="saY-fP-EEW" id="4DV-cC-8cz"/>
+                        <outlet property="carbsUnitLabel" destination="qyu-wZ-l4Q" id="iJN-V9-XiU"/>
                         <outlet property="datePicker" destination="M5l-qV-xjH" id="itP-VQ-w6m"/>
                         <outlet property="doneButton" destination="6Fh-ms-ugk" id="RiQ-MN-r0W"/>
                         <outlet property="exerciseLabel" destination="9tx-02-GXf" id="GH5-oA-TX3"/>
                         <outlet property="exerciseStackView" destination="OJv-t7-QLZ" id="kuw-Ef-fXa"/>
                         <outlet property="exerciseTextField" destination="kl9-iM-MlH" id="hcJ-8j-9xT"/>
+                        <outlet property="exerciseUnitLabel" destination="Xyz-4w-lz5" id="ZIq-BX-AOI"/>
                         <outlet property="insulinLabel" destination="agq-m8-HZ9" id="rx7-pv-7Yo"/>
                         <outlet property="insulinStackView" destination="4G8-c0-IhJ" id="tao-kP-Rbv"/>
                         <outlet property="insulinTextField" destination="ggq-1D-Pj6" id="eDP-Dz-C8Z"/>
+                        <outlet property="insulinUnitLabel" destination="Sb5-Wd-8Ra" id="bME-qy-dZf"/>
                         <outlet property="titleNavigation" destination="nDn-qs-kKp" id="OLC-l6-yUz"/>
                     </connections>
                 </viewController>
@@ -1986,6 +2065,7 @@
         <image name="Treatments" width="30" height="30"/>
         <image name="chevron.backward" catalog="system" width="96" height="128"/>
         <image name="chevron.forward" catalog="system" width="96" height="128"/>
+        <image name="circle.fill" catalog="system" width="128" height="121"/>
         <image name="ellipsis.circle" catalog="system" width="128" height="121"/>
         <image name="lock" catalog="system" width="128" height="128"/>
         <image name="moon.zzz" catalog="system" width="115" height="128"/>

--- a/xdrip/Storyboards/Base.lproj/Main.storyboard
+++ b/xdrip/Storyboards/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -167,40 +168,40 @@
                                 <rect key="frame" x="0.0" y="88" width="390" height="673"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="0.0" shouldIndentWhileEditing="NO" reuseIdentifier="TreatmentsCell" id="Gwu-WR-xta" customClass="TreatmentTableViewCell" customModule="xdrip" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.666666030883789" width="390" height="43"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="0.0" shouldIndentWhileEditing="NO" reuseIdentifier="TreatmentsCell" rowHeight="26" id="Gwu-WR-xta" customClass="TreatmentTableViewCell" customModule="xdrip" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="44.666666030883789" width="390" height="26"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Gwu-WR-xta" id="DBW-d4-0o5">
-                                            <rect key="frame" x="0.0" y="0.0" width="390" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="390" height="26"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JuE-mg-S0t">
-                                                    <rect key="frame" x="29.999999999999996" y="11.333333333333334" width="43.666666666666657" height="20.333333333333329"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JuE-mg-S0t">
+                                                    <rect key="frame" x="19.999999999999996" y="3.3333333333333339" width="43.666666666666657" height="19.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </label>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.80000000000000004" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="v0f-JH-O27">
-                                                    <rect key="frame" x="100" y="14.666666666666668" width="14" height="14"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.80000000000000004" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="v0f-JH-O27">
+                                                    <rect key="frame" x="80" y="6" width="14" height="14"/>
                                                     <imageReference key="image" image="circle.fill" catalog="system" symbolScale="small"/>
-                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font">
-                                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font" scale="small" weight="regular">
+                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     </preferredSymbolConfiguration>
                                                 </imageView>
-                                                <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U6e-jp-cms">
-                                                    <rect key="frame" x="130" y="12.333333333333334" width="46.666666666666657" height="19.333333333333329"/>
+                                                <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U6e-jp-cms">
+                                                    <rect key="frame" x="110.00000000000001" y="3.3333333333333339" width="46.666666666666671" height="19.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0na-qZ-kDB">
-                                                    <rect key="frame" x="305" y="11.333333333333334" width="10" height="20.333333333333329"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0na-qZ-kDB">
+                                                    <rect key="frame" x="348" y="3.3333333333333339" width="10" height="19.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="g" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ACN-iY-zpP">
-                                                    <rect key="frame" x="320" y="11.333333333333334" width="9" height="20.333333333333329"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="g" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ACN-iY-zpP">
+                                                    <rect key="frame" x="361" y="3.3333333333333339" width="9" height="19.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -208,17 +209,17 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="JuE-mg-S0t" firstAttribute="centerY" secondItem="DBW-d4-0o5" secondAttribute="centerY" id="84R-oM-joS"/>
-                                                <constraint firstItem="0na-qZ-kDB" firstAttribute="top" secondItem="DBW-d4-0o5" secondAttribute="topMargin" constant="0.33333396911621094" id="9Bs-6Y-KoA"/>
-                                                <constraint firstItem="v0f-JH-O27" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leading" constant="100" id="FgJ-Op-Uvh"/>
+                                                <constraint firstItem="v0f-JH-O27" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leading" constant="80" id="FgJ-Op-Uvh"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="ACN-iY-zpP" secondAttribute="trailing" id="J1K-Uc-ySX"/>
+                                                <constraint firstItem="0na-qZ-kDB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="U6e-jp-cms" secondAttribute="trailing" constant="8" symbolic="YES" id="M2z-50-BVR"/>
                                                 <constraint firstItem="v0f-JH-O27" firstAttribute="centerY" secondItem="DBW-d4-0o5" secondAttribute="centerY" id="X4l-JC-GWN"/>
-                                                <constraint firstItem="ACN-iY-zpP" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leadingMargin" constant="300" id="arA-ZJ-NI8"/>
                                                 <constraint firstItem="ACN-iY-zpP" firstAttribute="centerY" secondItem="DBW-d4-0o5" secondAttribute="centerY" id="ctq-Os-Q9z"/>
-                                                <constraint firstItem="ACN-iY-zpP" firstAttribute="top" secondItem="DBW-d4-0o5" secondAttribute="topMargin" constant="0.33333396911621094" id="hVc-39-Abc"/>
-                                                <constraint firstItem="JuE-mg-S0t" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leadingMargin" constant="10" id="je8-Tg-HZP"/>
-                                                <constraint firstItem="U6e-jp-cms" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leadingMargin" constant="110" id="jun-UY-ULN"/>
+                                                <constraint firstItem="v0f-JH-O27" firstAttribute="leading" secondItem="JuE-mg-S0t" secondAttribute="trailing" constant="16.333333333333343" id="eZh-Jc-02b"/>
+                                                <constraint firstItem="JuE-mg-S0t" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="DBW-d4-0o5" secondAttribute="leadingMargin" id="je8-Tg-HZP"/>
+                                                <constraint firstItem="U6e-jp-cms" firstAttribute="leading" secondItem="DBW-d4-0o5" secondAttribute="leadingMargin" constant="90" id="jun-UY-ULN"/>
                                                 <constraint firstItem="0na-qZ-kDB" firstAttribute="baseline" secondItem="U6e-jp-cms" secondAttribute="baseline" id="msL-Ny-DNX"/>
                                                 <constraint firstItem="0na-qZ-kDB" firstAttribute="baseline" secondItem="JuE-mg-S0t" secondAttribute="baseline" id="oc4-P3-VQ8"/>
-                                                <constraint firstItem="ACN-iY-zpP" firstAttribute="leading" secondItem="0na-qZ-kDB" secondAttribute="trailing" constant="5" id="ysQ-u2-2AH"/>
+                                                <constraint firstItem="ACN-iY-zpP" firstAttribute="leading" secondItem="0na-qZ-kDB" secondAttribute="trailing" constant="3" id="ysQ-u2-2AH"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" white="0.17999999999999999" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1849,39 +1850,39 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="60" translatesAutoresizingMaskIntoConstraints="NO" id="Ltu-UO-Ypa">
-                                <rect key="frame" x="31" y="148" width="328" height="436"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Ltu-UO-Ypa">
+                                <rect key="frame" x="35" y="216" width="320" height="412"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="lph-Ca-ZpH">
-                                        <rect key="frame" x="0.0" y="0.0" width="328" height="160"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="lph-Ca-ZpH">
+                                        <rect key="frame" x="8" y="0.0" width="304" height="166"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="ZDj-72-yiq" userLabel="Carbs Stack">
-                                                <rect key="frame" x="0.0" y="0.0" width="328" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ZDj-72-yiq" userLabel="Carbs Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="304" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fvP-G8-Gxk">
-                                                        <rect key="frame" x="0.0" y="0.0" width="140" height="34"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="fvP-G8-Gxk">
+                                                        <rect key="frame" x="0.0" y="0.0" width="148" height="34"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="XcQ-AC-RqE"/>
+                                                            <constraint firstAttribute="height" constant="34" id="aUb-ck-1k7"/>
                                                         </constraints>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fCq-zr-tpJ">
-                                                        <rect key="frame" x="180" y="0.0" width="148" height="34"/>
+                                                        <rect key="frame" x="156" y="0.0" width="148" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="14" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="saY-fP-EEW">
                                                                 <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" constant="70" id="o92-Cd-7bP"/>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="o92-Cd-7bP"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="g" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qyu-wZ-l4Q">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="g" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="qyu-wZ-l4Q">
                                                                 <rect key="frame" x="78" y="0.0" width="70" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="txt-Ig-4H7"/>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="txt-Ig-4H7"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1890,34 +1891,31 @@
                                                         </subviews>
                                                     </stackView>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="fCq-zr-tpJ" firstAttribute="centerY" secondItem="fvP-G8-Gxk" secondAttribute="centerY" id="Adp-k2-96x"/>
+                                                </constraints>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="4G8-c0-IhJ" userLabel="Insulin Stack">
-                                                <rect key="frame" x="0.0" y="42" width="328" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="4G8-c0-IhJ" userLabel="Insulin Stack">
+                                                <rect key="frame" x="0.0" y="44" width="304" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="agq-m8-HZ9">
-                                                        <rect key="frame" x="0.0" y="0.0" width="140" height="34"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="PIM-iN-dt1"/>
-                                                        </constraints>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Insulin:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="agq-m8-HZ9">
+                                                        <rect key="frame" x="0.0" y="0.0" width="148" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Mur-mt-d6N">
-                                                        <rect key="frame" x="180" y="0.0" width="148" height="34"/>
+                                                        <rect key="frame" x="156" y="0.0" width="148" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0.0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ggq-1D-Pj6">
                                                                 <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" constant="70" id="KId-Tf-1aj"/>
-                                                                </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="U" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sb5-Wd-8Ra">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="U" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Sb5-Wd-8Ra">
                                                                 <rect key="frame" x="78" y="0.0" width="70" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="Rsc-c6-Z0w"/>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="Rsc-c6-Z0w"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1927,33 +1925,30 @@
                                                     </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="OJv-t7-QLZ" userLabel="Exercise Stack">
-                                                <rect key="frame" x="0.0" y="84" width="328" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="OJv-t7-QLZ" userLabel="Exercise Stack">
+                                                <rect key="frame" x="0.0" y="88" width="304" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Exercise:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9tx-02-GXf">
-                                                        <rect key="frame" x="0.0" y="0.0" width="140" height="34"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="c4f-TH-tJq"/>
-                                                        </constraints>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Exercise:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="9tx-02-GXf">
+                                                        <rect key="frame" x="0.0" y="0.0" width="148" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="TtC-Eo-Vt4">
-                                                        <rect key="frame" x="180" y="0.0" width="148" height="34"/>
+                                                        <rect key="frame" x="156" y="0.0" width="148" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="kl9-iM-MlH">
                                                                 <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" constant="70" id="1kf-sW-mbf"/>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="1kf-sW-mbf"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mins" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xyz-4w-lz5">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mins" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Xyz-4w-lz5">
                                                                 <rect key="frame" x="78" y="0.0" width="70" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="hsJ-Uv-7Hq"/>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="hsJ-Uv-7Hq"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1963,33 +1958,30 @@
                                                     </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="6xP-xO-cse">
-                                                <rect key="frame" x="0.0" y="126" width="328" height="34"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="6xP-xO-cse">
+                                                <rect key="frame" x="0.0" y="132" width="304" height="34"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="BG Check:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gju-y6-ier">
-                                                        <rect key="frame" x="0.0" y="0.0" width="140" height="34"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="Hmx-Cz-ud6"/>
-                                                        </constraints>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="BG Check:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Gju-y6-ier">
+                                                        <rect key="frame" x="0.0" y="0.0" width="148" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Int-v5-ymt">
-                                                        <rect key="frame" x="180" y="0.0" width="148" height="34"/>
+                                                        <rect key="frame" x="156" y="0.0" width="148" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" minimumFontSize="16" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="3jm-to-PhE">
                                                                 <rect key="frame" x="0.0" y="0.0" width="70" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" constant="70" id="xoy-M1-gJY"/>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="xoy-M1-gJY"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="decimalPad" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             </textField>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mg/dl" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iho-Ag-dJP">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mg/dl" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="iho-Ag-dJP">
                                                                 <rect key="frame" x="78" y="0.0" width="70" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="2Xx-qh-kkF"/>
+                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="2Xx-qh-kkF"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -2000,9 +1992,13 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="4G8-c0-IhJ" secondAttribute="bottom" constant="88" id="7a5-8C-MlF"/>
+                                            <constraint firstItem="ZDj-72-yiq" firstAttribute="top" secondItem="lph-Ca-ZpH" secondAttribute="top" id="UrI-4I-Rog"/>
+                                        </constraints>
                                     </stackView>
                                     <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" style="wheels" translatesAutoresizingMaskIntoConstraints="NO" id="M5l-qV-xjH">
-                                        <rect key="frame" x="4" y="220" width="320" height="216"/>
+                                        <rect key="frame" x="0.0" y="196" width="320" height="216"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="color" keyPath="textColor">
                                                 <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -2017,7 +2013,7 @@
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Ltu-UO-Ypa" firstAttribute="centerX" secondItem="u0y-ki-EPd" secondAttribute="centerX" id="0AB-vn-joB"/>
-                            <constraint firstItem="Ltu-UO-Ypa" firstAttribute="top" secondItem="mwU-Tw-d7Q" secondAttribute="top" constant="60" id="T43-7U-ObG"/>
+                            <constraint firstItem="Ltu-UO-Ypa" firstAttribute="centerY" secondItem="u0y-ki-EPd" secondAttribute="centerY" id="Bap-4A-Ae8"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Treatments" image="Home" id="ucH-hI-fdv"/>

--- a/xdrip/Storyboards/ar.lproj/Treatments.strings
+++ b/xdrip/Storyboards/ar.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "BG Check";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/da.lproj/Treatments.strings
+++ b/xdrip/Storyboards/da.lproj/Treatments.strings
@@ -10,6 +10,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "BG Kontrol";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/de.lproj/Treatments.strings
+++ b/xdrip/Storyboards/de.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "BG-Messung";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/en.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/en.lproj/SettingsViews.strings
@@ -30,8 +30,8 @@
 "settingsviews_showTreatmentsOnChart" = "Show Treatments on Chart?";
 "settingsviews_smallBolusTreatmentThreshold" = "Micro-bolus Threshold:";
 "settingsviews_smallBolusTreatmentThresholdMessage" = "Below how many units should we consider a bolus as a micro-bolus?\n\n(Recommended value: 1.0U)";
-"settingsviews_showSmallBolusTreatmentsOnChart" = "Show Micro-Bolus on Chart?";
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-Bolus in List?";
+"settingsviews_showSmallBolusTreatmentsOnChart" = "Show Micro-bolus on Chart?";
+"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
 "settingsviews_sectiontitlestatistics" = "Statistics";
 "settingsviews_showStatistics" = "Show Statistics?";
 "settingsviews_daysToUseStatisticsTitle" = "Days to Calculate?";

--- a/xdrip/Storyboards/en.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/en.lproj/SettingsViews.strings
@@ -30,6 +30,8 @@
 "settingsviews_showTreatmentsOnChart" = "Show Treatments on Chart?";
 "settingsviews_smallBolusTreatmentThreshold" = "Micro-bolus Threshold:";
 "settingsviews_smallBolusTreatmentThresholdMessage" = "Below how many units should we consider a bolus as a micro-bolus?\n\n(Recommended value: 1.0U)";
+"settingsviews_showSmallBolusTreatmentsOnChart" = "Show Micro-Bolus on Chart?";
+"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-Bolus in List?";
 "settingsviews_sectiontitlestatistics" = "Statistics";
 "settingsviews_showStatistics" = "Show Statistics?";
 "settingsviews_daysToUseStatisticsTitle" = "Days to Calculate?";

--- a/xdrip/Storyboards/en.lproj/Treatments.strings
+++ b/xdrip/Storyboards/en.lproj/Treatments.strings
@@ -10,6 +10,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "BG Check";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/es.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/es.lproj/SettingsViews.strings
@@ -21,8 +21,10 @@
 "settingsviews_showtarget" = "Mostrar Línea Target?";
 "settingsviews_sectiontitletreatments" = "Tratamientos";
 "settingsviews_showTreatmentsOnChart" = "Mostrar Tratamientos?";
-"settingsviews_smallBolusTreatmentThreshold" = "Límite micro-bolo:";
+"settingsviews_smallBolusTreatmentThreshold" = "Límite Micro-bolo:";
 "settingsviews_smallBolusTreatmentThresholdMessage" = "Por debajo de cuántas unidades debemos considerar un bolo como micro-bolo?\n\n(Valor recomendado: 1.0U)";
+"settingsviews_showSmallBolusTreatmentsOnChart" = "Mostrar Micro-bolos en Gráfica?";
+"settingsviews_showSmallBolusTreatmentsInList" = "Mostrar Micro-bolos en Listado?";
 "settingsviews_sectiontitlestatistics" = "Estadísticas";
 "settingsviews_showStatistics" = "Mostrar Estadísticas?";
 "settingsviews_daysToUseStatisticsTitle" = "Días a Calcular?";

--- a/xdrip/Storyboards/es.lproj/Treatments.strings
+++ b/xdrip/Storyboards/es.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "Control Glucemia";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/fi.lproj/Treatments.strings
+++ b/xdrip/Storyboards/fi.lproj/Treatments.strings
@@ -14,7 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
-"treatments_bgcheck" = "Verensokerin Tarkistus";
+"treatments_bgcheck" = "BG Check";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/fi.lproj/Treatments.strings
+++ b/xdrip/Storyboards/fi.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "Verensokerin Tarkistus";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/fr.lproj/Treatments.strings
+++ b/xdrip/Storyboards/fr.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "Contrôle Glycémie";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/it.lproj/Treatments.strings
+++ b/xdrip/Storyboards/it.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "Controllo Glicemia";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/nl.lproj/Treatments.strings
+++ b/xdrip/Storyboards/nl.lproj/Treatments.strings
@@ -14,7 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
-"treatments_bgcheck" = "Bloedglucose Check";
+"treatments_bgcheck" = "BG Check";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/nl.lproj/Treatments.strings
+++ b/xdrip/Storyboards/nl.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "Bloedglucose Check";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/pl-PL.lproj/Treatments.strings
+++ b/xdrip/Storyboards/pl-PL.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "Pomiar Glikemii";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/pt.lproj/Treatments.strings
+++ b/xdrip/Storyboards/pt.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "Verificar Glicose";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/ru.lproj/Treatments.strings
+++ b/xdrip/Storyboards/ru.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "BG Check";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/sl.lproj/Treatments.strings
+++ b/xdrip/Storyboards/sl.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "Kontrola Glykémie";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/sv.lproj/Treatments.strings
+++ b/xdrip/Storyboards/sv.lproj/Treatments.strings
@@ -14,7 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
-"treatments_bgcheck" = "Blodsockerkontroll";
+"treatments_bgcheck" = "BG Check";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/sv.lproj/Treatments.strings
+++ b/xdrip/Storyboards/sv.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "Blodsockerkontroll";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Storyboards/zh.lproj/Treatments.strings
+++ b/xdrip/Storyboards/zh.lproj/Treatments.strings
@@ -14,6 +14,7 @@
 "treatments_carbs" = "Carbs";
 "treatments_insulin" = "Insulin";
 "treatments_exercise" = "Exercise";
+"treatments_bgcheck" = "BG Check";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";

--- a/xdrip/Texts/TextsCommon.swift
+++ b/xdrip/Texts/TextsCommon.swift
@@ -21,7 +21,7 @@ class Texts_Common {
         return NSLocalizedString("common_mmol", tableName: filename, bundle: Bundle.main, value: "mmol/l", comment: "mmol/l")
     }()
 
-    static let bloodGLucoseUnit: String = {
+    static let bloodGlucoseUnit: String = {
         return NSLocalizedString("common_bloodglucoseunit", tableName: filename, bundle: Bundle.main, value: "Blood Glucose Unit", comment: "can be used in several screens, just the words Bloodglucose unit")
     }()
     

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -123,7 +123,7 @@ class Texts_SettingsView {
     }()
     
     static let settingsviews_smallBolusTreatmentThreshold = {
-        return NSLocalizedString("settingsviews_smallBolusTreatmentThreshold", tableName: filename, bundle: Bundle.main, value: "Micro-Bolus Threshold:", comment: "When clicking the threshold setting, a pop up asks for the number of units under which a bolus should be considered a micro-bolus")
+        return NSLocalizedString("settingsviews_smallBolusTreatmentThreshold", tableName: filename, bundle: Bundle.main, value: "Micro-bolus Threshold:", comment: "When clicking the threshold setting, a pop up asks for the number of units under which a bolus should be considered a micro-bolus")
     }()
     
     static let settingsviews_smallBolusTreatmentThresholdMessage = {
@@ -131,11 +131,11 @@ class Texts_SettingsView {
     }()
     
     static let settingsviews_showSmallBolusTreatmentsOnChart: String = {
-        return NSLocalizedString("settingsviews_showSmallBolusTreatmentsOnChart", tableName: filename, bundle: Bundle.main, value: "Show Micro-Bolus on Chart?", comment: "treatments settings, show the micro-bolus on main chart")
+        return NSLocalizedString("settingsviews_showSmallBolusTreatmentsOnChart", tableName: filename, bundle: Bundle.main, value: "Show Micro-bolus on Chart?", comment: "treatments settings, show the micro-bolus on main chart")
     }()
     
     static let settingsviews_showSmallBolusTreatmentsInList: String = {
-        return NSLocalizedString("settingsviews_showSmallBolusTreatmentsInList", tableName: filename, bundle: Bundle.main, value: "Show Micro-Bolus in List?", comment: "treatments settings, show the micro-bolus in the treatment list")
+        return NSLocalizedString("settingsviews_showSmallBolusTreatmentsInList", tableName: filename, bundle: Bundle.main, value: "Show Micro-bolus in List?", comment: "treatments settings, show the micro-bolus in the treatment list")
     }()
     
     // MARK: - Section Statistics

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -130,6 +130,14 @@ class Texts_SettingsView {
         return NSLocalizedString("settingsviews_smallBolusTreatmentThresholdMessage", tableName: filename, bundle: Bundle.main, value: "Below how many units should we consider a bolus as a micro-bolus?\n\n(Recommended value: 1.0U)", comment: "When clicking the threshold setting, a pop up asks for the number of units under which a bolus should be considered a micro-bolus")
     }()
     
+    static let settingsviews_showSmallBolusTreatmentsOnChart: String = {
+        return NSLocalizedString("settingsviews_showSmallBolusTreatmentsOnChart", tableName: filename, bundle: Bundle.main, value: "Show Micro-Bolus on Chart?", comment: "treatments settings, show the micro-bolus on main chart")
+    }()
+    
+    static let settingsviews_showSmallBolusTreatmentsInList: String = {
+        return NSLocalizedString("settingsviews_showSmallBolusTreatmentsInList", tableName: filename, bundle: Bundle.main, value: "Show Micro-Bolus in List?", comment: "treatments settings, show the micro-bolus in the treatment list")
+    }()
+    
     // MARK: - Section Statistics
     
     static let sectionTitleStatistics: String = {

--- a/xdrip/Texts/TextsTreatmentsView.swift
+++ b/xdrip/Texts/TextsTreatmentsView.swift
@@ -51,6 +51,10 @@ enum Texts_TreatmentsView {
 	static let exercise:String = {
 		return NSLocalizedString("treatments_exercise", tableName: filename, bundle: Bundle.main, value: "Exercise", comment: "Exercise.")
 	}()
+    
+    static let bgCheck:String = {
+        return NSLocalizedString("treatments_bgcheck", tableName: filename, bundle: Bundle.main, value: "BG Check", comment: "Blood Glucose Check")
+    }()
 
 	static let questionMark:String = {
 		return NSLocalizedString("treatments_question_mark", tableName: filename, bundle: Bundle.main, value: "?", comment: "Literally a question mark, used as unknown abbreviation.")

--- a/xdrip/Texts/TextsTreatmentsView.swift
+++ b/xdrip/Texts/TextsTreatmentsView.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// all texts related to treatmentss (2 views)
+/// all texts related to treatments (2 views)
 enum Texts_TreatmentsView {
 	static private let filename = "Treatments"
 
@@ -15,29 +15,17 @@ enum Texts_TreatmentsView {
 	static let newEntryTitle:String = {
 		return NSLocalizedString("treatments_new_entry", tableName: filename, bundle: Bundle.main, value: "New Treatment", comment: "New entry view title.")
 	}()
-	
-	static let carbsWithUnit:String = {
-		return NSLocalizedString("treatments_carbs_with_unit", tableName: filename, bundle: Bundle.main, value: "Carbs (g):", comment: "Carbs with unit.")
-	}()
-	
-	static let insulinWithUnit:String = {
-		return NSLocalizedString("treatments_insulin_with_unit", tableName: filename, bundle: Bundle.main, value: "Insulin (U):", comment: "Insulin with unit.")
-	}()
-	
-	static let exerciseWithUnit:String = {
-		return NSLocalizedString("treatments_exercise_with_unit", tableName: filename, bundle: Bundle.main, value: "Exercise (min):", comment: "Exercise with unit.")
-	}()
 
 	static let carbsUnit:String = {
 		return NSLocalizedString("treatments_carbs_unit", tableName: filename, bundle: Bundle.main, value: "g", comment: "Carbs unit.")
 	}()
 	
 	static let insulinUnit:String = {
-		return NSLocalizedString("treatments_insulin_unit", tableName: filename, bundle: Bundle.main, value: "U:", comment: "Insulin unit.")
+		return NSLocalizedString("treatments_insulin_unit", tableName: filename, bundle: Bundle.main, value: "U", comment: "Insulin unit.")
 	}()
 	
 	static let exerciseUnit:String = {
-		return NSLocalizedString("treatments_exercise_unit", tableName: filename, bundle: Bundle.main, value: "min", comment: "Exercise unit.")
+		return NSLocalizedString("treatments_exercise_unit", tableName: filename, bundle: Bundle.main, value: "mins", comment: "Exercise unit.")
 	}()
 
 	static let carbs:String = {

--- a/xdrip/Treatments/TreatmentNSResponse.swift
+++ b/xdrip/Treatments/TreatmentNSResponse.swift
@@ -26,12 +26,6 @@ public struct TreatmentNSResponse {
     
     /// - eventType received from NightScout (for downloaded treatments) or uploaded to NightScout (for treatments created in xdrip4ios)
     public let nightscoutEventType: String?
-    
-    /// - eventType received from NightScout (for downloaded treatments) or uploaded to NightScout (for treatments created in xdrip4ios)
-//    public let nightscoutGlucoseType: String?
-    
-    /// - eventType received from NightScout (for downloaded treatments) or uploaded to NightScout (for treatments created in xdrip4ios)
-//    public let nightscoutUnits: String?
 	
     public let value: Double
     

--- a/xdrip/Treatments/TreatmentNSResponse.swift
+++ b/xdrip/Treatments/TreatmentNSResponse.swift
@@ -26,13 +26,19 @@ public struct TreatmentNSResponse {
     
     /// - eventType received from NightScout (for downloaded treatments) or uploaded to NightScout (for treatments created in xdrip4ios)
     public let nightscoutEventType: String?
+    
+    /// - eventType received from NightScout (for downloaded treatments) or uploaded to NightScout (for treatments created in xdrip4ios)
+//    public let nightscoutGlucoseType: String?
+    
+    /// - eventType received from NightScout (for downloaded treatments) or uploaded to NightScout (for treatments created in xdrip4ios)
+//    public let nightscoutUnits: String?
 	
     public let value: Double
     
 	/// Takes a NSDictionary from nightscout response and returns an array TreatmentNSResponse. Can be more than one, eg NightScout treatment of type 'Snack Bolus' could contain an insulin value and a carbs value
     ///
     /// id will be the id retrieved from nightscout + "-insulin", "-carbs", "-exercise", according to treatment type
-    public static func fromNighscout(dictionary: NSDictionary) -> [TreatmentNSResponse] {
+    public static func fromNightscout(dictionary: NSDictionary) -> [TreatmentNSResponse] {
         
         var treatmentNSResponses: [TreatmentNSResponse] = []
         
@@ -92,6 +98,12 @@ public struct TreatmentNSResponse {
                 
             }
             
+            if let glucose = dictionary["glucose"] as? Double, let units = dictionary["units"] as? String {
+                
+                treatmentNSResponses.append(TreatmentNSResponse(id: id + TreatmentType.BgCheck.idExtension(), createdAt: date, eventType: .BgCheck, nightscoutEventType: nightScoutEventType, value: units == "mg/dl" ? glucose : glucose.mmolToMgdl()))
+                
+            }
+            
 		}
         
 		return treatmentNSResponses
@@ -106,7 +118,7 @@ public struct TreatmentNSResponse {
 		for element in array {
 			if let dictionary = element as? NSDictionary {
                 
-                responses = responses + TreatmentNSResponse.fromNighscout(dictionary: dictionary)
+                responses = responses + TreatmentNSResponse.fromNightscout(dictionary: dictionary)
                 
 			}
 		}

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewTreatmentsSettingsViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewTreatmentsSettingsViewModel.swift
@@ -18,6 +18,12 @@ fileprivate enum Setting:Int, CaseIterable {
     //should we use the user values for High + Low, or use the standard range?
     case smallBolusTreatmentThreshold = 1
     
+    //should we show the micro-boluses on the main chart?
+    case showSmallBolusTreatmentsOnChart = 2
+    
+    //should we show the micro-boluses in the treatment list/table?
+    case showSmallBolusTreatmentsInList = 3
+    
     
 }
 
@@ -35,6 +41,12 @@ struct SettingsViewTreatmentsSettingsViewModel:SettingsViewModelProtocol {
             
         case .smallBolusTreatmentThreshold:
             return nil
+            
+        case .showSmallBolusTreatmentsOnChart:
+            return UISwitch(isOn: UserDefaults.standard.showSmallBolusTreatmentsOnChart, action: {(isOn:Bool) in UserDefaults.standard.showSmallBolusTreatmentsOnChart = isOn})
+            
+        case .showSmallBolusTreatmentsInList:
+            return UISwitch(isOn: UserDefaults.standard.showSmallBolusTreatmentsInList, action: {(isOn:Bool) in UserDefaults.standard.showSmallBolusTreatmentsInList = isOn})
             
         }
     }
@@ -73,6 +85,24 @@ struct SettingsViewTreatmentsSettingsViewModel:SettingsViewModelProtocol {
         case .smallBolusTreatmentThreshold:
             return SettingsSelectedRowAction.askText(title: Texts_SettingsView.settingsviews_smallBolusTreatmentThreshold, message: Texts_SettingsView.settingsviews_smallBolusTreatmentThresholdMessage, keyboardType: .decimalPad, text: UserDefaults.standard.smallBolusTreatmentThreshold.description, placeHolder: "0.0", actionTitle: nil, cancelTitle: nil, actionHandler: {(threshold:String) in if let threshold = Double(threshold) {UserDefaults.standard.smallBolusTreatmentThreshold = Double(threshold)}}, cancelHandler: nil, inputValidator: nil)
             
+        case .showSmallBolusTreatmentsOnChart:
+            return SettingsSelectedRowAction.callFunction(function: {
+                if UserDefaults.standard.showSmallBolusTreatmentsOnChart {
+                    UserDefaults.standard.showSmallBolusTreatmentsOnChart = false
+                } else {
+                    UserDefaults.standard.showSmallBolusTreatmentsOnChart = true
+                }
+            })
+            
+        case .showSmallBolusTreatmentsInList:
+            return SettingsSelectedRowAction.callFunction(function: {
+                if UserDefaults.standard.showSmallBolusTreatmentsInList {
+                    UserDefaults.standard.showSmallBolusTreatmentsInList = false
+                } else {
+                    UserDefaults.standard.showSmallBolusTreatmentsInList = true
+                }
+            })
+            
         }
     }
     
@@ -95,6 +125,12 @@ struct SettingsViewTreatmentsSettingsViewModel:SettingsViewModelProtocol {
         case .smallBolusTreatmentThreshold:
             return Texts_SettingsView.settingsviews_smallBolusTreatmentThreshold
             
+        case .showSmallBolusTreatmentsOnChart:
+            return Texts_SettingsView.settingsviews_showSmallBolusTreatmentsOnChart
+            
+        case .showSmallBolusTreatmentsInList:
+            return Texts_SettingsView.settingsviews_showSmallBolusTreatmentsInList
+            
         }
     }
     
@@ -103,7 +139,7 @@ struct SettingsViewTreatmentsSettingsViewModel:SettingsViewModelProtocol {
         
         switch setting {
             
-        case .showTreatmentsOnChart:
+        case .showTreatmentsOnChart, .showSmallBolusTreatmentsOnChart, .showSmallBolusTreatmentsInList:
             return UITableViewCell.AccessoryType.none
             
         case .smallBolusTreatmentThreshold:
@@ -117,7 +153,7 @@ struct SettingsViewTreatmentsSettingsViewModel:SettingsViewModelProtocol {
         
         switch setting {
             
-        case .showTreatmentsOnChart:
+        case .showTreatmentsOnChart, .showSmallBolusTreatmentsOnChart, .showSmallBolusTreatmentsInList:
             return nil
             
         case .smallBolusTreatmentThreshold:

--- a/xdrip/View Controllers/Treatments/TreatmentTableViewCell.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentTableViewCell.swift
@@ -12,10 +12,15 @@ class TreatmentTableViewCell: UITableViewCell {
 	@IBOutlet weak var typeLabel: UILabel!
 	@IBOutlet weak var valueLabel: UILabel!
 	@IBOutlet weak var dateLabel: UILabel!
-	
+    @IBOutlet weak var unitLabel: UILabel!
+    @IBOutlet weak var iconImageView: UIImageView!
+    
 	public func setupWithTreatment(_ treatment: TreatmentEntry) {
 		self.typeLabel.text = treatment.treatmentType.asString()
 		self.valueLabel.text = treatment.displayValue()
+        self.unitLabel.text = treatment.displayUnit()
+        self.iconImageView.tintColor = treatment.treatmentType.iconColor()
+        self.iconImageView.image = treatment.treatmentType.iconImage()
 		
 		let formatter = DateFormatter()
 		formatter.dateFormat = "HH:mm"

--- a/xdrip/View Controllers/Treatments/TreatmentTableViewCell.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentTableViewCell.swift
@@ -10,21 +10,93 @@ import Foundation
 
 class TreatmentTableViewCell: UITableViewCell {
 	@IBOutlet weak var typeLabel: UILabel!
-	@IBOutlet weak var valueLabel: UILabel!
-	@IBOutlet weak var dateLabel: UILabel!
+    @IBOutlet weak var valueLabel: UILabel!
+    @IBOutlet weak var dateLabel: UILabel!
     @IBOutlet weak var unitLabel: UILabel!
     @IBOutlet weak var iconImageView: UIImageView!
     
-	public func setupWithTreatment(_ treatment: TreatmentEntry) {
-		self.typeLabel.text = treatment.treatmentType.asString()
-		self.valueLabel.text = treatment.displayValue()
-        self.unitLabel.text = treatment.displayUnit()
-        self.iconImageView.tintColor = treatment.treatmentType.iconColor()
-        self.iconImageView.image = treatment.treatmentType.iconImage()
-		
-		let formatter = DateFormatter()
-		formatter.dateFormat = "HH:mm"
-
-		self.dateLabel.text = formatter.string(from: treatment.date)
-	}
+    public func setupWithTreatment(_ treatment: TreatmentEntry) {
+        
+        // date label
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        
+        self.dateLabel.text = formatter.string(from: treatment.date)
+        
+        
+        // treatment type icon
+        switch treatment.treatmentType {
+            
+        case .Insulin:
+            self.iconImageView.tintColor =  ConstantsGlucoseChart.bolusTreatmentColor
+            
+        case .Carbs:
+            self.iconImageView.tintColor =  ConstantsGlucoseChart.carbsTreatmentColor
+            
+        case .Exercise:
+            self.iconImageView.tintColor =  UIColor.magenta
+            
+        case .BgCheck:
+            self.iconImageView.tintColor =  ConstantsGlucoseChart.bgCheckTreatmentColorInner
+            
+        }
+        
+        if #available(iOS 13.0, *) {
+            
+            switch treatment.treatmentType {
+                
+            case .Insulin:
+                self.iconImageView.image =  UIImage(systemName: "arrowtriangle.down.fill")!
+                
+            case .Carbs:
+                self.iconImageView.image =  UIImage(systemName: "circle.fill")!
+                
+            case .Exercise:
+                self.iconImageView.image =  UIImage(systemName: "heart.fill")!
+                
+            case .BgCheck:
+                self.iconImageView.image =  UIImage(systemName: "drop.fill")!
+                
+            }
+            
+        } else {
+            
+            self.iconImageView.image =  nil
+            
+        }
+        
+        
+        // treatment type label
+        self.typeLabel.text = treatment.treatmentType.asString()
+        
+        // treatment value label
+        if treatment.treatmentType == .BgCheck {
+            
+            // save typing
+            let isMgDl: Bool = UserDefaults.standard.bloodGlucoseUnitIsMgDl
+            
+            // convert to mmol/l if needed, round accordingly and add the correct units
+            self.valueLabel.text = treatment.value.mgdlToMmol(mgdl: isMgDl).bgValueRounded(mgdl: isMgDl).stringWithoutTrailingZeroes
+            
+        } else {
+            
+            self.valueLabel.text = treatment.value.stringWithoutTrailingZeroes
+            
+        }
+        
+        
+        // treatment unit label
+        if treatment.treatmentType == .BgCheck {
+            
+            // convert to mmol/l if needed, round accordingly and add the correct units
+            self.unitLabel.text =  String(UserDefaults.standard.bloodGlucoseUnitIsMgDl ? Texts_Common.mgdl : Texts_Common.mmol)
+            
+        } else {
+            
+            self.unitLabel.text = treatment.treatmentType.unit()
+            
+        }
+        
+    }
+    
 }

--- a/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
@@ -12,18 +12,26 @@ import Foundation
 class TreatmentsInsertViewController : UIViewController {
 	
 	@IBOutlet weak var titleNavigation: UINavigationItem!
+    
 	@IBOutlet weak var carbsLabel: UILabel!
 	@IBOutlet weak var insulinLabel: UILabel!
 	@IBOutlet weak var exerciseLabel: UILabel!
+    @IBOutlet weak var bgCheckLabel: UILabel!
+    
 	@IBOutlet weak var doneButton: UIBarButtonItem!
+    
 	@IBOutlet weak var datePicker: UIDatePicker!
+    
 	@IBOutlet weak var carbsTextField: UITextField!
 	@IBOutlet weak var insulinTextField: UITextField!
 	@IBOutlet weak var exerciseTextField: UITextField!
+    @IBOutlet weak var bgCheckTextField: UITextField!
+    
     @IBOutlet weak var carbsStackView: UIStackView!
     @IBOutlet weak var insulinStackView: UIStackView!
     @IBOutlet weak var exerciseStackView: UIStackView!
-    
+    @IBOutlet weak var bgCheckStackView: UIStackView!
+
     // MARK: - private properties
     
 	/// reference to coreDataManager
@@ -67,15 +75,20 @@ class TreatmentsInsertViewController : UIViewController {
 		// Title
 		self.titleNavigation.title = Texts_TreatmentsView.newEntryTitle
         
+        // update the BG Check placeholder text depending on BG unit being used
+        self.bgCheckTextField.placeholder = Double(0).mgdlToMmolAndToString(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl)
+        
 		// Labels for each TextField
 		self.carbsLabel.text = Texts_TreatmentsView.carbsWithUnit
 		self.insulinLabel.text = Texts_TreatmentsView.insulinWithUnit
 		self.exerciseLabel.text = Texts_TreatmentsView.exerciseWithUnit
+        self.bgCheckLabel.text = Texts_TreatmentsView.bgCheck + " (" + String(UserDefaults.standard.bloodGlucoseUnitIsMgDl ? Texts_Common.mgdl : Texts_Common.mmol) + ")"
 		
 		// Done button
 		self.addDoneButtonOnNumpad(textField: self.carbsTextField)
 		self.addDoneButtonOnNumpad(textField: self.insulinTextField)
 		self.addDoneButtonOnNumpad(textField: self.exerciseTextField)
+        self.addDoneButtonOnNumpad(textField: self.bgCheckTextField)
         
 		self.setDismissKeyboard()
 
@@ -94,6 +107,9 @@ class TreatmentsInsertViewController : UIViewController {
                 exerciseTextField.isHidden = true
                 exerciseLabel.isHidden = true
                 exerciseStackView.isHidden = true
+                bgCheckTextField.isHidden = true
+                bgCheckLabel.isHidden = true
+                bgCheckStackView.isHidden = true
 
             case .Exercise:
                 // set text to value of treatMentEntryToUpdate
@@ -106,12 +122,34 @@ class TreatmentsInsertViewController : UIViewController {
                 insulinTextField.isHidden = true
                 insulinLabel.isHidden = true
                 insulinStackView.isHidden = true
+                bgCheckTextField.isHidden = true
+                bgCheckLabel.isHidden = true
+                bgCheckStackView.isHidden = true
 
             case .Insulin:
                 // set text to value of treatMentEntryToUpdate
                 insulinTextField.text = treatMentEntryToUpdate.value.stringWithoutTrailingZeroes
                 
                 // hide the other fields
+                carbsTextField.isHidden = true
+                carbsLabel.isHidden = true
+                carbsStackView.isHidden = true
+                exerciseTextField.isHidden = true
+                exerciseLabel.isHidden = true
+                exerciseStackView.isHidden = true
+                bgCheckTextField.isHidden = true
+                bgCheckLabel.isHidden = true
+                bgCheckStackView.isHidden = true
+                
+            case .BgCheck:
+                // set text to value of treatMentEntryToUpdate
+                // as the BG Check values are always stored in coredata as mg/dl, the number must be converted and rounded as needed
+                bgCheckTextField.text = treatMentEntryToUpdate.value.mgdlToMmol(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl).bgValueRounded(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl).stringWithoutTrailingZeroes
+                
+                // hide the other fields
+                insulinTextField.isHidden = true
+                insulinLabel.isHidden = true
+                insulinStackView.isHidden = true
                 carbsTextField.isHidden = true
                 carbsLabel.isHidden = true
                 carbsStackView.isHidden = true
@@ -209,6 +247,9 @@ class TreatmentsInsertViewController : UIViewController {
             case .Exercise:
                 updateFunction(exerciseTextField)
                 
+            case .BgCheck:
+                updateFunction(bgCheckTextField)
+                
             }
             
         } else {
@@ -248,6 +289,7 @@ class TreatmentsInsertViewController : UIViewController {
             createFunction(carbsTextField.text, .Carbs)
             createFunction(insulinTextField.text, .Insulin)
             createFunction(exerciseTextField.text, .Exercise)
+            createFunction(bgCheckTextField.text, .BgCheck)
 
         }
         

--- a/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
@@ -27,6 +27,11 @@ class TreatmentsInsertViewController : UIViewController {
 	@IBOutlet weak var exerciseTextField: UITextField!
     @IBOutlet weak var bgCheckTextField: UITextField!
     
+    @IBOutlet weak var carbsUnitLabel: UILabel!
+    @IBOutlet weak var insulinUnitLabel: UILabel!
+    @IBOutlet weak var exerciseUnitLabel: UILabel!
+    @IBOutlet weak var bgCheckUnitLabel: UILabel!
+    
     @IBOutlet weak var carbsStackView: UIStackView!
     @IBOutlet weak var insulinStackView: UIStackView!
     @IBOutlet weak var exerciseStackView: UIStackView!
@@ -79,11 +84,17 @@ class TreatmentsInsertViewController : UIViewController {
         self.bgCheckTextField.placeholder = Double(0).mgdlToMmolAndToString(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl)
         
 		// Labels for each TextField
-		self.carbsLabel.text = Texts_TreatmentsView.carbsWithUnit
-		self.insulinLabel.text = Texts_TreatmentsView.insulinWithUnit
-		self.exerciseLabel.text = Texts_TreatmentsView.exerciseWithUnit
-        self.bgCheckLabel.text = Texts_TreatmentsView.bgCheck + " (" + String(UserDefaults.standard.bloodGlucoseUnitIsMgDl ? Texts_Common.mgdl : Texts_Common.mmol) + ")"
+		self.carbsLabel.text = Texts_TreatmentsView.carbs
+		self.insulinLabel.text = Texts_TreatmentsView.insulin
+		self.exerciseLabel.text = Texts_TreatmentsView.exercise
+        self.bgCheckLabel.text = Texts_TreatmentsView.bgCheck
 		
+        // Unit labels for each TextField
+        self.carbsUnitLabel.text = Texts_TreatmentsView.carbsUnit
+        self.insulinUnitLabel.text = Texts_TreatmentsView.insulinUnit
+        self.exerciseUnitLabel.text = Texts_TreatmentsView.exerciseUnit
+        self.bgCheckUnitLabel.text = String(UserDefaults.standard.bloodGlucoseUnitIsMgDl ? Texts_Common.mgdl : Texts_Common.mmol)
+        
 		// Done button
 		self.addDoneButtonOnNumpad(textField: self.carbsTextField)
 		self.addDoneButtonOnNumpad(textField: self.insulinTextField)
@@ -100,45 +111,27 @@ class TreatmentsInsertViewController : UIViewController {
                 // set text to value of treatMentEntryToUpdate
                 carbsTextField.text = treatMentEntryToUpdate.value.stringWithoutTrailingZeroes
                 
-                // hide the other fields
-                insulinTextField.isHidden = true
-                insulinLabel.isHidden = true
+                // hide the other stack views
                 insulinStackView.isHidden = true
-                exerciseTextField.isHidden = true
-                exerciseLabel.isHidden = true
                 exerciseStackView.isHidden = true
-                bgCheckTextField.isHidden = true
-                bgCheckLabel.isHidden = true
                 bgCheckStackView.isHidden = true
 
             case .Exercise:
                 // set text to value of treatMentEntryToUpdate
                 exerciseTextField.text = treatMentEntryToUpdate.value.stringWithoutTrailingZeroes
                 
-                // hide the other fields
-                carbsTextField.isHidden = true
-                carbsLabel.isHidden = true
+                // hide the other stack views
                 carbsStackView.isHidden = true
-                insulinTextField.isHidden = true
-                insulinLabel.isHidden = true
                 insulinStackView.isHidden = true
-                bgCheckTextField.isHidden = true
-                bgCheckLabel.isHidden = true
                 bgCheckStackView.isHidden = true
 
             case .Insulin:
                 // set text to value of treatMentEntryToUpdate
                 insulinTextField.text = treatMentEntryToUpdate.value.stringWithoutTrailingZeroes
                 
-                // hide the other fields
-                carbsTextField.isHidden = true
-                carbsLabel.isHidden = true
+                // hide the other stack views
                 carbsStackView.isHidden = true
-                exerciseTextField.isHidden = true
-                exerciseLabel.isHidden = true
                 exerciseStackView.isHidden = true
-                bgCheckTextField.isHidden = true
-                bgCheckLabel.isHidden = true
                 bgCheckStackView.isHidden = true
                 
             case .BgCheck:
@@ -146,15 +139,9 @@ class TreatmentsInsertViewController : UIViewController {
                 // as the BG Check values are always stored in coredata as mg/dl, the number must be converted and rounded as needed
                 bgCheckTextField.text = treatMentEntryToUpdate.value.mgdlToMmol(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl).bgValueRounded(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl).stringWithoutTrailingZeroes
                 
-                // hide the other fields
-                insulinTextField.isHidden = true
-                insulinLabel.isHidden = true
+                // hide the other stack views
                 insulinStackView.isHidden = true
-                carbsTextField.isHidden = true
-                carbsLabel.isHidden = true
                 carbsStackView.isHidden = true
-                exerciseTextField.isHidden = true
-                exerciseLabel.isHidden = true
                 exerciseStackView.isHidden = true
 
             }

--- a/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
@@ -170,14 +170,22 @@ class TreatmentsInsertViewController : UIViewController {
                     var treatMentEntryToUpdateChanged = false
                     
                     if treatMentEntryToUpdate.value != value {
+        
+                        if treatMentEntryToUpdate.treatmentType == .BgCheck {
+            
+                            treatMentEntryToUpdate.value = value.mmolToMgdl(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl).bgValueRounded(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl)
+                            
+                        } else {
+                            
+                            treatMentEntryToUpdate.value = value
+                            
+                        }
                         
-                        treatMentEntryToUpdate.value = value
-
                         // sets text in textField to "0" to avoid that new treatmentEntry is created
                         textField.text = "0"
-
+                        
                         treatMentEntryToUpdateChanged = true
-                                                
+                        
                     }
                     
                     if treatMentEntryToUpdate.date != self.datePicker.date {
@@ -254,8 +262,14 @@ class TreatmentsInsertViewController : UIViewController {
             // if yes, creates a new TreatmentEntry
             let createFunction = { [self] (text: String?, treatmentType: TreatmentType) in
                 
-                if let text = text, let value = Double(text.replacingOccurrences(of: ",", with: ".")), value > 0 {
-
+                if let text = text, var value = Double(text.replacingOccurrences(of: ",", with: ".")), value > 0 {
+        
+                        if treatmentType == .BgCheck {
+            
+                            value = value.mmolToMgdl(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl).bgValueRounded(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl)
+                            
+                        }
+                    
                     // create the treatment and append to treatments
                     _ = TreatmentEntry(date: Date(timeInterval: dateOffset, since: datePicker.date), value: value, treatmentType: treatmentType, nightscoutEventType: nil, nsManagedObjectContext: self.coreDataManager.mainManagedObjectContext)
                     

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -49,6 +49,9 @@ class TreatmentsViewController : UIViewController {
         // add observer for bloodGlucoseUnitIsMgDl, to reload the screen whenever the bg unit changes
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.bloodGlucoseUnitIsMgDl.rawValue, options: .new, context: nil)
         
+        // add observer for showSmallBolusTreatmentsInList, to reload the screen whenever the user wants to show or hide the micro-bolus treatments
+        UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.showSmallBolusTreatmentsInList.rawValue, options: .new, context: nil)
+        
 	}
 	
 
@@ -94,7 +97,15 @@ class TreatmentsViewController : UIViewController {
 	/// Reloads treatmentCollection and calls reloadData on tableView.
 	private func reload() {
         
-        self.treatmentCollection = TreatmentCollection(treatments: treatmentEntryAccessor.getLatestTreatments(howOld: TimeInterval(days: 100)).filter( {!$0.treatmentdeleted} ))
+        if UserDefaults.standard.showSmallBolusTreatmentsInList {
+            
+            self.treatmentCollection = TreatmentCollection(treatments: treatmentEntryAccessor.getLatestTreatments(howOld: TimeInterval(days: 100)).filter( {!$0.treatmentdeleted} ))
+            
+        } else {
+            
+            self.treatmentCollection = TreatmentCollection(treatments: treatmentEntryAccessor.getLatestTreatments(howOld: TimeInterval(days: 100)).filter( {!$0.treatmentdeleted && (($0.treatmentType != .Insulin) || ($0.treatmentType == .Insulin && $0.value >= UserDefaults.standard.smallBolusTreatmentThreshold))} ))
+            
+        }
 
 		self.tableView.reloadData()
         
@@ -110,7 +121,7 @@ class TreatmentsViewController : UIViewController {
                 
                 switch keyPathEnum {
                     
-                case UserDefaults.Key.nightScoutTreatmentsUpdateCounter, UserDefaults.Key.bloodGlucoseUnitIsMgDl :
+                case UserDefaults.Key.nightScoutTreatmentsUpdateCounter, UserDefaults.Key.bloodGlucoseUnitIsMgDl, UserDefaults.Key.showSmallBolusTreatmentsInList :
                     // Reloads data and table.
                     self.reload()
                     

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -46,7 +46,8 @@ class TreatmentsViewController : UIViewController {
         // add observer for nightScoutTreatmentsUpdateCounter, to reload the screen whenever the value changes
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.nightScoutTreatmentsUpdateCounter.rawValue, options: .new, context: nil)
         
-
+        // add observer for bloodGlucoseUnitIsMgDl, to reload the screen whenever the bg unit changes
+        UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.bloodGlucoseUnitIsMgDl.rawValue, options: .new, context: nil)
         
 	}
 	
@@ -109,7 +110,7 @@ class TreatmentsViewController : UIViewController {
                 
                 switch keyPathEnum {
                     
-                case UserDefaults.Key.nightScoutTreatmentsUpdateCounter :
+                case UserDefaults.Key.nightScoutTreatmentsUpdateCounter, UserDefaults.Key.bloodGlucoseUnitIsMgDl :
                     // Reloads data and table.
                     self.reload()
                     

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -221,12 +221,12 @@ extension TreatmentsViewController: UITableViewDelegate, UITableViewDataSource {
 		// Set textcolor to white and increase font
 		if let textLabel = titleView.textLabel {
 			textLabel.textColor = UIColor.white
-			textLabel.font = textLabel.font.withSize(18)
+			textLabel.font = textLabel.font.withSize(16)
 		}
 	}
 
 	func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-		return 40.0
+		return 32.0
 	}
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -52,6 +52,9 @@ class TreatmentsViewController : UIViewController {
         // add observer for showSmallBolusTreatmentsInList, to reload the screen whenever the user wants to show or hide the micro-bolus treatments
         UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.showSmallBolusTreatmentsInList.rawValue, options: .new, context: nil)
         
+        // add observer for smallBolusTreatmentThreshold, to reload the screen whenever the user changes the threshold value (this can mean we need to show more, or less, bolus treatments)
+        UserDefaults.standard.addObserver(self, forKeyPath: UserDefaults.Key.smallBolusTreatmentThreshold.rawValue, options: .new, context: nil)
+        
 	}
 	
 
@@ -121,7 +124,7 @@ class TreatmentsViewController : UIViewController {
                 
                 switch keyPathEnum {
                     
-                case UserDefaults.Key.nightScoutTreatmentsUpdateCounter, UserDefaults.Key.bloodGlucoseUnitIsMgDl, UserDefaults.Key.showSmallBolusTreatmentsInList :
+                case UserDefaults.Key.nightScoutTreatmentsUpdateCounter, UserDefaults.Key.bloodGlucoseUnitIsMgDl, UserDefaults.Key.showSmallBolusTreatmentsInList, UserDefaults.Key.smallBolusTreatmentThreshold :
                     // Reloads data and table.
                     self.reload()
                     


### PR DESCRIPTION
- BG Checks (finger prick) can be entered as a treatment
- will be converted and stored in coredata as mg/dl (to avoid having to add units to the treatment coredata model)
- will be converted and shown locally in the correct unit
- will be synced with Nightscout in the original unit
- Nightscout uploads will add the "GlucoseType"="Finger" and "units" attributes to align with BG checks entered via Care Portal.
- BG checks displayed on the main chart as a red circle with gray border as per Nightscout style
- observer added to refresh treatment table (values/units) if the bg unit is changed by the user
- treatment table layout improvements
- treatment edit/insert layout improvements
- units are now separated from values and greyed out
- treatment icon implemented (is returned based upon .treatmentType)
- new option to hide the micro-boluses from the main chart
- new option to hide the micro-boluses in the treatments list/table