### PR TITLE
update project to work with new iOS17 EKEventStore requirements

### DIFF
--- a/xdrip.xcodeproj/project.pbxproj
+++ b/xdrip.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/xdrip/Storyboards/en.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/en.lproj/SettingsViews.strings
@@ -99,7 +99,8 @@
 "settingsviews_displayTrendInCalendarEvent" = "Display Trend?";
 "displayUnitInCalendarEvent" = "Display Unit?";
 "displayDeltaInCalendarEvent" = "Display Delta?";
-"infoCalendarAccessDeniedByUser" = "You previously denied access to your Calendar.\n\nTo enable it go to your device settings, privacy, calendars and enable it.";
+"infoCalendarAccessDeniedByUser" = "You previously denied access to your calendars.\n\nGo to iPhone Settings > %@ > Calendars and enable full access.";
+"infoCalendarAccessWriteOnly" = "You cannot use Calendar Events until you update the calendar access permission from 'Add Events Only' to 'Full Access'.\n\nGo to iPhone Settings > %@ > Calendars and select 'Full Access'.";
 "infoCalendarAccessRestricted" = "You cannot give authorization to %@ to access your calendar. This is possibly due to active restrictions such as parental controls being in place.";
 "settingsviews_CalenderIntervalTitle" = "Event Interval";
 "settingsviews_CalenderIntervalMessage" = "Minimum interval between two calender events (mins)";

--- a/xdrip/Storyboards/es.lproj/BluetoothPeripheralView.strings
+++ b/xdrip/Storyboards/es.lproj/BluetoothPeripheralView.strings
@@ -30,16 +30,6 @@
 "confirmDisconnectTitle" = "Confirmar Desconexión";
 "confirmDisconnectMessage" = "Haz click en 'Desconectar' para confirmar que deseas desconectar el transmisor.";
 "warmingUpUntil" = "Calentando hasta";
-
-/////////////////////////////////////////////////////////////////////////////////////////////
-/////   Translation needed - remove this header after translation                       /////
-/////////////////////////////////////////////////////////////////////////////////////////////
-
-/// Dexcom bluetooth screen. Is another app used in parallel or not
-"useOtherDexcomApp" = "Read from Dexcom app";
-
-/// cell text, sensor start time
-"sensorStartDate" = "Sensor Started";
-
-/// cell text, transmitter start time
-"transmittterStartDate" = "Transmitter Started";
+"useOtherDexcomApp" = "Usar a la vez la app de Dexcom";
+"sensorStartDate" = "Sensor iniciado";
+"transmittterStartDate" = "Transmisor iniciado";

--- a/xdrip/Storyboards/es.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/es.lproj/SettingsViews.strings
@@ -87,7 +87,8 @@
 "settingsviews_displayTrendInCalendarEvent" = "Mostrar Tendencia?";
 "displayUnitInCalendarEvent" = "Mostrar Unidad?";
 "displayDeltaInCalendarEvent" = "Mostrar Delta?";
-"infoCalendarAccessDeniedByUser" = "Has denegado previamente permiso para acceder al calendario.\n\nPara habilitarlo de nuevo, ir a Configuración en tu iPhone, Privacidad, Calendarios y habilitarlo.";
+"infoCalendarAccessDeniedByUser" = "Has denegado previamente permiso para acceder al calendario.\n\nIr a Configuración iPhone > %@ > Calendarios y habilitarlo.";
+"infoCalendarAccessWriteOnly" = "No puedes usar Eventos de Calendario hasta que actualices los permisos de 'Sólo agregar eventos' a 'Acceso completo'.\n\nIr a Configuración iPhone > %@ > Calendarios y seleccionar 'Acceso completo'.";
 "infoCalendarAccessRestricted" = "No se puede autorizar a que %@ tenga acceso a tu calendario. Podría ser debido a que restricciones tipo Controles Parentales o similares lo están impidiendo.";
 "sectionTitleTrace" = "Rastrear/Issue Reporting";
 "sendTraceFile" = "Enviar Archivo de Rastreo";

--- a/xdrip/Storyboards/nl.lproj/SettingsViews.strings
+++ b/xdrip/Storyboards/nl.lproj/SettingsViews.strings
@@ -83,7 +83,8 @@
 "settingsviews_displayTrendInCalendarEvent" = "Toon Trend?";
 "displayUnitInCalendarEvent" = "Toon Eenheid?";
 "displayDeltaInCalendarEvent" = "Toon Delta?";
-"infoCalendarAccessDeniedByUser" = "In het verleden heb je toegang geweigerd tot je Agenda.\n\nOm toestemming te geven, ga naar iPhone Instellingen, Privacy, Agenda's en schakel in.";
+"infoCalendarAccessDeniedByUser" = "In het verleden heb je toegang geweigerd tot je Agenda.\n\nGa naar iPhone-instellingen > %@ > Agenda's en kies 'Volledige toegang'.";
+"infoCalendarAccessWriteOnly" = "Je kunt Agenda Activiteiten niet gebruiken totdat je de Agenda-toegang hebt gewijzigd van 'Voeg alleen activiteiten toe' naar 'Volledige toegang'.\n\nGa naar iPhone-instellingen > %@ > Agenda's en kies 'Volledige toegang'.";
 "infoCalendarAccessRestricted" = "Geen toegang voor %@ tot je agenda. Dit komt waarschijnlijk door actieve beperkingen zoals Ouderlijk Toezicht.";
 "sectionTitleTrace" = "Probleemrapportage";
 "sendTraceFile" = "Verstuur Probleemrapportage";

--- a/xdrip/Supporting Files/Info.plist
+++ b/xdrip/Supporting Files/Info.plist
@@ -43,8 +43,10 @@
 	<string>Connect to CGM Transmitter and M5Stack</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Connect to CGM Transmitter and M5Stack</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay</string>
 	<key>NSCalendarsUsageDescription</key>
-	<string>To create events with reading values as title, so that it can be viewed on Apple Watch</string>
+	<string>To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Store bloodglucose readings</string>
 	<key>NSHealthUpdateUsageDescription</key>

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -465,7 +465,11 @@ class Texts_SettingsView {
     }()
     
     static let infoCalendarAccessDeniedByUser: String = {
-        return NSLocalizedString("infoCalendarAccessDeniedByUser", tableName: filename, bundle: Bundle.main, value: "You previously denied access to your Calendar.\n\nTo enable it go to your device settings, privacy, calendars and enable it", comment: "If user has earlier denied access to calendar, and then tries to activate creation of events in calendar, this message will be shown")
+        return String(format: NSLocalizedString("infoCalendarAccessDeniedByUser", tableName: filename, bundle: Bundle.main, value: "You previously denied access to your calendars.\n\nGo to iPhone Settings > %@ > Calendars and enable full access.", comment: "If user has earlier denied access to calendar, and then tries to activate creation of events in calendar, this message will be shown"), ConstantsHomeView.applicationName)
+    }()
+    
+    static let infoCalendarAccessWriteOnly: String = {
+        return String(format: NSLocalizedString("infoCalendarAccessWriteOnly", tableName: filename, bundle: Bundle.main, value: "You cannot use Calendar Events until you update the calendar access permission from 'Add Events Only' to 'Full Access'.\n\nGo to iPhone Settings > %@ > Calendars and select 'Full Access'.", comment: "The user needs to update their calendar permissions"), ConstantsHomeView.applicationName)
     }()
     
     static let infoCalendarAccessRestricted: String = {


### PR DESCRIPTION
iOS17-specific NSCalendarsFullAccessUsageDescription key added to info.plist. This will allow the app to ask for Full Access when using iOS17.

![image](https://github.com/JohanDegraeve/xdripswift/assets/37302780/116c2173-aeff-4603-afc3-52e3eeabfb53)

If using iOS17, we will now check to see if Full Access is granted (if an existing user has just updated to iOS17, then it won't be). If not, then calendar events will be disabled (to prevent the calendar from filling up with old events) and we will prompt the user to update their calendar settings from 'Add Events Only' to 'Full Access'. If no access is granted, the existing warning is used.

![image](https://github.com/JohanDegraeve/xdripswift/assets/37302780/f2f2937b-b665-4635-b29e-684ac8c203d4)

Once the update to Full Access in the iPhone Settings, the app will allow normal Calendar Event use again.

if using <=iOS16 we will use the previous/existing workflow but with small corrections to the error messaging if calendar permission is disabled.

Translations added for Spanish and Dutch.