### PR TITLE
Calendar event visual indicator option

### DIFF
--- a/xdrip/Constants/ConstantsWatch.swift
+++ b/xdrip/Constants/ConstantsWatch.swift
@@ -3,6 +3,28 @@ import Foundation
 enum ConstantsWatch {
     
     /// text to add as notes in glucose events
-    static let textInCreatedEvent = "created by xdrip"
+    static let textInCreatedEvent = "created by xDrip4iOS"
     
+    /// text to use as the visual indicator in the calendar title when bg is "Urgent"
+    static let visualIndicatorUrgent = "🔴"
+    
+    /// text to use as the visual indicator in the calendar title when bg is "Not Urgent"
+    static let visualIndicatorNotUrgent = "🟡"
+    
+    /// text to use as the visual indicator in the calendar title when bg is "In Range"
+    static let visualIndicatorInRange = "🟢"
+}
+
+
+// Indentifiers for blood glucose range descriptions
+enum BgRangeDescription {
+    
+    /// bg range is "urgent" (either high or low)
+    case urgent
+    
+    /// bg range is "not urgent" (either high or low)
+    case notUrgent
+    
+    /// bg range is "in range"
+    case inRange
 }

--- a/xdrip/Core Data/classes/BgReading+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/BgReading+CoreDataClass.swift
@@ -204,6 +204,28 @@ public class BgReading: NSManagedObject {
 
     }
     
+    /// Return the BgRange description/type of the current BgReading value based on the configured objectives
+    func bgRangeDescription() -> BgRangeDescription {
+        
+        // Prepare the bgReading value
+        let bgValue = self.calculatedValue.mgdlToMmol(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl)
+        
+        if (bgValue >= UserDefaults.standard.urgentHighMarkValueInUserChosenUnit
+            || bgValue <= UserDefaults.standard.urgentLowMarkValueInUserChosenUnit){
+            // BG is higher than urgentHigh or lower than urgentLow objectives
+            return BgRangeDescription.urgent
+        }
+        
+        if (bgValue >= UserDefaults.standard.highMarkValueInUserChosenUnit
+            || bgValue <= UserDefaults.standard.lowMarkValueInUserChosenUnit){
+            // BG is between urgentHigh/high and low/urgentLow objectives
+            return BgRangeDescription.notUrgent
+        }
+        
+        // BG is not high or low so considered "in range"
+        return BgRangeDescription.inRange
+    }
+    
     /// taken over form xdripplus
     ///
     /// - parameters:

--- a/xdrip/Extensions/UserDefaults.swift
+++ b/xdrip/Extensions/UserDefaults.swift
@@ -247,6 +247,10 @@ extension UserDefaults {
         /// calendar interval
         case calendarInterval = "calendarInterval"
         
+        /// should a visual coloured indicator be shown in the calendar title yes or no
+        case displayVisualIndicatorInCalendarEvent = "displayVisualIndicator"
+        
+        
         // Other Settings (not user configurable)
         
         /// - in case missed reading alert settings are changed by user, this value will be set to true
@@ -1511,8 +1515,17 @@ extension UserDefaults {
         }
     }
     
-
+    /// should a visual coloured indicator be shown in the calendar title,  yes or no, default no
+    @objc dynamic var displayVisualIndicatorInCalendarEvent: Bool {
+        get {
+            return bool(forKey: Key.displayVisualIndicatorInCalendarEvent.rawValue)
+        }
+        set {
+            set(newValue, forKey: Key.displayVisualIndicatorInCalendarEvent.rawValue)
+        }
+    }
     
+
     // MARK: - =====  Other Settings ======
     
     /// - in case missed reading alert settings are changed by user, this value will be set to true

--- a/xdrip/Managers/Watch/WatchManager.swift
+++ b/xdrip/Managers/Watch/WatchManager.swift
@@ -91,6 +91,27 @@ class WatchManager: NSObject {
         // start with the reading in correct unit
         var title = lastReading[0].unitizedString(unitIsMgDl: UserDefaults.standard.bloodGlucoseUnitIsMgDl).description
         
+        // add the visual indicator to the title to show what range the current
+        // reading is in
+        if (UserDefaults.standard.displayVisualIndicatorInCalendarEvent){
+            
+            var visualIndicator = ""
+        
+            // get the current range of the last reading then
+            // configure the indicator based on the relevant range
+            switch lastReading[0].bgRangeDescription() {
+            case .inRange:
+                visualIndicator = ConstantsWatch.visualIndicatorInRange
+            case .notUrgent:
+                visualIndicator = ConstantsWatch.visualIndicatorNotUrgent
+            case .urgent:
+                visualIndicator = ConstantsWatch.visualIndicatorUrgent
+            }
+            
+            // pre-append the indicator to the title
+            title = visualIndicator + " " + title
+        }
+        
         // add trend if needed and available
         if (!lastReading[0].hideSlope && UserDefaults.standard.displayTrendInCalendarEvent) {
             title = title + " " + lastReading[0].slopeArrow()

--- a/xdrip/Storyboards/en.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/en.lproj/SettingsViews.strings
@@ -12,6 +12,8 @@
 "settingsviews_showReadingInNotification" = "Show BG in Notifications?";
 "settingsviews_labelShowReadingInAppBadge" = "Show BG in the App Badge?";
 "settingsviews_multipleAppBadgeValueWith10" = "Multiply App Badge Reading by 10?";
+"settingsviews_IntervalTitle" = "Notification Interval";
+"settingsviews_IntervalMessage" = "Minimum interval between two notifications (mins)";
 "settingsviews_allowScreenRotation" = "Allow Chart Rotation?";
 "settingsviews_showMiniChart" = "Show the Mini-Chart?";
 "settingsviews_showClockWhenScreenIsLocked" = "Show Clock when Locked?";
@@ -78,8 +80,8 @@
 "settingsviews_speakreadingslanguageselection" = "Select Language";
 "settingsviews_speakTrend" = "Speak Trend?";
 "settingsviews_speakDelta" = "Speak Delta?";
-"settingsviews_IntervalTitle" = "Notification Interval:";
-"settingsviews_IntervalMessage" = "Minimum interval between two notifications, in minutes";
+"settingsviews_SpeakIntervalTitle" = "Speak Interval";
+"settingsviews_SpeakIntervalMessage" = "Minimum interval between two voice announcements (mins)";
 "settingsviews_sectiontitleAbout" = "About %@";
 "settingsviews_Version" = "Version:";
 "settingsviews_license" = "License";
@@ -99,6 +101,8 @@
 "displayDeltaInCalendarEvent" = "Display Delta?";
 "infoCalendarAccessDeniedByUser" = "You previously denied access to your Calendar.\n\nTo enable it go to your device settings, privacy, calendars and enable it.";
 "infoCalendarAccessRestricted" = "You cannot give authorization to %@ to access your calendar. This is possibly due to active restrictions such as parental controls being in place.";
+"settingsviews_CalenderIntervalTitle" = "Event Interval";
+"settingsviews_CalenderIntervalMessage" = "Minimum interval between two calender events (mins)";
 "sectionTitleTrace" = "Issue Reporting";
 "sendTraceFile" = "Send Issue Report";
 "describeProblem" = "Explain why you need to send the trace file with as much detail as possible. If you have already reported your problem in the Facebook support group '%@', then mention your facebook name in the e-mail";

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -70,6 +70,14 @@ class Texts_SettingsView {
         return NSLocalizedString("warningChangeFromMasterToFollower", tableName: filename, bundle: Bundle.main, value: "Switch from master to follower will stop your current sensor. Do you want to continue ?", comment: "general settings, when switching from master to follower, if confirmation is asked, this message will be shown.")
     }()
     
+    static let settingsviews_IntervalTitle = {
+        return NSLocalizedString("settingsviews_IntervalTitle", tableName: filename, bundle: Bundle.main, value: "Notification Interval", comment: "When clicking the notification interval setting, a pop up asks for minimum number of minutes between two readings, this is the pop up message - this is used for setting the interval between two readings in BG notifications, Speak readings, Apple Watch")
+    }()
+    
+    static let settingsviews_IntervalMessage = {
+        return NSLocalizedString("settingsviews_IntervalMessage", tableName: filename, bundle: Bundle.main, value: "Minimum interval between two notifications (mins)", comment: "When clicking the interval setting, a pop up asks for minimum number of minutes between two notifications, this is the pop up message - this is used for setting the interval between two readings in BG notifications, Speak readings, Apple Watch")
+    }()
+    
     // MARK: - Section Home Screen
     
     static let sectionTitleHomeScreen: String = {
@@ -362,14 +370,15 @@ class Texts_SettingsView {
     static let labelSpeakDelta = {
         return NSLocalizedString("settingsviews_speakDelta", tableName: filename, bundle: Bundle.main, value: "Speak Delta?", comment: "speak settings, where user can enable or disable speak delta")
     }()
-
-    static let settingsviews_IntervalTitle = {
-        return NSLocalizedString("settingsviews_IntervalTitle", tableName: filename, bundle: Bundle.main, value: "Notification Interval:", comment: "When clicking the notification interval setting, a pop up asks for minimum number of minutes between two readings, this is the pop up message - this is used for setting the interval between two readings in BG notifications, Speak readings, Apple Watch")
+    
+    static let settingsviews_SpeakIntervalTitle = {
+        return NSLocalizedString("settingsviews_SpeakIntervalTitle", tableName: filename, bundle: Bundle.main, value: "Speak Interval", comment: "When clicking the speak interval setting, a pop up asks for minimum number of minutes between two speech events, this is the pop up message - this is used for setting the interval between two spoken bg announcements")
     }()
     
-    static let settingsviews_IntervalMessage = {
-        return NSLocalizedString("settingsviews_IntervalMessage", tableName: filename, bundle: Bundle.main, value: "Minimum interval between two notifications (mins)", comment: "When clicking the interval setting, a pop up asks for minimum number of minutes between two notifications, this is the pop up message - this is used for setting the interval between two readings in BG notifications, Speak readings, Apple Watch")
+    static let settingsviews_SpeakIntervalMessage = {
+        return NSLocalizedString("settingsviews_SpeakIntervalMessage", tableName: filename, bundle: Bundle.main, value: "Minimum interval between two voice announcements (mins)", comment: "When clicking the interval setting, a pop up asks for minimum number of minutes between two bg announcements, this is the pop up message - this is used for setting the interval between two readings in BG announcements, Speak readings, Apple Watch")
     }()
+    
     
     // MARK: - Section About Info
     
@@ -462,6 +471,19 @@ class Texts_SettingsView {
     static let infoCalendarAccessRestricted: String = {
         return String(format: NSLocalizedString("infoCalendarAccessRestricted", tableName: filename, bundle: Bundle.main, value: "You cannot give authorization to %@ to access your calendar. This is possibly due to active restrictions such as parental controls being in place.", comment: "If user is not allowed to give any app access to the Calendar, due to restrictions. And then tries to activate creation of events in calendar, this message will be shown"), ConstantsHomeView.applicationName)
     }()
+    
+    static let displayVisualIndicatorInCalendar: String = {
+        return NSLocalizedString("settingsviews_displayVisualIndicatorInCalendarEvent", tableName: filename, bundle: Bundle.main, value: "Display Visual Indicator?", comment: "Calendar Events Settings - text in row where user needs to say if the visual target indicator should be displayed or not")
+    }()
+    
+    static let settingsviews_CalenderIntervalTitle = {
+        return NSLocalizedString("settingsviews_CalenderIntervalTitle", tableName: filename, bundle: Bundle.main, value: "Event Interval:", comment: "When clicking the event interval setting, a pop up asks for minimum number of minutes between two events, this is the pop up message - this is used for setting the interval between two calendar events")
+    }()
+    
+    static let settingsviews_CalenderIntervalMessage = {
+        return NSLocalizedString("settingsviews_CalenderIntervalMessage", tableName: filename, bundle: Bundle.main, value: "Minimum interval between two calender events (mins)", comment: "When clicking the interval setting, a pop up asks for minimum number of minutes between two calendar events, this is the pop up message - this is used for setting the interval between two calendar events, Speak readings, Apple Watch")
+    }()
+    
     
     // MARK: - Issue Reporting
     

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewAppleWatchSettingsViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewAppleWatchSettingsViewModel.swift
@@ -20,8 +20,11 @@ fileprivate enum Setting:Int, CaseIterable {
     /// should units be displayed yes or no
     case displayUnits = 4
     
+    /// should a visual indicator be shown on the calendar title
+    case displayVisualIndicator = 5
+    
     /// minimum time between two readings, for which event should be created (in minutes)
-    case calendarInterval = 5
+    case calendarInterval = 6
 
 }
 
@@ -66,8 +69,11 @@ class SettingsViewAppleWatchSettingsViewModel: SettingsViewModelProtocol {
         case .displayUnits:
             return Texts_SettingsView.displayUnitInCalendarEvent
             
+        case .displayVisualIndicator:
+            return Texts_SettingsView.displayVisualIndicatorInCalendar
+            
         case .calendarInterval:
-            return Texts_SettingsView.settingsviews_IntervalTitle
+            return Texts_SettingsView.settingsviews_CalenderIntervalTitle
 
         }
 
@@ -107,7 +113,7 @@ class SettingsViewAppleWatchSettingsViewModel: SettingsViewModelProtocol {
         case .calenderId:
             return UITableViewCell.AccessoryType.disclosureIndicator
             
-        case .displayTrend, .displayDelta, .displayUnits:
+        case .displayTrend, .displayDelta, .displayUnits, .displayVisualIndicator:
             return UITableViewCell.AccessoryType.none
             
         case .calendarInterval:
@@ -125,7 +131,7 @@ class SettingsViewAppleWatchSettingsViewModel: SettingsViewModelProtocol {
         case .calenderId:
             return UserDefaults.standard.calenderId
             
-        case .createCalendarEvent, .displayTrend, .displayDelta, .displayUnits:
+        case .createCalendarEvent, .displayTrend, .displayDelta, .displayUnits, .displayVisualIndicator:
             return nil
             
         case .calendarInterval:
@@ -206,6 +212,9 @@ class SettingsViewAppleWatchSettingsViewModel: SettingsViewModelProtocol {
         case .displayUnits:
             return UISwitch(isOn: UserDefaults.standard.displayUnitInCalendarEvent, action: {(isOn:Bool) in UserDefaults.standard.displayUnitInCalendarEvent = isOn})
             
+        case .displayVisualIndicator:
+            return UISwitch(isOn: UserDefaults.standard.displayVisualIndicatorInCalendarEvent, action: {(isOn:Bool) in UserDefaults.standard.displayVisualIndicatorInCalendarEvent = isOn})
+            
         case .calendarInterval:
             return nil
             
@@ -243,7 +252,7 @@ class SettingsViewAppleWatchSettingsViewModel: SettingsViewModelProtocol {
         
         switch setting {
             
-        case .createCalendarEvent, .displayDelta, .displayTrend, .displayUnits:
+        case .createCalendarEvent, .displayDelta, .displayTrend, .displayUnits, .displayVisualIndicator:
             
             // depending on status of authorization, we will either do nothing or show a message
             
@@ -301,7 +310,7 @@ class SettingsViewAppleWatchSettingsViewModel: SettingsViewModelProtocol {
 
         case .calendarInterval:
         
-            return SettingsSelectedRowAction.askText(title: Texts_SettingsView.settingsviews_IntervalTitle, message: Texts_SettingsView.settingsviews_IntervalMessage, keyboardType: .numberPad, text: UserDefaults.standard.calendarInterval.description, placeHolder: "0", actionTitle: nil, cancelTitle: nil, actionHandler: {(interval:String) in if let interval = Int(interval) {UserDefaults.standard.calendarInterval = Int(interval)}}, cancelHandler: nil, inputValidator: nil)
+            return SettingsSelectedRowAction.askText(title: Texts_SettingsView.settingsviews_CalenderIntervalTitle, message: Texts_SettingsView.settingsviews_CalenderIntervalMessage, keyboardType: .numberPad, text: UserDefaults.standard.calendarInterval.description, placeHolder: "0", actionTitle: nil, cancelTitle: nil, actionHandler: {(interval:String) in if let interval = Int(interval) {UserDefaults.standard.calendarInterval = Int(interval)}}, cancelHandler: nil, inputValidator: nil)
 
         }
         

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewSpeakSettingsViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewSpeakSettingsViewModel.swift
@@ -60,7 +60,7 @@ class SettingsViewSpeakSettingsViewModel: NSObject, SettingsViewModelProtocol {
         case .speakDelta:
             return .nothing
         case .speakInterval:
-            return SettingsSelectedRowAction.askText(title: Texts_SettingsView.settingsviews_IntervalTitle, message: Texts_SettingsView.settingsviews_IntervalMessage, keyboardType: .numberPad, text: UserDefaults.standard.speakInterval.description, placeHolder: "0", actionTitle: nil, cancelTitle: nil, actionHandler: {(interval:String) in if let interval = Int(interval) {UserDefaults.standard.speakInterval = Int(interval)}}, cancelHandler: nil, inputValidator: nil)
+            return SettingsSelectedRowAction.askText(title: Texts_SettingsView.settingsviews_SpeakIntervalTitle, message: Texts_SettingsView.settingsviews_SpeakIntervalMessage, keyboardType: .numberPad, text: UserDefaults.standard.speakInterval.description, placeHolder: "0", actionTitle: nil, cancelTitle: nil, actionHandler: {(interval:String) in if let interval = Int(interval) {UserDefaults.standard.speakInterval = Int(interval)}}, cancelHandler: nil, inputValidator: nil)
         case .speakBgReadingLanguage:
             
             //find index for languageCode type currently stored in userdefaults
@@ -106,7 +106,7 @@ class SettingsViewSpeakSettingsViewModel: NSObject, SettingsViewModelProtocol {
         case .speakDelta:
             return Texts_SettingsView.labelSpeakDelta
         case .speakInterval:
-            return Texts_SettingsView.settingsviews_IntervalTitle
+            return Texts_SettingsView.settingsviews_SpeakIntervalTitle
         }
     }
     


### PR DESCRIPTION
- calendar event visual indicator (#411)
- will change colour depending on BG value as per main chart objective values for (urgent high, high, low and urgent low)
- option added to show/hide visual indicator in Calendar Event settings
- small changes made to interval label texts

Co-Authored-By: Gary Dalley <4158482+gonkowonko@users.noreply.github.com>