### PR TITLE
"Sensor Started" breaks Nightscout's plugin

### DIFF
--- a/xdrip/Managers/NightScout/NightScoutUploadManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutUploadManager.swift
@@ -489,7 +489,7 @@ public class NightScoutUploadManager: NSObject {
         
         let dataToUpload = [
             "_id": sensor.id,
-            "eventType": "Sensor Started",
+            "eventType": "Sensor Start",
             "created_at": sensor.startDate.ISOStringFromDate(),
             "enteredBy": ConstantsHomeView.applicationName
         ]


### PR DESCRIPTION
Nightscout upload "Sensor Started" inconsistent with Nightscout's sensorage.js plugin

Changing back to "Start" for [Nightscout's sensorage.js plugin](https://github.com/nightscout/cgm-remote-monitor/blob/a09e586b95065d502390475bb4ec415f95c7eff5/lib/plugins/sensorage.js#L53) to work as previously.