### PR TITLE
Update minimum G6 Firefly ID from 8G to 8A

### DIFF
--- a/xdrip/BluetoothTransmitter/CGM/Dexcom/Generic/String+Dexcom.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Dexcom/Generic/String+Dexcom.swift
@@ -10,7 +10,8 @@ extension String {
             
         }
         
-        if self >= "8G" {
+        // changed from 8G to 8A as Dexcom seemed to have gone through the alphabet and started again for G6 transmitters as from summer 2022
+        if self >= "8A" {
             
             return true
             


### PR DESCRIPTION
Dexcom seemed to have sold so many G6s that they've finished the alphabet and rolled back to before 8G. I have a transmitter manufactured in July 2022 with ID 8Dxxxx.

This change just identifies transmitters after 8A as Firefly (instead of 8G as before).