### PR TITLE
Skip calibration need if xdrip on follower mode

### DIFF
--- a/xdrip/Core Data/accessors/CalibrationsAccessor.swift
+++ b/xdrip/Core Data/accessors/CalibrationsAccessor.swift
@@ -37,11 +37,11 @@ class CalibrationsAccessor {
     /// - returns:
     ///     - the last calibration, can be nil
     func lastCalibrationForActiveSensor(withActivesensor sensor:Sensor?) -> Calibration? {
+        // check that xdrip is in follower mode, no calibration possible
+        if !UserDefaults.standard.isMaster {return nil}
         
         guard let sensor = sensor else {return nil}
-        
         return getFirstOrLastCalibration(withActivesensor: sensor, first: false)
-        
     }
     
     /// Returns last calibrations, possibly zero


### PR DESCRIPTION
I have been switching between Libre 2 and Libre 3 the last few weeks, this an annoying alert that one needs to silence every once in a while. There is no need to trigger the calibration alert when in follower mode