### PR TITLE
Sync the GitHub runner clock with the Windows time server

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Install Project Dependencies
         run: bundle install
 
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
+
       # Create or update identifiers for app
       - name: Fastlane Provision
         run: bundle exec fastlane identifiers

--- a/.github/workflows/build_xdrip.yml
+++ b/.github/workflows/build_xdrip.yml
@@ -89,8 +89,12 @@ jobs:
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
 
       # Install project dependencies
-      - name: Install project dependencies
+      - name: Install Project Dependencies
         run: bundle install
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
       
       # Build signed Xdrip4iOS IPA file
       - name: Fastlane Build & Archive

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Install Project Dependencies
         run: bundle install
 
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
+
       # Create or update certificates for app
       - name: Create Certificates
         run: bundle exec fastlane certs

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -127,6 +127,10 @@ jobs:
 
       - name: Install Project Dependencies
         run: bundle install
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
         
       - name: Validate Fastlane Secrets
         run: |


### PR DESCRIPTION
Adding a step to workflow jobs that interface Apple servers, as a workaround for build issues caused by runner clocks being out of sync. See https://github.com/actions/runner issue number 2996 for details.

name: Sync clock
run: sudo sntp -sS time.windows.com
Added to the following workflows / jobs:

validate_secrets.yml / validate-fastlane-secrets
add_identifiers.yml / identifiers
build_xdrip.yml / build
create_certs.yml / certificates
