### PR TITLE
fix speech "trending flat" bug

### DIFF
--- a/xdrip/Texts/TextsSpeakReading.swift
+++ b/xdrip/Texts/TextsSpeakReading.swift
@@ -138,7 +138,7 @@ public static func setLanguageCode(code:String?) {
     
     static var trendfortyfiveup:String {
         get {
-            return NSLocalizedString("trendflat", tableName: filename, bundle: bundle!, value: "up", comment: "For speak reading functionality")
+            return NSLocalizedString("trendfortyfiveup", tableName: filename, bundle: bundle!, value: "up", comment: "For speak reading functionality")
         }
     }
     


### PR DESCRIPTION
Report in the Facebook group. Speak BG Readings function is announcing "....trending flat" for 45 degree up rises.

It was just a bad copy/paste in the text files that's been there since the beginning of the project.

![image](https://user-images.githubusercontent.com/37302780/174823174-f1cbff33-409e-480a-a59e-647335837b9b.jpeg)
