### PR TITLE
implement treatment filtering in list

### DIFF
--- a/xdrip/Extensions/UserDefaults.swift
+++ b/xdrip/Extensions/UserDefaults.swift
@@ -81,6 +81,15 @@ extension UserDefaults {
         /// should the micro-boluses be listed in the treatment list/table?
         case showSmallBolusTreatmentsInList = "showSmallBolusTreatmentsInList"
         
+        /// should the normal boluses be listed in the treatment list/table?
+        case showBolusTreatmentsInList = "showBolusTreatmentsInList"
+        
+        /// should the carbs be listed in the treatment list/table?
+        case showCarbsTreatmentsInList = "showCarbsTreatmentsInList"
+        
+        /// should the BG Checks be listed in the treatment list/table?
+        case showBgCheckTreatmentsInList = "showBgCheckTreatmentsInList"
+        
         // Statistics settings
         
         /// show the statistics? How many days should we use for the calculations?
@@ -855,6 +864,39 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: Key.showSmallBolusTreatmentsInList.rawValue)
+        }
+    }
+    
+    /// should the app show the normal bolus treatments in the treatments list/table?
+    @objc dynamic var showBolusTreatmentsInList: Bool {
+        // default value for bool in userdefaults is false, by default we want the app to *show* the normal bolus treatments in the treatments table
+        get {
+            return !bool(forKey: Key.showBolusTreatmentsInList.rawValue)
+        }
+        set {
+            set(!newValue, forKey: Key.showBolusTreatmentsInList.rawValue)
+        }
+    }
+    
+    /// should the app show the normal bolus treatments in the treatments list/table?
+    @objc dynamic var showCarbsTreatmentsInList: Bool {
+        // default value for bool in userdefaults is false, by default we want the app to *show* the normal bolus treatments in the treatments table
+        get {
+            return !bool(forKey: Key.showCarbsTreatmentsInList.rawValue)
+        }
+        set {
+            set(!newValue, forKey: Key.showCarbsTreatmentsInList.rawValue)
+        }
+    }
+    
+    /// should the app show the BG Check treatments in the treatments list/table?
+    @objc dynamic var showBgCheckTreatmentsInList: Bool {
+        // default value for bool in userdefaults is false, by default we want the app to *show* the BG Check treatments in the treatments table
+        get {
+            return !bool(forKey: Key.showBgCheckTreatmentsInList.rawValue)
+        }
+        set {
+            set(!newValue, forKey: Key.showBgCheckTreatmentsInList.rawValue)
         }
     }
     

--- a/xdrip/Storyboards/Base.lproj/Main.storyboard
+++ b/xdrip/Storyboards/Base.lproj/Main.storyboard
@@ -164,7 +164,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="24" estimatedSectionHeaderHeight="-1" sectionFooterHeight="24" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="XPB-uN-uCA">
-                                <rect key="frame" x="0.0" y="88" width="390" height="673"/>
+                                <rect key="frame" x="0.0" y="128" width="390" height="633"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="0.0" shouldIndentWhileEditing="NO" reuseIdentifier="TreatmentsCell" rowHeight="26" id="Gwu-WR-xta" customClass="TreatmentTableViewCell" customModule="xdrip" customModuleProvider="target">
@@ -239,15 +239,105 @@
                                     <outlet property="delegate" destination="01q-Jv-AjA" id="zLD-2f-MIF"/>
                                 </connections>
                             </tableView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ENW-aW-U8f">
+                                <rect key="frame" x="0.0" y="88" width="390" height="40"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GAt-uS-uta">
+                                        <rect key="frame" x="10" y="9.6666666666666714" width="42.666666666666664" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TOp-MQ-ekU">
+                                        <rect key="frame" x="302" y="4.6666666666666714" width="35" height="31"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="35" id="DTj-KO-pri"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="tinted">
+                                            <imageReference key="image" image="circle.fill" catalog="system" symbolScale="default"/>
+                                            <color key="baseForegroundColor" red="1" green="0.57637232540000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="baseBackgroundColor" white="0.25" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="filterCarbsButtonAction:" destination="01q-Jv-AjA" eventType="touchUpInside" id="ZH8-iq-56Z"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ajs-26-kaa">
+                                        <rect key="frame" x="345" y="4.6666666666666714" width="35" height="31"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="35" id="jwI-Mt-2xL"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="tinted" title=" ">
+                                            <imageReference key="image" image="drop.fill" catalog="system" symbolScale="default"/>
+                                            <fontDescription key="titleFontDescription" type="system" pointSize="10"/>
+                                            <color key="baseForegroundColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="baseBackgroundColor" white="0.25" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="filterBgCheckButtonAction:" destination="01q-Jv-AjA" eventType="touchUpInside" id="54B-Gg-Ezc"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H0N-EK-5JX">
+                                        <rect key="frame" x="259" y="4.6666666666666714" width="35" height="31"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="35" id="Kch-nb-3re"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="tinted" title=" ">
+                                            <imageReference key="image" image="arrowtriangle.down.fill" catalog="system" symbolScale="small"/>
+                                            <fontDescription key="titleFontDescription" type="system" pointSize="3"/>
+                                            <color key="baseForegroundColor" systemColor="systemBlueColor"/>
+                                            <color key="baseBackgroundColor" white="0.25" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="filterSmallBolusButtonAction:" destination="01q-Jv-AjA" eventType="touchUpInside" id="W9u-TH-KTx"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WHF-BG-N8A">
+                                        <rect key="frame" x="216" y="4.6666666666666714" width="35" height="31"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="35" id="eK9-uP-9Td"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="tinted" image="arrowtriangle.down.fill" catalog="system" title=" ">
+                                            <color key="baseForegroundColor" systemColor="systemBlueColor"/>
+                                            <color key="baseBackgroundColor" white="0.25" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="filterBolusButtonAction:" destination="01q-Jv-AjA" eventType="touchUpInside" id="gfe-t9-mVs"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="H0N-EK-5JX" firstAttribute="leading" secondItem="WHF-BG-N8A" secondAttribute="trailing" constant="8" id="3iC-ib-7K0"/>
+                                    <constraint firstAttribute="height" constant="40" id="4MD-px-ask"/>
+                                    <constraint firstItem="TOp-MQ-ekU" firstAttribute="centerY" secondItem="ENW-aW-U8f" secondAttribute="centerY" id="DV0-6w-GDv"/>
+                                    <constraint firstItem="GAt-uS-uta" firstAttribute="leading" secondItem="ENW-aW-U8f" secondAttribute="leading" constant="10" id="F30-pg-uC7"/>
+                                    <constraint firstAttribute="trailing" secondItem="ajs-26-kaa" secondAttribute="trailing" constant="10" id="IZX-7g-OnD"/>
+                                    <constraint firstItem="ajs-26-kaa" firstAttribute="centerY" secondItem="ENW-aW-U8f" secondAttribute="centerY" id="Ixx-ci-HcP"/>
+                                    <constraint firstItem="TOp-MQ-ekU" firstAttribute="leading" secondItem="H0N-EK-5JX" secondAttribute="trailing" constant="8" id="Xs3-0i-h4q"/>
+                                    <constraint firstItem="H0N-EK-5JX" firstAttribute="centerY" secondItem="ENW-aW-U8f" secondAttribute="centerY" id="kWl-TM-Ftm"/>
+                                    <constraint firstItem="WHF-BG-N8A" firstAttribute="centerY" secondItem="ENW-aW-U8f" secondAttribute="centerY" id="v7h-tm-wmM"/>
+                                    <constraint firstItem="GAt-uS-uta" firstAttribute="centerY" secondItem="ENW-aW-U8f" secondAttribute="centerY" id="vPy-zS-OGO"/>
+                                    <constraint firstItem="H0N-EK-5JX" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="GAt-uS-uta" secondAttribute="trailing" constant="8" symbolic="YES" id="wVK-yg-ll4"/>
+                                    <constraint firstItem="ajs-26-kaa" firstAttribute="leading" secondItem="TOp-MQ-ekU" secondAttribute="trailing" constant="8" id="ybQ-Y1-HIW"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="l6g-XB-W8K"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="XPB-uN-uCA" firstAttribute="trailing" secondItem="l6g-XB-W8K" secondAttribute="trailing" id="4II-Lt-Jac"/>
                             <constraint firstItem="XPB-uN-uCA" firstAttribute="leading" secondItem="l6g-XB-W8K" secondAttribute="leading" id="55U-5F-TZa"/>
+                            <constraint firstItem="ENW-aW-U8f" firstAttribute="leading" secondItem="l6g-XB-W8K" secondAttribute="leading" id="IwZ-5e-7ar"/>
+                            <constraint firstItem="ENW-aW-U8f" firstAttribute="top" secondItem="l6g-XB-W8K" secondAttribute="top" id="SIF-s1-yiS"/>
                             <constraint firstItem="XPB-uN-uCA" firstAttribute="centerX" secondItem="os0-CD-Pjv" secondAttribute="centerX" id="THx-wK-P5b"/>
+                            <constraint firstItem="l6g-XB-W8K" firstAttribute="trailing" secondItem="ENW-aW-U8f" secondAttribute="trailing" id="ei2-TK-Fwd"/>
+                            <constraint firstItem="XPB-uN-uCA" firstAttribute="top" secondItem="ENW-aW-U8f" secondAttribute="bottom" id="gxk-mF-XVw"/>
                             <constraint firstItem="XPB-uN-uCA" firstAttribute="bottom" secondItem="l6g-XB-W8K" secondAttribute="bottom" id="ktr-HH-FqK"/>
-                            <constraint firstItem="XPB-uN-uCA" firstAttribute="top" secondItem="l6g-XB-W8K" secondAttribute="top" id="vph-fE-Ppx"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Treatments" image="Home" id="EM7-TR-8Pt"/>
@@ -260,6 +350,11 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="filterBgCheckButtonOutlet" destination="ajs-26-kaa" id="D4e-nR-BEp"/>
+                        <outlet property="filterBolusButtonOutlet" destination="WHF-BG-N8A" id="1sC-ev-RxQ"/>
+                        <outlet property="filterCarbsButtonOutlet" destination="TOp-MQ-ekU" id="1je-4O-lE8"/>
+                        <outlet property="filterLabelOutlet" destination="GAt-uS-uta" id="Ur2-6Q-mas"/>
+                        <outlet property="filterSmallBolusButtonOutlet" destination="H0N-EK-5JX" id="jOc-Tu-pLJ"/>
                         <outlet property="tableView" destination="XPB-uN-uCA" id="fV3-OR-Exz"/>
                         <outlet property="titleNavigation" destination="fUA-gv-91n" id="b1y-Qh-HjD"/>
                     </connections>
@@ -2091,15 +2186,20 @@
         <image name="Home" width="30" height="30"/>
         <image name="Settings" width="30" height="30"/>
         <image name="Treatments" width="30" height="30"/>
+        <image name="arrowtriangle.down.fill" catalog="system" width="128" height="124"/>
         <image name="chevron.backward" catalog="system" width="96" height="128"/>
         <image name="chevron.forward" catalog="system" width="96" height="128"/>
         <image name="circle.fill" catalog="system" width="128" height="121"/>
+        <image name="drop.fill" catalog="system" width="101" height="128"/>
         <image name="ellipsis.circle" catalog="system" width="128" height="121"/>
         <image name="lock" catalog="system" width="128" height="128"/>
         <image name="moon.zzz" catalog="system" width="115" height="128"/>
         <image name="questionmark.circle" catalog="system" width="128" height="121"/>
         <image name="scope" catalog="system" width="128" height="122"/>
         <image name="sensor14_14_alt" width="390" height="14"/>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemGrayColor">
             <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/xdrip/Storyboards/ar.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/ar.lproj/SettingsViews.strings
@@ -144,8 +144,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/da.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/da.lproj/SettingsViews.strings
@@ -133,8 +133,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/de.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/de.lproj/SettingsViews.strings
@@ -359,8 +359,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/en.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/en.lproj/SettingsViews.strings
@@ -28,7 +28,6 @@
 "settingsviews_smallBolusTreatmentThreshold" = "Micro-bolus Threshold:";
 "settingsviews_smallBolusTreatmentThresholdMessage" = "Below how many units should we consider a bolus as a micro-bolus?\n\n(Recommended value: 1.0U)";
 "settingsviews_showSmallBolusTreatmentsOnChart" = "Show Micro-bolus on Chart?";
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
 "settingsviews_sectiontitlestatistics" = "Statistics";
 "settingsviews_showStatistics" = "Show Statistics?";
 "settingsviews_daysToUseStatisticsTitle" = "Days to Calculate?";

--- a/xdrip/Storyboards/en.lproj/Treatments.strings
+++ b/xdrip/Storyboards/en.lproj/Treatments.strings
@@ -15,3 +15,4 @@
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";
 "treatments_filterTreatmentsLabel" = "Filter:";
+"treatments_cannotStoreFutureBGCheck" = "You cannot store a BG Check in the future.\n\nIt will be stored at the actual time.";

--- a/xdrip/Storyboards/en.lproj/Treatments.strings
+++ b/xdrip/Storyboards/en.lproj/Treatments.strings
@@ -14,3 +14,4 @@
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";
+"treatments_filterTreatmentsLabel" = "Filter:";

--- a/xdrip/Storyboards/es.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/es.lproj/SettingsViews.strings
@@ -24,7 +24,6 @@
 "settingsviews_smallBolusTreatmentThreshold" = "Límite Micro-bolo:";
 "settingsviews_smallBolusTreatmentThresholdMessage" = "Por debajo de cuántas unidades debemos considerar un bolo como micro-bolo?\n\n(Valor recomendado: 1.0U)";
 "settingsviews_showSmallBolusTreatmentsOnChart" = "Mostrar Micro-bolos en Gráfica?";
-"settingsviews_showSmallBolusTreatmentsInList" = "Mostrar Micro-bolos en Listado?";
 "settingsviews_sectiontitlestatistics" = "Estadísticas";
 "settingsviews_showStatistics" = "Mostrar Estadísticas?";
 "settingsviews_daysToUseStatisticsTitle" = "Días a Calcular?";

--- a/xdrip/Storyboards/es.lproj/Treatments.strings
+++ b/xdrip/Storyboards/es.lproj/Treatments.strings
@@ -2,19 +2,20 @@
 /////   Translation needed - remove this header after translation                       /////
 /////////////////////////////////////////////////////////////////////////////////////////////
 
-"treatments_title" = "Treatments";
-"treatments_new_button" = "New";
-"treatments_new_entry" = "New Treatment";
+"treatments_title" = "Tratamientos";
+"treatments_new_button" = "Nuevo";
+"treatments_new_entry" = "Nuevo Tratamiento";
 "treatments_carbs_with_unit" = "Carbs (g):";
-"treatments_insulin_with_unit" = "Insulin (U):";
-"treatments_exercise_with_unit" = "Exercise (min):";
+"treatments_insulin_with_unit" = "Insulina (U):";
+"treatments_exercise_with_unit" = "Ejercicio (min):";
 "treatments_carbs_unit" = "g";
 "treatments_insulin_unit" = "U";
 "treatments_exercise_unit" = "min";
 "treatments_carbs" = "Carbs";
-"treatments_insulin" = "Insulin";
-"treatments_exercise" = "Exercise";
+"treatments_insulin" = "Insulina";
+"treatments_exercise" = "Ejercicio";
 "treatments_bgcheck" = "Control Glucemia";
 "treatments_question_mark" = "?";
 "treatments_success" = "Success";
 "treatments_sync_complete" = "Synchronization complete.";
+"treatments_filterTreatmentsLabel" = "Filtrar:";

--- a/xdrip/Storyboards/fi.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/fi.lproj/SettingsViews.strings
@@ -214,8 +214,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/fr.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/fr.lproj/SettingsViews.strings
@@ -200,8 +200,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/it.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/it.lproj/SettingsViews.strings
@@ -406,8 +406,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/nl.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/nl.lproj/SettingsViews.strings
@@ -185,8 +185,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/pl-PL.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/pl-PL.lproj/SettingsViews.strings
@@ -406,8 +406,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/pt.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/pt.lproj/SettingsViews.strings
@@ -146,8 +146,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/ru.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/ru.lproj/SettingsViews.strings
@@ -406,8 +406,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/sl.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/sl.lproj/SettingsViews.strings
@@ -406,8 +406,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/sv.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/sv.lproj/SettingsViews.strings
@@ -155,8 +155,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Storyboards/uk.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/uk.lproj/SettingsViews.strings
@@ -6,9 +6,6 @@
 /// used in settings, section Info, title of the license setting
 "settingsviews_license" = "License";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// help settings, should the online help be translated automatically if needed
 "settingsviews_translateOnlineHelp" = "Translate Automatically?";
 

--- a/xdrip/Storyboards/zh.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/zh.lproj/SettingsViews.strings
@@ -330,8 +330,5 @@
 /// When clicking the retention setting, a pop up asks for how many days should data be stored
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 
-/// treatments settings, show the micro-bolus in the treatment list
-"settingsviews_showSmallBolusTreatmentsInList" = "Show Micro-bolus in List?";
-
 /// Housekeeper retention period, for how long to store data
 "settingsviews_housekeeperRetentionPeriod" = "Retention Period (days):";

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -138,10 +138,6 @@ class Texts_SettingsView {
         return NSLocalizedString("settingsviews_showSmallBolusTreatmentsOnChart", tableName: filename, bundle: Bundle.main, value: "Show Micro-bolus on Chart?", comment: "treatments settings, show the micro-bolus on main chart")
     }()
     
-    static let settingsviews_showSmallBolusTreatmentsInList: String = {
-        return NSLocalizedString("settingsviews_showSmallBolusTreatmentsInList", tableName: filename, bundle: Bundle.main, value: "Show Micro-bolus in List?", comment: "treatments settings, show the micro-bolus in the treatment list")
-    }()
-    
     // MARK: - Section Statistics
     
     static let sectionTitleStatistics: String = {

--- a/xdrip/Texts/TextsTreatmentsView.swift
+++ b/xdrip/Texts/TextsTreatmentsView.swift
@@ -47,5 +47,9 @@ enum Texts_TreatmentsView {
 	static let questionMark:String = {
 		return NSLocalizedString("treatments_question_mark", tableName: filename, bundle: Bundle.main, value: "?", comment: "Literally a question mark, used as unknown abbreviation.")
 	}()
+    
+    static let filterTreatmentsLabel:String = {
+        return NSLocalizedString("treatments_filterTreatmentsLabel", tableName: filename, bundle: Bundle.main, value: "Filter:", comment: "filter the treatments by type")
+    }()
 
 }

--- a/xdrip/Texts/TextsTreatmentsView.swift
+++ b/xdrip/Texts/TextsTreatmentsView.swift
@@ -51,5 +51,9 @@ enum Texts_TreatmentsView {
     static let filterTreatmentsLabel:String = {
         return NSLocalizedString("treatments_filterTreatmentsLabel", tableName: filename, bundle: Bundle.main, value: "Filter:", comment: "filter the treatments by type")
     }()
+    
+    static let cannotStoreFutureBGCheck:String = {
+        return NSLocalizedString("treatments_cannotStoreFutureBGCheck", tableName: filename, bundle: Bundle.main, value: "You cannot store a BG Check in the future.\n\nIt will be stored at the actual time.", comment: "warn about trying to set a future bg value")
+    }()
 
 }

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewTreatmentsSettingsViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewTreatmentsSettingsViewModel.swift
@@ -21,9 +21,6 @@ fileprivate enum Setting:Int, CaseIterable {
     //should we show the micro-boluses on the main chart?
     case showSmallBolusTreatmentsOnChart = 2
     
-    //should we show the micro-boluses in the treatment list/table?
-    case showSmallBolusTreatmentsInList = 3
-    
     
 }
 
@@ -44,9 +41,6 @@ struct SettingsViewTreatmentsSettingsViewModel:SettingsViewModelProtocol {
             
         case .showSmallBolusTreatmentsOnChart:
             return UISwitch(isOn: UserDefaults.standard.showSmallBolusTreatmentsOnChart, action: {(isOn:Bool) in UserDefaults.standard.showSmallBolusTreatmentsOnChart = isOn})
-            
-        case .showSmallBolusTreatmentsInList:
-            return UISwitch(isOn: UserDefaults.standard.showSmallBolusTreatmentsInList, action: {(isOn:Bool) in UserDefaults.standard.showSmallBolusTreatmentsInList = isOn})
             
         }
     }
@@ -94,15 +88,6 @@ struct SettingsViewTreatmentsSettingsViewModel:SettingsViewModelProtocol {
                 }
             })
             
-        case .showSmallBolusTreatmentsInList:
-            return SettingsSelectedRowAction.callFunction(function: {
-                if UserDefaults.standard.showSmallBolusTreatmentsInList {
-                    UserDefaults.standard.showSmallBolusTreatmentsInList = false
-                } else {
-                    UserDefaults.standard.showSmallBolusTreatmentsInList = true
-                }
-            })
-            
         }
     }
     
@@ -128,9 +113,6 @@ struct SettingsViewTreatmentsSettingsViewModel:SettingsViewModelProtocol {
         case .showSmallBolusTreatmentsOnChart:
             return Texts_SettingsView.settingsviews_showSmallBolusTreatmentsOnChart
             
-        case .showSmallBolusTreatmentsInList:
-            return Texts_SettingsView.settingsviews_showSmallBolusTreatmentsInList
-            
         }
     }
     
@@ -139,7 +121,7 @@ struct SettingsViewTreatmentsSettingsViewModel:SettingsViewModelProtocol {
         
         switch setting {
             
-        case .showTreatmentsOnChart, .showSmallBolusTreatmentsOnChart, .showSmallBolusTreatmentsInList:
+        case .showTreatmentsOnChart, .showSmallBolusTreatmentsOnChart:
             return UITableViewCell.AccessoryType.none
             
         case .smallBolusTreatmentThreshold:
@@ -153,7 +135,7 @@ struct SettingsViewTreatmentsSettingsViewModel:SettingsViewModelProtocol {
         
         switch setting {
             
-        case .showTreatmentsOnChart, .showSmallBolusTreatmentsOnChart, .showSmallBolusTreatmentsInList:
+        case .showTreatmentsOnChart, .showSmallBolusTreatmentsOnChart:
             return nil
             
         case .smallBolusTreatmentThreshold:

--- a/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
@@ -154,7 +154,7 @@ class TreatmentsInsertViewController : UIViewController {
 	@IBAction func doneButtonTapped(_ sender: UIBarButtonItem) {
         
         // if treatMentEntryToUpdate not nil, then assign new value or delete it
-        // it's either type carbs, insulin or exercise
+        // it's either type carbs, insulin, exercise or a BG check
         if let treatMentEntryToUpdate = treatMentEntryToUpdate {
 
             // code reused three times
@@ -185,6 +185,17 @@ class TreatmentsInsertViewController : UIViewController {
                         textField.text = "0"
                         
                         treatMentEntryToUpdateChanged = true
+                        
+                    }
+                    
+                    // check if the user is editing a future bg check or trying to edit one into the future. This can be dangerous for some APS systems that use BG checks as well as CGM values for their predictions. Set the current time to now.
+                    if treatMentEntryToUpdate.treatmentType == .BgCheck && (treatMentEntryToUpdate.date > Date() || self.datePicker.date > Date()) {
+                        
+                        self.datePicker.setDate(Date(), animated: true)
+                        
+                        let alert = UIAlertController(title: Texts_Common.warning, message: Texts_TreatmentsView.cannotStoreFutureBGCheck, actionHandler: nil)
+                        
+                        self.present(alert, animated: true, completion: nil)
                         
                     }
                     
@@ -268,6 +279,16 @@ class TreatmentsInsertViewController : UIViewController {
             
                             value = value.mmolToMgdl(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl).bgValueRounded(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl)
                             
+                            // For safety in some APS systems, ensure the user isn't trying to add a future BG Check. If so, warn/inform them and set the datePicker date to the actual date/time.
+                            if datePicker.date > Date() {
+                                
+                                datePicker.setDate(Date(), animated: true)
+                                
+                                let alert = UIAlertController(title: Texts_Common.warning, message: Texts_TreatmentsView.cannotStoreFutureBGCheck, actionHandler: nil)
+                                
+                                self.present(alert, animated: true, completion: nil)
+                                
+                            }
                         }
                     
                     // create the treatment and append to treatments


### PR DESCRIPTION
- the different treatment types (insulin, carbs, BG checks) can be filtered if required to show/hide them in the treatment table
- if boluses are shown, an option to filter micro-boluses is also enabled.
- button icon images are set individually as filled/unfilled to more clearly show if they are selected
- .getTreatments call reduced from 100 days to 21 days to save overhead
- previous settings options to show micro-boluses in the treatments table (and associated translations) removed as no longer needed
- safety feature added to prevent future BGs being added/assigned @bjornoleh

![IMG_4904](https://user-images.githubusercontent.com/37302780/175322628-485f6fae-eab3-492d-b59f-dab5300ff312.jpeg)


