### PR TITLE
Remove unnecessary Google Translate query parameters

### DIFF
--- a/xdrip/Constants/ConstantsHomeView.swift
+++ b/xdrip/Constants/ConstantsHomeView.swift
@@ -27,8 +27,7 @@ enum ConstantsHomeView {
     /// example URL to show the online help in Spanish using Google Translate
     /// https://xdrip4ios-readthedocs-io.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl=es&_x_tr_hl=es&_x_tr_pto=nui
     /// we'll use this to spilt into two separate strings
-    static let onlineHelpURLTranslated1 = "https://xdrip4ios-readthedocs-io.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl="
-    static let onlineHelpURLTranslated2 = "&_x_tr_hl=es&_x_tr_pto=nui"
+    static let onlineHelpURLTranslated = "https://xdrip4ios-readthedocs-io.translate.goog/en/latest/?_x_tr_sl=auto&_x_tr_tl="
 
     /// github.com repository URL for the project
     static let gitHubURL = "https://github.com/JohanDegraeve/xdripswift"

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -64,7 +64,7 @@ final class RootViewController: UIViewController {
         // important to check the the URLs actually exist in ConstansHomeView before trying to open them
         if let languageCode = languageCode, languageCode != ConstantsHomeView.onlineHelpBaseLocale && UserDefaults.standard.translateOnlineHelp {
             
-            guard let url = URL(string: ConstantsHomeView.onlineHelpURLTranslated1 + languageCode + ConstantsHomeView.onlineHelpURLTranslated2) else { return }
+            guard let url = URL(string: ConstantsHomeView.onlineHelpURLTranslated + languageCode) else { return }
             
             UIApplication.shared.open(url)
             

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewHelpSettingModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewHelpSettingModel.swift
@@ -56,7 +56,7 @@ struct SettingsViewHelpSettingsViewModel:SettingsViewModelProtocol {
             // important to check the the URLs actually exist in ConstansHomeView before trying to open them
             if languageCode != ConstantsHomeView.onlineHelpBaseLocale && UserDefaults.standard.translateOnlineHelp {
                 
-                guard let url = URL(string: ConstantsHomeView.onlineHelpURLTranslated1 + languageCode! + ConstantsHomeView.onlineHelpURLTranslated2) else { return .nothing}
+                guard let url = URL(string: ConstantsHomeView.onlineHelpURLTranslated + languageCode!) else { return .nothing }
                 
                 UIApplication.shared.open(url)
                 


### PR DESCRIPTION
Appending the `onlineHelpURLTranslated2` string to the translation URL is not necessary, especially the `_x_tr_hl=es` query parameter, as the Google Translate UI at the top of the page defaults to Spanish rather than the user's native language.