### PR TITLE
New L2 EU patchInfo designation "c5"

### DIFF
--- a/xdrip/BluetoothTransmitter/CGM/Libre/Bubble/CGMBubbleTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Bubble/CGMBubbleTransmitter.swift
@@ -212,7 +212,7 @@ class CGMBubbleTransmitter:BluetoothTransmitter, CGMTransmitter {
                                 // if firmware < 2.6, libre2 and libreUS will decrypt fram local
                                 // after decryptFRAM, the libre2 and libreUS 344 will be libre1 344 data format
                                 // firmware >= 2.6, then bubble already decrypted the data, no need for decryption we already have the 344 bytes
-                                if libreSensorType == .libre2 || libreSensorType == .libreUS || libreSensorType == .libreUSE6 {
+                                if libreSensorType == .libre2 || libreSensorType == .libre2C5 || libreSensorType == .libreUS || libreSensorType == .libreUSE6 {
                                     
                                     if let firmware = firmware?.toDouble(), firmware < 2.6 {
                                         

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreDataParser.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreDataParser.swift
@@ -231,7 +231,7 @@ class LibreDataParser {
                 // should never come here ?
                 trace("in libreDataProcessor, is libreUS but data is not decrypted - no further processing", log: log, category: ConstantsLog.categoryLibreDataParser, type: .info)
                 
-            case .libre2:
+            case .libre2, .libre2C5:
                 
                 // should never come here ?
                 trace("in libreDataProcessor, is libre2 but data is not decrypted - no further processing", log: log, category: ConstantsLog.categoryLibreDataParser, type: .info)

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorSerialNumber.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorSerialNumber.swift
@@ -104,7 +104,7 @@ public struct LibreSensorSerialNumber: CustomStringConvertible {
                 
                 first = "1"
                 
-            case .libre2:
+            case .libre2, .libre2C5:
             
                 first = "3"
                 

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorType.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorType.swift
@@ -6,13 +6,15 @@ import os
 public enum LibreSensorType: String {
     
     // Libre 1
-    case libre1    = "DF"
+    case libre1 = "DF"
     
-    case libre1A2 =  "A2"
+    case libre1A2 = "A2"
     
-    case libre2    = "9D"
+    case libre2 = "9D"
     
-    case libreUS   = "E5"
+    case libre2C5 = "C5"
+    
+    case libreUS = "E5"
     
     case libreUSE6 = "E6"
    
@@ -30,6 +32,9 @@ public enum LibreSensorType: String {
             
         case .libre2:
             return "Libre 2"
+            
+        case .libre2C5:
+            return "Libre 2 C5"
             
         case .libreUS:
             return "Libre US"
@@ -56,7 +61,7 @@ public enum LibreSensorType: String {
         }
         
         // decrypt if libre2 or libreUS
-        if self == .libre2 || self == .libreUS || self == .libreUSE6 {
+        if self == .libre2 || self == .libre2C5 || self == .libreUS || self == .libreUSE6 {
             
             var libreData = rxBuffer.subdata(in: headerLength..<(rxBufferEnd + 1))
 
@@ -123,6 +128,9 @@ public enum LibreSensorType: String {
         case "9D":
             return .libre2
             
+        case "C5":
+            return .libre2C5 // new Libre 2 EU type (May 2023)
+            
         case "E5":
             return .libreUS
             
@@ -150,7 +158,7 @@ public enum LibreSensorType: String {
         case .libre1A2:
             return 14
 
-        case .libre2:
+        case .libre2, .libre2C5:
             return 14
 
         case .libreUS, .libreUSE6:


### PR DESCRIPTION
EU L2 sensors have started appearing * with a new patchInfo configuration starting with c5 instead of the usual/previous 9d.

This commit enables support for these as a new sensor type allowing the serial number to be correctly reported as "3MHxxxxxxx" so that it will connect via BLE.

* these new c5 sensors have first appeared in Portugal in mid May 2023 but have now also started appearing in Germany.