### PR TITLE
Add option to share to Loop just once every 5 minutes

### DIFF
--- a/xdrip/Extensions/UserDefaults.swift
+++ b/xdrip/Extensions/UserDefaults.swift
@@ -291,7 +291,11 @@ extension UserDefaults {
             
         /// timestamp lastest reading shared with Loop
         case timeStampLatestLoopSharedBgReading = "timeStampLatestLoopSharedBgReading"
-            
+        
+        /// Loop sharing will be limited to just once every 5 minutes if true
+        case shareToLoopOnceEvery5Minutes = "shareToLoopOnceEvery5Minutes"
+        
+
         // Trace
         /// should debug level logs be added in trace file or not, and also in NSLog
         case addDebugLevelLogsInTraceFileAndNSLog = "addDebugLevelLogsInTraceFileAndNSLog"
@@ -1653,13 +1657,23 @@ extension UserDefaults {
         }
     }
 
-    /// timestamp lastest reading uploaded to NightScout
+    /// timestamp lastest reading shared with Loop via App Group
     var timeStampLatestLoopSharedBgReading:Date? {
         get {
             return object(forKey: Key.timeStampLatestLoopSharedBgReading.rawValue) as? Date
         }
         set {
             set(newValue, forKey: Key.timeStampLatestLoopSharedBgReading.rawValue)
+        }
+    }
+    
+    /// Loop sharing will be limited to just once every 5 minutes if true - default false
+    var shareToLoopOnceEvery5Minutes: Bool {
+        get {
+            return bool(forKey: Key.shareToLoopOnceEvery5Minutes.rawValue)
+        }
+        set {
+            set(newValue, forKey: Key.shareToLoopOnceEvery5Minutes.rawValue)
         }
     }
     

--- a/xdrip/Storyboards/en.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/en.lproj/SettingsViews.strings
@@ -127,6 +127,7 @@
 "settingsviews_housekeeperRetentionPeriodMessage" = "For how many days should data be stored? (Min 90, Max 365)\n\n(Recommended: 90 days)";
 "suppressUnLockPayLoad" = "Suppress Unlock Payload";
 "suppressLoopShare" = "Suppress Loop Share";
+"shareToLoopOnceEvery5Minutes" = "Share to Loop every 5 mins";
 "Select Time" = "Select Time";
 "Select Value" = "Select Value";
 "expanatoryTextSelectTime" = "As of what time should the value apply";

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -572,6 +572,10 @@ class Texts_SettingsView {
     static let warningLoopDelayAlreadyExists: String = {
         return NSLocalizedString("warningLoopDelayAlreadyExists", tableName: filename, bundle: Bundle.main, value: "There is already a loopDelay for this time.", comment: "When user creates new loopdelay, with a timestamp that already exists - this is the warning text")
     }()
+    
+    static let shareToLoopOnceEvery5Minutes: String = {
+        return NSLocalizedString("shareToLoopOnceEvery5Minutes", tableName: filename, bundle: Bundle.main, value: "Share to Loop every 5 mins", comment: "Should loop data be shared only every 5 minutes")
+    }()
 
     static let nsLog: String = {
         return NSLocalizedString("nslog", tableName: filename, bundle: Bundle.main, value: "NSLog", comment: "deloper settings, row title for NSLog - with NSLog enabled, a developer can view log information as explained here https://github.com/JohanDegraeve/xdripswift/wiki/NSLog")

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewDevelopmentSettingsViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewDevelopmentSettingsViewModel.swift
@@ -17,10 +17,13 @@ fileprivate enum Setting:Int, CaseIterable {
     /// if true, then readings will not be written to shared user defaults (for loop)
     case suppressLoopShare = 4
     
+    /// if true, then readings will only be written to shared user defaults (for loop) every 5 minutes (>4.5 mins to be exact)
+    case shareToLoopOnceEvery5Minutes = 5
+    
     /// to create artificial delay in readings stored in sharedUserDefaults for loop. Minutes - so that Loop receives more smoothed values.
     ///
     /// Default value 0, if used then recommended value is multiple of 5 (eg 5 ot 10)
-    case loopDelay = 5
+    case loopDelay = 6
     
 }
 
@@ -59,6 +62,9 @@ struct SettingsViewDevelopmentSettingsViewModel:SettingsViewModelProtocol {
         case .suppressLoopShare:
             return Texts_SettingsView.suppressLoopShare
             
+        case .shareToLoopOnceEvery5Minutes:
+            return Texts_SettingsView.shareToLoopOnceEvery5Minutes
+            
         case .loopDelay:
             return Texts_SettingsView.loopDelaysScreenTitle
             
@@ -71,7 +77,7 @@ struct SettingsViewDevelopmentSettingsViewModel:SettingsViewModelProtocol {
         
         switch setting {
             
-        case .NSLogEnabled, .OSLogEnabled, .smoothLibreValues, .suppressUnLockPayLoad, .suppressLoopShare:
+        case .NSLogEnabled, .OSLogEnabled, .smoothLibreValues, .suppressUnLockPayLoad, .shareToLoopOnceEvery5Minutes, .suppressLoopShare:
             return UITableViewCell.AccessoryType.none
             
         case .loopDelay:
@@ -86,22 +92,7 @@ struct SettingsViewDevelopmentSettingsViewModel:SettingsViewModelProtocol {
         
         switch setting {
             
-        case .NSLogEnabled:
-            return nil
-            
-        case .OSLogEnabled:
-            return nil
-            
-        case .smoothLibreValues:
-            return nil
-            
-        case .suppressUnLockPayLoad:
-            return nil
-            
-        case .suppressLoopShare:
-            return nil
-            
-        case .loopDelay:
+        case .NSLogEnabled, .OSLogEnabled, .smoothLibreValues, .suppressUnLockPayLoad, .suppressLoopShare, .shareToLoopOnceEvery5Minutes, .loopDelay:
             return nil
             
         }
@@ -154,6 +145,14 @@ struct SettingsViewDevelopmentSettingsViewModel:SettingsViewModelProtocol {
                 
             })
             
+        case .shareToLoopOnceEvery5Minutes:
+            return UISwitch(isOn: UserDefaults.standard.shareToLoopOnceEvery5Minutes, action: {
+                (isOn:Bool) in
+                
+                UserDefaults.standard.shareToLoopOnceEvery5Minutes = isOn
+                
+            })
+            
         case .loopDelay:
             return nil
             
@@ -171,7 +170,7 @@ struct SettingsViewDevelopmentSettingsViewModel:SettingsViewModelProtocol {
         
         switch setting {
             
-        case .NSLogEnabled, .OSLogEnabled, .smoothLibreValues, .suppressUnLockPayLoad, .suppressLoopShare:
+        case .NSLogEnabled, .OSLogEnabled, .smoothLibreValues, .suppressUnLockPayLoad, .shareToLoopOnceEvery5Minutes, .suppressLoopShare:
             return .nothing
             
         case .loopDelay:


### PR DESCRIPTION
- option added to the developer settings to limit sharing BG array to just once every 5 minutes (should maybe move all Loop options to a separate section in the future)
- added as a Loop 3 has removed the check to only calculate Loop cycles every 5 minutes and with the 60 second CGM data from Libre 2 BLE, this causes loop cycles very often and maybe drain some pump batteries.
- note that this new option does not give 5 minute readings per se... it will give Loop the array of last readings (irrespective of if they were every 1 or 5 minutes) every 5 minutes. The user will still see readings every 60 seconds, but they will arrive in blocks every 5 minutes and trigger a Loop cycle.