### PR TITLE
Enforce a minimum sensor warm-up time before processing new glucose v…

### DIFF
--- a/xdrip/Constants/ConstantsHomeView.swift
+++ b/xdrip/Constants/ConstantsHomeView.swift
@@ -30,4 +30,6 @@ enum ConstantsHomeView {
     static let onlineHelpURLTranslated1 = "https://xdrip4ios-readthedocs-io.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl="
     static let onlineHelpURLTranslated2 = "&_x_tr_hl=es&_x_tr_pto=nui"
 
+    /// github.com repository URL for the project
+    static let gitHubURL = "https://github.com/JohanDegraeve/xdripswift"
 }

--- a/xdrip/Constants/ConstantsMaster.swift
+++ b/xdrip/Constants/ConstantsMaster.swift
@@ -3,4 +3,10 @@ enum ConstantsMaster {
     
     /// maximum age in seconds, of reading in alert flow. If age of latest reading is more than this number, then no alert check will be done
     static let maximumBgReadingAgeForAlertsInSeconds = 240.0
+    
+    /// minimum sensor warm-up time required for all sensors before allowing the app to process a BG reading
+    /// this will only be relevant for active sensors that hold a sensorAge value
+    /// some transmitters (such as Dexcom) enforce warm-up on the transmitter side before transmitting values
+    static let minimumSensorWarmUpRequiredInMinutes = 45.0
+    
 }

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -389,6 +389,10 @@ class Texts_SettingsView {
         return NSLocalizedString("settingsviews_license", tableName: filename, bundle: Bundle.main, value: "License", comment: "used in settings, section Info, title of the license setting")
     }()
     
+    static let showGitHub = {
+        return NSLocalizedString("settingsviews_showGitHub", tableName: filename, bundle: Bundle.main, value: "GitHub", comment: "used in settings, section Info, open the GitHub page of the project")
+    }()
+    
     // MARK: - Section M5Stack
     
     static let m5StackSettingsViewScreenTitle: String = {

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/Atom/AtomBluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/Atom/AtomBluetoothPeripheralViewModel.swift
@@ -203,21 +203,21 @@ extension AtomBluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
             
             // firmware text could be longer than screen width, clicking the row allos to see it in pop up with more text place
             if let firmware = atom.firmware {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.firmware + " : " + firmware)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.firmware + ": " + firmware)
             }
             
         case .hardWare:
             
             // hardware text could be longer than screen width, clicking the row allows to see it in pop up with more text place
             if let hardware = atom.hardware {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.hardware + " : " + hardware)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.hardware + ": " + hardware)
             }
             
         case .sensorSerialNumber:
             
             // serial text could be longer than screen width, clicking the row allows to see it in a pop up with more text place
             if let serialNumber = atom.blePeripheral.sensorSerialNumber {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " : " + serialNumber)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " " + serialNumber)
             }
             
         }

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/Blucon/BluconBluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/Blucon/BluconBluetoothPeripheralViewModel.swift
@@ -154,7 +154,7 @@ extension BluconBluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
             
             // serial text could be longer than screen width, clicking the row allows to see it in a pop up with more text place
             if let serialNumber = blucon.blePeripheral.sensorSerialNumber {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " : " + serialNumber)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " " + serialNumber)
             }
             
         }

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/Bubble/BubbleBluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/Bubble/BubbleBluetoothPeripheralViewModel.swift
@@ -213,21 +213,21 @@ extension BubbleBluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
             
             // firmware text could be longer than screen width, clicking the row allos to see it in pop up with more text place
             if let firmware = bubble.firmware {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.firmware + " : " + firmware)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.firmware + ": " + firmware)
             }
 
         case .hardWare:
 
             // hardware text could be longer than screen width, clicking the row allows to see it in pop up with more text place
             if let hardware = bubble.hardware {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.hardware + " : " + hardware)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.hardware + ": " + hardware)
             }
             
         case .sensorSerialNumber:
             
             // serial text could be longer than screen width, clicking the row allows to see it in a pop up with more text place
             if let serialNumber = bubble.blePeripheral.sensorSerialNumber {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " : " + serialNumber)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " " + serialNumber)
             }
             
         }

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/GNSENtry/GNSEntryBluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/GNSENtry/GNSEntryBluetoothPeripheralViewModel.swift
@@ -160,7 +160,7 @@ extension GNSEntryBluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
             
             // firmware text could be longer than screen width, clicking the row allos to see it in pop up with more text place
             if let firmWareVersion = gNSEntry.firmwareVersion {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.firmware + " : " + firmWareVersion)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.firmware + ": " + firmwareVersion)
             }
 
         case .serialNumber:

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/GNSENtry/GNSEntryBluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/GNSENtry/GNSEntryBluetoothPeripheralViewModel.swift
@@ -160,7 +160,7 @@ extension GNSEntryBluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
             
             // firmware text could be longer than screen width, clicking the row allos to see it in pop up with more text place
             if let firmWareVersion = gNSEntry.firmwareVersion {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.firmware + ": " + firmwareVersion)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.firmware + ": " + firmWareVersion)
             }
 
         case .serialNumber:

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/Libre2/Libre2BluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/Libre2/Libre2BluetoothPeripheralViewModel.swift
@@ -159,7 +159,7 @@ extension Libre2BluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
             
             // serial text could be longer than screen width, clicking the row allows to see it in a pop up with more text place
             if let serialNumber = libre2.blePeripheral.sensorSerialNumber {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " : " + serialNumber)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " " + serialNumber)
             }
 
         case .sensorStartTime:

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/MiaoMiao/MiaoMiaoBluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/MiaoMiao/MiaoMiaoBluetoothPeripheralViewModel.swift
@@ -203,21 +203,21 @@ extension MiaoMiaoBluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
             
             // firmware text could be longer than screen width, clicking the row allos to see it in pop up with more text place
             if let firmware = miaoMiao.firmware {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.firmware + " : " + firmware)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.firmware + ": " + firmware)
             }
 
         case .hardWare:
 
             // hardware text could be longer than screen width, clicking the row allows to see it in pop up with more text place
             if let hardware = miaoMiao.hardware {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.hardware + " : " + hardware)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_Common.hardware + ": " + hardware)
             }
             
         case .sensorSerialNumber:
             
             // serial text could be longer than screen width, clicking the row allows to see it in a pop up with more text place
             if let serialNumber = miaoMiao.blePeripheral.sensorSerialNumber {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " : " + serialNumber)
+                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " " + serialNumber)
             }
             
         }

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -3099,8 +3099,30 @@ extension RootViewController: CGMTransmitterDelegate {
             
         }
         
-        // process new readings
-        processNewGlucoseData(glucoseData: &glucoseData, sensorAge: sensorAge)
+        // let's check to ensure that the sensor is not within the minimum warm-up time as defined in ConstantsMaster
+        var supressReadingIfSensorIsWarmingUp: Bool = false
+        
+        if let sensorAgeInSeconds = sensorAge {
+            
+            let secondsUntilWarmUpComplete = (ConstantsMaster.minimumSensorWarmUpRequiredInMinutes * 60) - sensorAgeInSeconds
+            
+            if secondsUntilWarmUpComplete > 0 {
+                
+                supressReadingIfSensorIsWarmingUp = true
+                
+                trace("Sensor is still warming up. BG reading processing will remain suppressed for another %{public}@ minutes. (%{public}@ minutes warm-up required).", log: log, category: ConstantsLog.categoryRootView, type: .info, Int(secondsUntilWarmUpComplete/60).description, ConstantsMaster.minimumSensorWarmUpRequiredInMinutes.description)
+                
+            }
+            
+        }
+        
+        // process new readings if sensor is not still warming up
+        if !supressReadingIfSensorIsWarmingUp {
+            
+            processNewGlucoseData(glucoseData: &glucoseData, sensorAge: sensorAge)
+            
+        }
+        
         
     }
     

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewInfoViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewInfoViewModel.swift
@@ -11,8 +11,11 @@ fileprivate enum Setting:Int, CaseIterable {
     /// licenseInfo
     case licenseInfo = 2
     
+    /// link to open the project GitHub page
+    case showGitHub = 3
+    
     /// link to icons8
-    case icons8 = 3
+    case icons8 = 4
     
 }
 
@@ -46,6 +49,9 @@ struct SettingsViewInfoViewModel:SettingsViewModelProtocol {
         case .buildNumber:
             return Texts_SettingsView.build
             
+        case .showGitHub:
+            return Texts_SettingsView.showGitHub
+            
         case .icons8:
             return "Icons By icons8.com"
 
@@ -68,7 +74,7 @@ struct SettingsViewInfoViewModel:SettingsViewModelProtocol {
         case .licenseInfo:
             return .detailButton
             
-        case .icons8:
+        case .showGitHub, .icons8:
             return .disclosureIndicator
             
         }
@@ -97,11 +103,7 @@ struct SettingsViewInfoViewModel:SettingsViewModelProtocol {
 
             return version
             
-        case .licenseInfo:
-            
-            return nil
-            
-        case .icons8:
+        case .licenseInfo, .showGitHub, .icons8:
             
             return nil
 
@@ -132,6 +134,13 @@ struct SettingsViewInfoViewModel:SettingsViewModelProtocol {
         case .licenseInfo:
             return SettingsSelectedRowAction.showInfoText(title: ConstantsHomeView.applicationName, message: Texts_HomeView.licenseInfo + ConstantsHomeView.infoEmailAddress)
 
+        case .showGitHub:
+            guard let url = URL(string: ConstantsHomeView.gitHubURL) else { return .nothing}
+            
+            UIApplication.shared.open(url)
+            
+            return .nothing
+            
         case .icons8:
             guard let url = URL(string: "https://icons8.com") else { return .nothing}
             


### PR DESCRIPTION
…alues

- implemented to ensure a minimum time has passed since sensor activation
- especially necessary for Libre sensors (either Libre 2 BLE or Libre through transmitters) that can transmit glucose values immediately after activation. The first 50 minutes can often produce very unreliable values so it's better to just not process anything during this time.
- note that there is no set time after which the sensor values are reliable. Sometimes after 10 minutes, values are good. Sometimes it needs 30 or even 40 minutes.
- warm-up time is therefore initially set to 45 minutes warm-up time but minimumSensorWarmUpRequiredInMinutes can be edited in ConstantsMaster.swift
- GitHub link added to the Info/About section of the Settings screen