### PR TITLE
Fix speak readings on iOS 16

### DIFF
--- a/xdrip/Managers/Speak/BGReadingSpeaker.swift
+++ b/xdrip/Managers/Speak/BGReadingSpeaker.swift
@@ -9,6 +9,8 @@ class BGReadingSpeaker:NSObject {
     // MARK: - public properties
     
     // MARK: - private properties
+
+    private let syn = AVSpeechSynthesizer.init()
     
     /// reference to coreDataManager
     private var coreDataManager:CoreDataManager
@@ -166,8 +168,6 @@ class BGReadingSpeaker:NSObject {
     
     /// will speak the text, using language code for pronunciation
     private func say(text:String, language:String?) {
-        
-        let syn = AVSpeechSynthesizer.init()
         let utterance = AVSpeechUtterance(string: text)
         utterance.rate = 0.51
         utterance.pitchMultiplier = 1


### PR DESCRIPTION
# NOTE: Do not merge before testing with speak readings on and waiting until it speaks.

## The issue

AVSpeechSynthesizer does not output any sound on iOS 16. **iOS 16 is going to be released tomorrow.**

## Help wanted

- Can someone confirm that the bug exists on their device?
- Can someone test running the change in this PR if they hit the crash as well?

I've been using my [ugly workaround](https://github.com/JohanDegraeve/xdripswift/pull/369) for this beta period, but I'd like to hear if I'm the only one hitting this bug...

## Solution

https://developer.apple.com/forums/thread/712809

It seems that AVSpeechSynthesizer on iOS 16 requires retaining the instance. I tested it working with a separate test app but I'm hitting a wall with xdrip.

If I move the let syn = AVSpeechSynthesizer.init() in BGReadingSpeaker.swift to file level or to the class level (out of the say function) I get Heap buffer overflow from the framework...

Can anyone try that? I'd like to know if my phone is in a funny state or if that's related to the xdripswift project.

<img width="1524" alt="187065809-192cf0b6-3e3e-4096-af0c-d8e99bb02257" src="https://user-images.githubusercontent.com/6566702/189518728-bf89d378-7f86-47ab-adb7-57057cde4413.png">