### PR TITLE
Various fixes and changes

### DIFF
--- a/xdrip/BluetoothTransmitter/CGM/Generic/TransmitterBatteryInfo.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Generic/TransmitterBatteryInfo.swift
@@ -17,7 +17,7 @@ enum TransmitterBatteryInfo: Equatable {
         case .DexcomG4(let level):
             return level.description
         case .DexcomG5(let voltA, let voltB, let res, let runt, let temp):
-            return "VoltageA = " + voltA.description + ", Voltage B = " + voltB.description + ", resistance = " + res.description + ", runtime = " + runt.description + ", temperature = " + temp.description
+            return "Voltage A: " + voltA.description + "0mV\nVoltage B: " + voltB.description + "0mV" + "\nResistance: " + res.description + "\nRuntime: " + (runt != -1 ? runt.description : "n/a") + "\nTemperature: " + temp.description
         case .percentage(let perc):
             return  perc.description + "%"
         }

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Bubble/CGMBubbleTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Bubble/CGMBubbleTransmitter.swift
@@ -212,7 +212,7 @@ class CGMBubbleTransmitter:BluetoothTransmitter, CGMTransmitter {
                                 // if firmware < 2.6, libre2 and libreUS will decrypt fram local
                                 // after decryptFRAM, the libre2 and libreUS 344 will be libre1 344 data format
                                 // firmware >= 2.6, then bubble already decrypted the data, no need for decryption we already have the 344 bytes
-                                if libreSensorType == .libre2 || libreSensorType == .libreUS {
+                                if libreSensorType == .libre2 || libreSensorType == .libreUS || libreSensorType == .libreUSE6 {
                                     
                                     if let firmware = firmware?.toDouble(), firmware < 2.6 {
                                         

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreDataParser.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreDataParser.swift
@@ -223,7 +223,7 @@ class LibreDataParser {
                 
                 libre1DataProcessor(libreSensorSerialNumber: libreSensorSerialNumber, libreSensorType: libreSensorType, libreData: libreData, cgmTransmitterDelegate: cgmTransmitterDelegate, testTimeStamp: testTimeStamp, completionHandler: completionHandler)
                 
-            case .libreUS:// not sure if this works for libreUS
+            case .libreUS, .libreUSE6:// not sure if this works for libreUS
                 
                 // libreUS isn't working yet, create an error and send to delegate
                 cgmTransmitterDelegate?.errorOccurred(xDripError: LibreOOPWebError.libreUSNotSupported)

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorSerialNumber.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorSerialNumber.swift
@@ -108,7 +108,7 @@ public struct LibreSensorSerialNumber: CustomStringConvertible {
             
                 first = "3"
                 
-            case .libre1, .libreUS:
+            case .libre1, .libreUS, .libreUSE6:
                 
                 first = "0"
                 

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorType.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorType.swift
@@ -13,6 +13,8 @@ public enum LibreSensorType: String {
     case libre2    = "9D"
     
     case libreUS   = "E5"
+    
+    case libreUSE6 = "E6"
    
     case libreProH = "70"
     
@@ -31,6 +33,9 @@ public enum LibreSensorType: String {
             
         case .libreUS:
             return "Libre US"
+            
+        case .libreUSE6:
+            return "Libre US E6"
             
         case .libreProH:
             return "Libre PRO H"
@@ -51,7 +56,7 @@ public enum LibreSensorType: String {
         }
         
         // decrypt if libre2 or libreUS
-        if self == .libre2 || self == .libreUS {
+        if self == .libre2 || self == .libreUS || self == .libreUSE6 {
             
             var libreData = rxBuffer.subdata(in: headerLength..<(rxBufferEnd + 1))
 
@@ -118,8 +123,11 @@ public enum LibreSensorType: String {
         case "9D":
             return .libre2
             
-        case "E5", "E6":
+        case "E5":
             return .libreUS
+            
+        case "E6":
+            return .libreUSE6
             
         case "70":
             return .libreProH
@@ -145,7 +153,7 @@ public enum LibreSensorType: String {
         case .libre2:
             return 14
 
-        case .libreUS:
+        case .libreUS, .libreUSE6:
             return nil
 
         case .libreProH:

--- a/xdrip/Core Data/classes/BgReading+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/BgReading+CoreDataClass.swift
@@ -178,15 +178,16 @@ public class BgReading: NSManagedObject {
         if (value > 0) { deltaSign = "+"; }
         
         // quickly check "value" and prevent "-0mg/dl" or "-0.0mmol/l" being displayed
+        // show unitized zero deltas as +0 or +0.0 as per Nightscout format
         if (mgdl) {
             if (value > -1) && (value < 1) {
-                return "0" + (showUnit ? (" " + Texts_Common.mgdl):"");
+                return "+0" + (showUnit ? (" " + Texts_Common.mgdl):"");
             } else {
                 return deltaSign + valueAsString + (showUnit ? (" " + Texts_Common.mgdl):"");
             }
         } else {
             if (value > -0.1) && (value < 0.1) {
-                return "0.0" + (showUnit ? (" " + Texts_Common.mmol):"");
+                return "+0.0" + (showUnit ? (" " + Texts_Common.mmol):"");
             } else {
                 return deltaSign + valueAsString + (showUnit ? (" " + Texts_Common.mmol):"");
             }

--- a/xdrip/Managers/NightScout/Endpoint+NightScout.swift
+++ b/xdrip/Managers/NightScout/Endpoint+NightScout.swift
@@ -9,6 +9,8 @@ extension Endpoint {
     /// - parameters:
     ///     - hostAndScheme : hostname, eg http://www.mysite.com or https://www.mysite.com - must include the scheme - IF HOST DOESN'T START WITH A KNOWN SCHEME, THEN A FATAL ERROR WILL BE THROWN - known scheme's can be found in type EndPointScheme
     ///     - count : maximum number of readings to get
+    ///     - token: the Nightscout token used for authentication (optional)
+    ///     - port: Nightscout server port number (optional)
     static func getEndpointForLatestNSEntries(hostAndScheme:String, count: Int, token: String?) -> Endpoint {
         
         // split hostAndScheme in host and scheme
@@ -30,10 +32,11 @@ extension Endpoint {
         }
         
         return Endpoint(
-            host:host,
-            scheme:scheme!,
+            host: host,
+            scheme: scheme!,
             path: "/api/v1/entries/sgv.json",
-            queryItems: queryItems
+            queryItems: queryItems,
+            port: UserDefaults.standard.nightScoutPort
         )
     }
 }

--- a/xdrip/Managers/NightScout/NightScoutUploadManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutUploadManager.swift
@@ -104,6 +104,7 @@ public class NightScoutUploadManager: NSObject {
         // and nightScoutUrl exists
         guard UserDefaults.standard.nightScoutEnabled, UserDefaults.standard.nightScoutUrl != nil else {return}
 
+        // TODO: crash here
         trace("    setting nightScoutSyncTreatmentsRequired to true, this will also initiate a treatments sync", log: self.oslog, category: ConstantsLog.categoryNightScoutUploadManager, type: .info)
         UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
         

--- a/xdrip/Managers/Speak/BGReadingSpeaker.swift
+++ b/xdrip/Managers/Speak/BGReadingSpeaker.swift
@@ -27,6 +27,11 @@ class BGReadingSpeaker:NSObject {
     /// to solve problem that sometemes UserDefaults key value changes is triggered twice for just one change
     private let keyValueObserverTimeKeeper:KeyValueObserverTimeKeeper = KeyValueObserverTimeKeeper()
     
+    /// speech synthesizer object
+    /// this must be created here instead of locally in the say() function for it to work correctly in iOS16
+    /// https://developer.apple.com/forums/thread/714984
+    private let syn = AVSpeechSynthesizer.init()
+    
     // MARK: - initializer
     
     /// init is private, to avoid creation
@@ -167,7 +172,6 @@ class BGReadingSpeaker:NSObject {
     /// will speak the text, using language code for pronunciation
     private func say(text:String, language:String?) {
         
-        let syn = AVSpeechSynthesizer.init()
         let utterance = AVSpeechUtterance(string: text)
         utterance.rate = 0.51
         utterance.pitchMultiplier = 1

--- a/xdrip/Storyboards/da.lproj/HomeView.strings
+++ b/xdrip/Storyboards/da.lproj/HomeView.strings
@@ -36,5 +36,5 @@
 "success" = "Success";
 "failed" = "Failed";
 "dexcomBatteryTooLow" = "The Transmitter battery is too low!";
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";

--- a/xdrip/Storyboards/de.lproj/HomeView.strings
+++ b/xdrip/Storyboards/de.lproj/HomeView.strings
@@ -110,7 +110,7 @@
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Storyboards/en.lproj/BluetoothPeripheralView.strings
+++ b/xdrip/Storyboards/en.lproj/BluetoothPeripheralView.strings
@@ -40,4 +40,4 @@
 "nfcScanSuccessfulMessage" = "\n✅ Scan successful ✅\n\nClick OK and just wait to allow the sensor to finish connecting via bluetooth.\n\nIn a short while the status should change to 'Connected'.";
 "nfcErrorMessageScanErrorRetrying" = "Sensor scan error\n\nRetrying... # ";
 "nfcErrorMessageScanFailed" = "Sensor scan has failed";
-
+"nonFixedSlopeWarning" = "Multi-point calibration is an advanced feature.\n\nPlease do not use this feature until you have read the calibration section of the online help and understand how it works.";

--- a/xdrip/Storyboards/en.lproj/BluetoothPeripheralView.strings
+++ b/xdrip/Storyboards/en.lproj/BluetoothPeripheralView.strings
@@ -41,3 +41,4 @@
 "nfcErrorMessageScanErrorRetrying" = "Sensor scan error\n\nRetrying... # ";
 "nfcErrorMessageScanFailed" = "Sensor scan has failed";
 "nonFixedSlopeWarning" = "Multi-point calibration is an advanced feature.\n\nPlease do not use this feature until you have read the calibration section of the online help and understand how it works.";
+"warmingUpUntil" = "Warming up until";

--- a/xdrip/Storyboards/en.lproj/HomeView.strings
+++ b/xdrip/Storyboards/en.lproj/HomeView.strings
@@ -38,6 +38,6 @@
 "failed" = "Failed";
 "calibrationNotNecessary" = "When using the native transmitter algorithm, manual calibration is not available.\n\nIf you want to calibrate, you can switch to the xDrip algorithm in the transmitter screen.";
 "dexcomBatteryTooLow" = "The Transmitter battery is too low!";
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 "calibrationNotNecessary" = "When using the native transmitter algorithm, manual calibration is not available.\n\nIf you want to calibrate, you can switch to the xDrip algorithm in the transmitter screen.";

--- a/xdrip/Storyboards/en.lproj/LibreNFC.strings
+++ b/xdrip/Storyboards/en.lproj/LibreNFC.strings
@@ -2,8 +2,7 @@
 "holdTopOfIphoneNearSensor" = "Hold the top of your iPhone near the sensor until it stops vibrating.";
 "deviceMustSupportNFC" = "This iPhone does not support NFC";
 "deviceMustSupportIOS14" = "To connect to Libre 2, this iPhone needs upgrading to iOS14";
-"donotusethelibrelinkapp" = "Connected to Libre 2.\n\nPlease ensure you have disabled bluetooth permission for the Libre app in your iPhone settings.\n\nIf you don't do this, when you scan with the Libre app you will break the connection between %@ and the Libre 2.";
 "scanComplete" = "Sensor scan successful";
 "holdTopOfIphoneNearSensor" = "Hold the top of your iPhone near the sensor until it stops vibrating.";
-"donotusethelibrelinkapp" = "Connected to Libre 2.\n\nPlease ensure you have disabled bluetooth permission for the Libre app in your iPhone settings.\n\nIf you don't do this, when you scan with the Libre app you will break the connection between %@ and the Libre 2.";
+"donotusethelibrelinkapp" = "Connected to Libre 2.\n\nPlease ensure you have disabled bluetooth permission for the Libre app in your iPhone settings.\n\nIf you don't do this, when you scan with the Libre app you will break the connection between %@ and the Libre 2.\n\nPlease note that there is a %@ minute warm-up period after starting a new Libre 2 before you will get readings.";
 "connectedLibre2DoesNotMatchScannedLibre2" = "You have scanned a new Libre sensor, but %@ has connected to a different sensor (probably the previous one).\n\nTo solve this do NOT delete this old sensor just yet. Click 'Disconnect' or 'Stop Scanning', go back to the previous screen and add a new CGM of type Libre 2 and scan the sensor again.\n\n%@ should now try and connect to the new sensor.";

--- a/xdrip/Storyboards/es.lproj/BluetoothPeripheralView.strings
+++ b/xdrip/Storyboards/es.lproj/BluetoothPeripheralView.strings
@@ -29,6 +29,7 @@
 "sensorType" = "Tipo de Sensor:";
 "confirmDisconnectTitle" = "Confirmar Desconexión";
 "confirmDisconnectMessage" = "Haz click en 'Desconectar' para confirmar que deseas desconectar el transmisor.";
+"warmingUpUntil" = "Calentando hasta";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Storyboards/es.lproj/LibreNFC.strings
+++ b/xdrip/Storyboards/es.lproj/LibreNFC.strings
@@ -2,5 +2,5 @@
 "holdTopOfIphoneNearSensor" = "Escanear el sensor con la parte superior de tu iPhone hasta que deje de vibrar";
 "deviceMustSupportNFC" = "Este iPhone no dispone de NFC";
 "deviceMustSupportIOS14" = "Para conectar a un sensor Libre 2, se debe actualizar este iPhone a iOS14";
-"donotusethelibrelinkapp" = "Conectado a tu Libre 2.\n\nPor favor, asegurarse que haya deshabilitado el permiso de bluetooth para la app del Libre en la configuración de tu iPhone.\n\nSi no lo haces, al escanear con la app del Libre, se cortará la conexión entre %@ y tu Libre 2.";
+"donotusethelibrelinkapp" = "Conectado a tu Libre 2.\n\nPor favor, asegurarse que haya deshabilitado el permiso de bluetooth para la app del Libre en la configuración de tu iPhone.\n\nSi no lo haces, al escanear con la app del Libre, se cortará la conexión entre %@ y tu Libre 2.\n\nSi acabas de conectar a un Libre 2 nuevo, no recibirás lecturas hasta que hayan pasado %@ minutos desde que se inició el sensor.";
 "nfcErrorRetryScan" = "Se ha producido un error al escanear el sensor. Haz click en 'Escanear' o si sigue fallando, haz click en 'Atrás', añadir de nuevo el Libre 2 y escanear otra vez.";

--- a/xdrip/Storyboards/fi.lproj/HomeView.strings
+++ b/xdrip/Storyboards/fi.lproj/HomeView.strings
@@ -55,7 +55,7 @@
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Storyboards/fr.lproj/HomeView.strings
+++ b/xdrip/Storyboards/fr.lproj/HomeView.strings
@@ -44,7 +44,7 @@
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Storyboards/it.lproj/HomeView.strings
+++ b/xdrip/Storyboards/it.lproj/HomeView.strings
@@ -126,7 +126,7 @@
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Storyboards/nl.lproj/HomeView.strings
+++ b/xdrip/Storyboards/nl.lproj/HomeView.strings
@@ -44,7 +44,7 @@
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Storyboards/pl-PL.lproj/HomeView.strings
+++ b/xdrip/Storyboards/pl-PL.lproj/HomeView.strings
@@ -126,7 +126,7 @@
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Storyboards/pt.lproj/HomeView.strings
+++ b/xdrip/Storyboards/pt.lproj/HomeView.strings
@@ -44,7 +44,7 @@
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Storyboards/sl.lproj/HomeView.strings
+++ b/xdrip/Storyboards/sl.lproj/HomeView.strings
@@ -126,7 +126,7 @@
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Storyboards/sv.lproj/HomeView.strings
+++ b/xdrip/Storyboards/sv.lproj/HomeView.strings
@@ -44,7 +44,7 @@
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Storyboards/uk.lproj/HomeView.strings
+++ b/xdrip/Storyboards/uk.lproj/HomeView.strings
@@ -94,7 +94,7 @@
 "scanbluetoothdeviceongoing" = "Scanning for Transmitter...";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /// status info : literally 'not known', used if transmitter name is not known
 "notknown" = "Not Known";

--- a/xdrip/Storyboards/zh.lproj/HomeView.strings
+++ b/xdrip/Storyboards/zh.lproj/HomeView.strings
@@ -83,7 +83,7 @@
 "stopSensorConfirmation" = "Are you sure you want to stop the sensor?";
 
 /// When user needs to enter sensor code, to start firefly sensor
-"enterSensorCode" = "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate";
+"enterSensorCode" = "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.";
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 /////   Translation needed - remove this header after translation                       /////

--- a/xdrip/Texts/TextsBluetoothPeripheralView.swift
+++ b/xdrip/Texts/TextsBluetoothPeripheralView.swift
@@ -140,4 +140,8 @@ class Texts_BluetoothPeripheralView {
         return NSLocalizedString("nfcScanNeeded", tableName: filename, bundle: Bundle.main, value: "NFC scan needed", comment: "text in status row, when waiting for a successful NFC scan before starting bluetooth scanning")
     }()
     
+    static let nonFixedSlopeWarning: String = {
+        return NSLocalizedString("nonFixedSlopeWarning", tableName: filename, bundle: Bundle.main, value: "Multi-point calibration is an advanced feature.\n\nPlease do not use this feature until you have read the calibration section of the online help and understand how it works.", comment: "text to inform the user that multi-point calibration is an advanced option and could be dangerous if used incorrectly")
+    }()
+    
 }

--- a/xdrip/Texts/TextsBluetoothPeripheralView.swift
+++ b/xdrip/Texts/TextsBluetoothPeripheralView.swift
@@ -144,4 +144,8 @@ class Texts_BluetoothPeripheralView {
         return NSLocalizedString("nonFixedSlopeWarning", tableName: filename, bundle: Bundle.main, value: "Multi-point calibration is an advanced feature.\n\nPlease do not use this feature until you have read the calibration section of the online help and understand how it works.", comment: "text to inform the user that multi-point calibration is an advanced option and could be dangerous if used incorrectly")
     }()
     
+    static let warmingUpUntil: String = {
+        return NSLocalizedString("warmingUpUntil", tableName: filename, bundle: Bundle.main, value: "Warming up until", comment: "sensor warm-up text")
+    }()
+    
 }

--- a/xdrip/Texts/TextsHomeView.swift
+++ b/xdrip/Texts/TextsHomeView.swift
@@ -169,7 +169,7 @@ enum Texts_HomeView {
     }()
     
     static let enterSensorCode: String = {
-        return NSLocalizedString("enterSensorCode", tableName: filename, bundle: Bundle.main, value: "if you don't have a sensor code use 0000 but be aware that you will not get readings until you calibrate", comment: "When user needs to enter sensor code, to start firefly sensor")
+        return NSLocalizedString("enterSensorCode", tableName: filename, bundle: Bundle.main, value: "If you don't know the sensor code use 0000 but be aware that you will need to manually calibrate before you get readings.", comment: "When user needs to enter sensor code, to start firefly sensor")
     }()
     
     static let stopSensorConfirmation: String = {

--- a/xdrip/Texts/TextsLibreNFC.swift
+++ b/xdrip/Texts/TextsLibreNFC.swift
@@ -21,7 +21,7 @@ class TextsLibreNFC {
     }()
     
     static let donotusethelibrelinkapp: String = {
-        return String(format: NSLocalizedString("donotusethelibrelinkapp", tableName: filename, bundle: Bundle.main, value: "Connected to Libre 2.\n\nPlease ensure you have disabled bluetooth permission for the Libre app in your iPhone settings.\n\nIf you don't do this, when you scan with the Libre app you will break the connection between %@ and the Libre 2.", comment: "After Libre NFC scanning, and after successful bluetooth connection, this message will be shown to explain that he or she should not allow bluetooth permission on the Libre app"), ConstantsHomeView.applicationName)
+        return String(format: NSLocalizedString("donotusethelibrelinkapp", tableName: filename, bundle: Bundle.main, value: "Connected to Libre 2.\n\nPlease ensure you have disabled bluetooth permission for the Libre app in your iPhone settings.\n\nIf you don't do this, when you scan with the Libre app you will break the connection between %@ and the Libre 2.\n\nPlease note that there is a %@ minute warm-up period after starting a new Libre 2 before you will get readings.", comment: "After Libre NFC scanning, and after successful bluetooth connection, this message will be shown to explain that he or she should not allow bluetooth permission on the Libre app"), ConstantsHomeView.applicationName, Int(ConstantsMaster.minimumSensorWarmUpRequiredInMinutes).description)
     }()
     
     static let connectedLibre2DoesNotMatchScannedLibre2: String = {

--- a/xdrip/Utilities/Network/Endpoint.swift
+++ b/xdrip/Utilities/Network/Endpoint.swift
@@ -17,6 +17,9 @@ struct Endpoint {
     /// array of URLQueryItem
     let queryItems: [URLQueryItem]
     
+    /// the Nightscout server port number
+    let port: Int
+    
     /// gets url
     var url: URL? {
         var components = URLComponents()
@@ -24,6 +27,11 @@ struct Endpoint {
         components.host = host
         components.path = path
         components.queryItems = queryItems
+        
+        // add the port number component only if it exists (this avoids URLComponents adding a port number of 0 as port number is stored as non-optional integer in UserDefaults)
+        if port != 0 {
+            components.port = port
+        }
         
         return components.url
     }

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/BluetoothPeripheralViewController.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/BluetoothPeripheralViewController.swift
@@ -1350,6 +1350,13 @@ extension BluetoothPeripheralViewController: UITableViewDataSource, UITableViewD
                     
                     self.bluetoothPeripheral?.blePeripheral.nonFixedSlopeEnabled = isOn
                     
+                    // show the user a warning if they enabled multi-point calibration as this should only be used by advanced users who understand how it works. Too many new users were enabling this and getting bad results.
+                    if isOn {
+                        
+                        self.present(UIAlertController(title: Texts_Common.warning, message: Texts_BluetoothPeripheralView.nonFixedSlopeWarning, actionHandler: nil), animated: true, completion: nil)
+                        
+                    }
+                    
                     // send info to bluetoothPeripheralManager
                     if let bluetoothPeripheral = self.bluetoothPeripheral {
 

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Dexcom/DexcomG5/DexcomG5BluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Dexcom/DexcomG5/DexcomG5BluetoothPeripheralViewModel.swift
@@ -213,6 +213,10 @@ extension DexcomG5BluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
         
         // default value for accessoryView is nil
         cell.accessoryView = nil
+        
+        // create disclosureIndicator in color ConstantsUI.disclosureIndicatorColor
+        // will be used whenever accessoryType is to be set to disclosureIndicator
+        let disclosureAccessoryView = DTCustomColoredAccessory(color: ConstantsUI.disclosureIndicatorColor)
 
         switch getDexcomSection(forSectionInTable: section) {
             
@@ -234,7 +238,8 @@ extension DexcomG5BluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
                 
                 cell.textLabel?.text = Texts_BluetoothPeripheralView.sensorStartDate
                 cell.detailTextLabel?.text = startDateString
-                cell.accessoryType = .none
+                cell.accessoryType = .disclosureIndicator
+                cell.accessoryView = disclosureAccessoryView
                 
             case .transmitterStartDate:
                 
@@ -247,7 +252,8 @@ extension DexcomG5BluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
                 
                 cell.textLabel?.text = Texts_BluetoothPeripheralView.transmittterStartDate
                 cell.detailTextLabel?.text = startDateString
-                cell.accessoryType = .none
+                cell.accessoryType = .disclosureIndicator
+                cell.accessoryView = disclosureAccessoryView
                 
             case .firmWareVersion:
                 
@@ -257,17 +263,13 @@ extension DexcomG5BluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
                 
             case .sensorStatus:
                 
-                // create disclosureIndicator in color ConstantsUI.disclosureIndicatorColor
-                // will be used whenever accessoryType is to be set to disclosureIndicator
-                let disclosureSensorStatusView = DTCustomColoredAccessory(color: ConstantsUI.disclosureIndicatorColor)
-                
                 cell.textLabel?.text = Texts_Common.sensorStatus
                 cell.detailTextLabel?.text = dexcomG5.sensorStatus
                 if cell.detailTextLabel?.text == nil {
                     cell.accessoryType = .none
                 } else {
                     cell.accessoryType = .disclosureIndicator
-                    cell.accessoryView = disclosureSensorStatusView
+                    cell.accessoryView = disclosureAccessoryView
                 }
                 
             case .userOtherApp:
@@ -399,7 +401,31 @@ extension DexcomG5BluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
                 return .showInfoText(title: Texts_Common.sensorStatus, message: "\n" + sensorStatus)
             }
             
-        case .sensorStartDate, .transmitterStartDate, .firmWareVersion, .userOtherApp:
+        case .sensorStartDate:
+            
+            if let startDate = dexcomG5?.sensorStartDate {
+                
+                var startDateString = startDate.toStringInUserLocale(timeStyle: .short, dateStyle: .short)
+                
+                startDateString += "\n\n" + startDate.daysAndHoursAgo() + " " + Texts_HomeView.ago
+                
+                return .showInfoText(title: Texts_BluetoothPeripheralView.sensorStartDate, message: "\n" + startDateString)
+                
+            }
+            
+        case .transmitterStartDate:
+            
+            if let startDate = dexcomG5?.transmitterStartDate {
+                
+                var startDateString = startDate.toStringInUserLocale(timeStyle: .short, dateStyle: .short)
+                
+                startDateString += "\n\n" + startDate.daysAndHoursAgo() + " " + Texts_HomeView.ago
+                
+                return .showInfoText(title: Texts_BluetoothPeripheralView.transmittterStartDate, message: "\n" + startDateString)
+                
+            }
+            
+        case .firmWareVersion, .userOtherApp:
             return .nothing
             
         }

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/Libre2/Libre2BluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Libre/Libre2/Libre2BluetoothPeripheralViewModel.swift
@@ -124,7 +124,7 @@ extension Libre2BluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
             cell.textLabel?.text = Texts_BluetoothPeripheralView.sensorSerialNumber
             cell.detailTextLabel?.text = libre2.blePeripheral.sensorSerialNumber
             cell.accessoryType = .disclosureIndicator
-            cell.accessoryView =  disclosureAccessoryView
+            cell.accessoryView = disclosureAccessoryView
 
         case .sensorStartTime:
             
@@ -133,12 +133,27 @@ extension Libre2BluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
             cell.textLabel?.text = Texts_HomeView.sensorStart
             
             if let sensorTimeInMinutes = libre2.sensorTimeInMinutes {
+                
                 let startDate = Date(timeIntervalSinceNow: -Double(sensorTimeInMinutes*60))
-                sensorStartTimeText = startDate.toStringInUserLocale(timeStyle: .none, dateStyle: .short)
-                sensorStartTimeText += " (" + startDate.daysAndHoursAgo() + ")"
+                
+                if sensorTimeInMinutes < Int(ConstantsMaster.minimumSensorWarmUpRequiredInMinutes) {
+                    
+                    // the Libre 2 is still in the forced warm-up time so let's make it clear to the user
+                    let sensorReadyDateTime = startDate.addingTimeInterval(ConstantsMaster.minimumSensorWarmUpRequiredInMinutes * 60)
+                    sensorStartTimeText = Texts_BluetoothPeripheralView.warmingUpUntil + " " + sensorReadyDateTime.toStringInUserLocale(timeStyle: .short, dateStyle: .none)
+                    
+                } else {
+                    
+                    // Libre 2 is not warming up so let's show the sensor start date and age
+                    sensorStartTimeText = startDate.toStringInUserLocale(timeStyle: .none, dateStyle: .short)
+                    sensorStartTimeText += " (" + startDate.daysAndHoursAgo() + ")"
+                    
+                }
+                
             }
             cell.detailTextLabel?.text = sensorStartTimeText
-            cell.accessoryType = .none
+            cell.accessoryType = .disclosureIndicator
+            cell.accessoryView = disclosureAccessoryView
             
         }
         
@@ -159,12 +174,21 @@ extension Libre2BluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
             
             // serial text could be longer than screen width, clicking the row allows to see it in a pop up with more text place
             if let serialNumber = libre2.blePeripheral.sensorSerialNumber {
-                return .showInfoText(title: Texts_HomeView.info, message: Texts_BluetoothPeripheralView.sensorSerialNumber + " " + serialNumber)
+                return .showInfoText(title: Texts_BluetoothPeripheralView.sensorSerialNumber, message: "\n" + serialNumber)
             }
 
         case .sensorStartTime:
             
-            return .nothing
+            if let sensorTimeInMinutes = libre2.sensorTimeInMinutes {
+                
+                let startDate = Date(timeIntervalSinceNow: -Double(sensorTimeInMinutes*60))
+                
+                var sensorStartTimeText = startDate.toStringInUserLocale(timeStyle: .short, dateStyle: .short)
+                
+                sensorStartTimeText += "\n\n" + startDate.daysAndHoursAgo() + " " + Texts_HomeView.ago
+                
+                return .showInfoText(title: Texts_BluetoothPeripheralView.sensorStartDate, message: "\n" + sensorStartTimeText)
+            }
             
         }
         

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -1992,8 +1992,8 @@ final class RootViewController: UIViewController {
     ///     - forceReset : if true, then force the update to be done even if the main chart is panned back in time (used for the double tap gesture)
     @objc private func updateLabelsAndChart(overrideApplicationState: Bool = false, forceReset: Bool = false) {
         
-        // force treatments sync
-        UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
+        // force treatments sync TODO: crash here
+        // UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
         
         // if glucoseChartManager not nil, then check if panned backward and if so then don't update the chart
         if let glucoseChartManager = glucoseChartManager  {
@@ -2306,7 +2306,7 @@ final class RootViewController: UIViewController {
     ///     - cGMTransmitter is required because startSensor command will be sent also to the transmitter
     private func startSensorAskUserForSensorCode(cGMTransmitter: CGMTransmitter) {
         
-        let alert = UIAlertController(title: Texts_HomeView.enterSensorCode, message: nil, keyboardType:.numberPad, text: nil, placeHolder: "0000", actionTitle: nil, cancelTitle: nil, actionHandler: {
+        let alert = UIAlertController(title: Texts_HomeView.info, message: Texts_HomeView.enterSensorCode, keyboardType:.numberPad, text: nil, placeHolder: "0000", actionTitle: nil, cancelTitle: nil, actionHandler: {
             (text:String) in
             
             if let coreDataManager = self.coreDataManager, let cgmTransmitter = self.bluetoothPeripheralManager?.getCGMTransmitter() {

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewNightScoutSettingsViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewNightScoutSettingsViewModel.swift
@@ -57,7 +57,12 @@ class SettingsViewNightScoutSettingsViewModel {
     private func testNightScoutCredentials() {
         
         // unwrap siteUrl and apiKey
-        guard let siteUrl = UserDefaults.standard.nightScoutUrl else {return}
+        guard var siteUrl = UserDefaults.standard.nightScoutUrl else {return}
+        
+        // add port number if it exists
+        if UserDefaults.standard.nightScoutPort != 0 {
+            siteUrl += ":" + UserDefaults.standard.nightScoutPort.description
+        }
                 
         if let url = URL(string: siteUrl) {
             


### PR DESCRIPTION
- BG speak readings fixed
- Nightscout port now used for follower download mode (entries.json and experiments/test)
- Warning now shown when the user enables multi-point calibration (too many new users were selecting this without understanding how it works)
- Dexcom battery info updated to show n/a for runtime if -1
- improvements to UI for Libre 2 warm-up handling/information
- extended sensor + transmitter start date pop-up information on rowSelectec()