### PR TITLE
Fix translation issue on AlertManager

### DIFF
--- a/xdrip/Managers/Alerts/AlertManager.swift
+++ b/xdrip/Managers/Alerts/AlertManager.swift
@@ -82,7 +82,7 @@ public class AlertManager:NSObject {
         
         // in snoozeValueStrings, replace all occurrences of minutes, minute, etc... by language dependent value
         for (index, _) in snoozeValueStrings.enumerated() {
-            snoozeValueStrings[index] = snoozeValueStrings[index].replacingOccurrences(of: "minutes", with: Texts_Common.minutes).replacingOccurrences(of: "hour", with: Texts_Common.hour).replacingOccurrences(of: "hours", with: Texts_Common.hours).replacingOccurrences(of: "day", with: Texts_Common.day).replacingOccurrences(of: "week", with: Texts_Common.week)
+            snoozeValueStrings[index] = snoozeValueStrings[index].replacingOccurrences(of: "minutes", with: Texts_Common.minutes).replacingOccurrences(of: "hours", with: Texts_Common.hours).replacingOccurrences(of: "hour", with: Texts_Common.hour).replacingOccurrences(of: "day", with: Texts_Common.day).replacingOccurrences(of: "week", with: Texts_Common.week)
         }
         
         //  initialize array of alertNotifications


### PR DESCRIPTION
Minor bug in string replacement during translation. Change order of string replacement as "hour" is included in "hours". This affects all language translations

e.g.
![IMG_2287](https://user-images.githubusercontent.com/7975347/190872174-711e5207-b4fd-40f6-9688-0324a494394e.jpeg)

