### PR TITLE
Use VoltageB instead of VoltageA for Dexcom Transmitter Battery Alarms

### DIFF
--- a/xdrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
@@ -238,7 +238,7 @@ enum CGMTransmitterType:String, CaseIterable {
             return ""
             
         case .dexcom:
-            return "voltA"
+            return "voltB"
             
         case .miaomiao, .Bubble, .Droplet1:
             return "%"

--- a/xdrip/BluetoothTransmitter/CGM/Generic/TransmitterBatteryInfo.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Generic/TransmitterBatteryInfo.swift
@@ -33,9 +33,9 @@ enum TransmitterBatteryInfo: Equatable {
             return ("battery" , percentage)
             
             
-        case .DexcomG5(voltageA: let voltageA, voltageB: _, resist: _, runtime: _, temperature: _):
+        case .DexcomG5(voltageA: _, voltageB: let voltageB, resist: _, runtime: _, temperature: _):
             
-            return ("batteryVoltage" , voltageA)
+            return ("batteryVoltage" , voltageB)
 
             
         case .DexcomG4(level: let level):

--- a/xdrip/Constants/ConstantsDefaultAlertLevels.swift
+++ b/xdrip/Constants/ConstantsDefaultAlertLevels.swift
@@ -1,7 +1,7 @@
 /// default alert levels to be used when creating defalt alert entries
 enum ConstantsDefaultAlertLevels {
     // default battery alert level, below this level an alert should be generated - this default value will be used when changing transmittertype
-    static let defaultBatteryAlertLevelDexcomG5 = 260
+    static let defaultBatteryAlertLevelDexcomG5 = 270
     static let defaultBatteryAlertLevelDexcomG4 = 210
     static let defaultBatteryAlertLevelMiaoMiao = 20
     static let defaultBatteryAlertLevelBubble = 20

--- a/xdrip/Constants/ConstantsDefaultAlertLevels.swift
+++ b/xdrip/Constants/ConstantsDefaultAlertLevels.swift
@@ -1,7 +1,7 @@
 /// default alert levels to be used when creating defalt alert entries
 enum ConstantsDefaultAlertLevels {
     // default battery alert level, below this level an alert should be generated - this default value will be used when changing transmittertype
-    static let defaultBatteryAlertLevelDexcomG5 = 300
+    static let defaultBatteryAlertLevelDexcomG5 = 260
     static let defaultBatteryAlertLevelDexcomG4 = 210
     static let defaultBatteryAlertLevelMiaoMiao = 20
     static let defaultBatteryAlertLevelBubble = 20

--- a/xdrip/Managers/Alerts/AlertKind.swift
+++ b/xdrip/Managers/Alerts/AlertKind.swift
@@ -359,8 +359,8 @@ public enum AlertKind:Int, CaseIterable {
                 switch transmitterBatteryInfo {
                 case .percentage(let percentage):
                     batteryLevelToCheck = percentage
-                case .DexcomG5(let voltageA, _, _, _, _):
-                    batteryLevelToCheck = voltageA
+                case .DexcomG5(_, let voltageB, _, _, _):
+                    batteryLevelToCheck = voltageB
                 case .DexcomG4(let level):
                     batteryLevelToCheck = level
                 }


### PR DESCRIPTION
Also change default alarm threshold to 260 (2600mV)