### PR TITLE
Issue498

### DIFF
--- a/xdrip.xcodeproj/project.pbxproj
+++ b/xdrip.xcodeproj/project.pbxproj
@@ -280,6 +280,12 @@
 		F830992823C32A13005741DF /* TextsWatlaaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F830992723C32A13005741DF /* TextsWatlaaView.swift */; };
 		F830993023C928E0005741DF /* WatlaaBluetoothTransmitterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F830992F23C928E0005741DF /* WatlaaBluetoothTransmitterDelegate.swift */; };
 		F84DDF4B279DF03400F7B5A4 /* TextsNightScout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84DDF4A279DF03400F7B5A4 /* TextsNightScout.swift */; };
+		F855422C2B7182C60058CE09 /* LoopFollowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F855422A2B7182C60058CE09 /* LoopFollowManager.swift */; };
+		F855422E2B756DF40058CE09 /* OmniPodHeartbeatBluetoothTransmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F855422D2B756DF40058CE09 /* OmniPodHeartbeatBluetoothTransmitter.swift */; };
+		F85542302B7573930058CE09 /* OmniPodHeartBeat+BluetoothPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = F855422F2B7573930058CE09 /* OmniPodHeartBeat+BluetoothPeripheral.swift */; };
+		F85542322B7573D20058CE09 /* OmniPodHeartBeat+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85542312B7573D20058CE09 /* OmniPodHeartBeat+CoreDataClass.swift */; };
+		F85542342B7574330058CE09 /* OmniPodHeartBeat+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85542332B7574330058CE09 /* OmniPodHeartBeat+CoreDataProperties.swift */; };
+		F85542362B7575B40058CE09 /* OmniPodHeartBeatBluetoothPeripheralViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85542352B7575B40058CE09 /* OmniPodHeartBeatBluetoothPeripheralViewModel.swift */; };
 		F856CE5B22EDC8E50083E436 /* ConstantsBluetoothPairing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F856CE5A22EDC8E50083E436 /* ConstantsBluetoothPairing.swift */; };
 		F857A32A253E2D9E00951BB2 /* LibreAlgorithmThresholds.swift in Sources */ = {isa = PBXBuildFile; fileRef = F857A329253E2D9E00951BB2 /* LibreAlgorithmThresholds.swift */; };
 		F857A334253F6A7600951BB2 /* LibreCalibrationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F857A333253F6A7500951BB2 /* LibreCalibrationInfo.swift */; };
@@ -498,6 +504,17 @@
 		F8E6C79124CEC2E3007C1199 /* Snooze.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8E6C79324CEC2E3007C1199 /* Snooze.strings */; };
 		F8EA6C8221B723BC0082976B /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EA6C8121B723BC0082976B /* Date.swift */; };
 		F8EA6CA921BBE3010082976B /* UniqueId.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EA6CA821BBE3010082976B /* UniqueId.swift */; };
+		F8EE3E9E2B6831A200B27B96 /* DexcomG7HeartBeat+BluetoothPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3E9C2B6831A200B27B96 /* DexcomG7HeartBeat+BluetoothPeripheral.swift */; };
+		F8EE3E9F2B6831A200B27B96 /* Libre2HeartBeat+BluetoothPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3E9D2B6831A200B27B96 /* Libre2HeartBeat+BluetoothPeripheral.swift */; };
+		F8EE3EA22B68332200B27B96 /* ConstantsHeartBeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3EA12B68332200B27B96 /* ConstantsHeartBeat.swift */; };
+		F8EE3EA62B6833FA00B27B96 /* DexcomG7HeartBeatBluetoothPeripheralViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3EA42B6833FA00B27B96 /* DexcomG7HeartBeatBluetoothPeripheralViewModel.swift */; };
+		F8EE3EA72B6833FA00B27B96 /* Libre3HeartBeatBluetoothPeripheralViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3EA52B6833FA00B27B96 /* Libre3HeartBeatBluetoothPeripheralViewModel.swift */; };
+		F8EE3EAC2B6834FD00B27B96 /* Libre2HeartBeat+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3EA82B6834FD00B27B96 /* Libre2HeartBeat+CoreDataClass.swift */; };
+		F8EE3EAD2B6834FD00B27B96 /* DexcomG7HeartBeat+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3EA92B6834FD00B27B96 /* DexcomG7HeartBeat+CoreDataProperties.swift */; };
+		F8EE3EAE2B6834FD00B27B96 /* DexcomG7HeartBeat+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3EAA2B6834FD00B27B96 /* DexcomG7HeartBeat+CoreDataClass.swift */; };
+		F8EE3EAF2B6834FD00B27B96 /* Libre2HeartBeat+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3EAB2B6834FD00B27B96 /* Libre2HeartBeat+CoreDataProperties.swift */; };
+		F8EE3EB22B683B2100B27B96 /* Libre3HeartbeatBluetoothTransmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3EB02B683B2100B27B96 /* Libre3HeartbeatBluetoothTransmitter.swift */; };
+		F8EE3EB32B683B2100B27B96 /* DexcomG7HeartbeatBluetoothTransmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE3EB12B683B2100B27B96 /* DexcomG7HeartbeatBluetoothTransmitter.swift */; };
 		F8EEDD5422FF685400D2D610 /* NSMutableURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EEDD5322FF685400D2D610 /* NSMutableURLRequest.swift */; };
 		F8EEDD552300136F00D2D610 /* DexcomShareTestResult.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8EEDD572300136F00D2D610 /* DexcomShareTestResult.strings */; };
 		F8EEDD6423020FAD00D2D610 /* NoCalibrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EEDD6323020FAD00D2D610 /* NoCalibrator.swift */; };
@@ -1174,6 +1191,12 @@
 		F83275882546225400D305E6 /* xdrip v14.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "xdrip v14.xcdatamodel"; sourceTree = "<group>"; };
 		F846CDD623046BAE00DCF016 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/SettingsViews.strings; sourceTree = "<group>"; };
 		F84DDF4A279DF03400F7B5A4 /* TextsNightScout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextsNightScout.swift; sourceTree = "<group>"; };
+		F855422A2B7182C60058CE09 /* LoopFollowManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoopFollowManager.swift; sourceTree = "<group>"; };
+		F855422D2B756DF40058CE09 /* OmniPodHeartbeatBluetoothTransmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmniPodHeartbeatBluetoothTransmitter.swift; sourceTree = "<group>"; };
+		F855422F2B7573930058CE09 /* OmniPodHeartBeat+BluetoothPeripheral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OmniPodHeartBeat+BluetoothPeripheral.swift"; sourceTree = "<group>"; };
+		F85542312B7573D20058CE09 /* OmniPodHeartBeat+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OmniPodHeartBeat+CoreDataClass.swift"; sourceTree = "<group>"; };
+		F85542332B7574330058CE09 /* OmniPodHeartBeat+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OmniPodHeartBeat+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		F85542352B7575B40058CE09 /* OmniPodHeartBeatBluetoothPeripheralViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmniPodHeartBeatBluetoothPeripheralViewModel.swift; sourceTree = "<group>"; };
 		F856CE5A22EDC8E50083E436 /* ConstantsBluetoothPairing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsBluetoothPairing.swift; sourceTree = "<group>"; };
 		F857A329253E2D9E00951BB2 /* LibreAlgorithmThresholds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibreAlgorithmThresholds.swift; sourceTree = "<group>"; };
 		F857A333253F6A7500951BB2 /* LibreCalibrationInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LibreCalibrationInfo.swift; sourceTree = "<group>"; };
@@ -1518,6 +1541,17 @@
 		F8E6C79224CEC2E3007C1199 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Snooze.strings; sourceTree = "<group>"; };
 		F8EA6C8121B723BC0082976B /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		F8EA6CA821BBE3010082976B /* UniqueId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniqueId.swift; sourceTree = "<group>"; };
+		F8EE3E9C2B6831A200B27B96 /* DexcomG7HeartBeat+BluetoothPeripheral.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DexcomG7HeartBeat+BluetoothPeripheral.swift"; sourceTree = "<group>"; };
+		F8EE3E9D2B6831A200B27B96 /* Libre2HeartBeat+BluetoothPeripheral.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Libre2HeartBeat+BluetoothPeripheral.swift"; sourceTree = "<group>"; };
+		F8EE3EA12B68332200B27B96 /* ConstantsHeartBeat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstantsHeartBeat.swift; sourceTree = "<group>"; };
+		F8EE3EA42B6833FA00B27B96 /* DexcomG7HeartBeatBluetoothPeripheralViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DexcomG7HeartBeatBluetoothPeripheralViewModel.swift; sourceTree = "<group>"; };
+		F8EE3EA52B6833FA00B27B96 /* Libre3HeartBeatBluetoothPeripheralViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Libre3HeartBeatBluetoothPeripheralViewModel.swift; sourceTree = "<group>"; };
+		F8EE3EA82B6834FD00B27B96 /* Libre2HeartBeat+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Libre2HeartBeat+CoreDataClass.swift"; sourceTree = "<group>"; };
+		F8EE3EA92B6834FD00B27B96 /* DexcomG7HeartBeat+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DexcomG7HeartBeat+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		F8EE3EAA2B6834FD00B27B96 /* DexcomG7HeartBeat+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DexcomG7HeartBeat+CoreDataClass.swift"; sourceTree = "<group>"; };
+		F8EE3EAB2B6834FD00B27B96 /* Libre2HeartBeat+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Libre2HeartBeat+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		F8EE3EB02B683B2100B27B96 /* Libre3HeartbeatBluetoothTransmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Libre3HeartbeatBluetoothTransmitter.swift; sourceTree = "<group>"; };
+		F8EE3EB12B683B2100B27B96 /* DexcomG7HeartbeatBluetoothTransmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DexcomG7HeartbeatBluetoothTransmitter.swift; sourceTree = "<group>"; };
 		F8EEDD5322FF685400D2D610 /* NSMutableURLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSMutableURLRequest.swift; sourceTree = "<group>"; };
 		F8EEDD562300136F00D2D610 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/DexcomShareTestResult.strings; sourceTree = "<group>"; };
 		F8EEDD612300139800D2D610 /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/DexcomShareTestResult.strings; sourceTree = "<group>"; };
@@ -2741,6 +2775,7 @@
 		F8E51D5B2448D8A3001C9E5A /* Loop */ = {
 			isa = PBXGroup;
 			children = (
+				F855422A2B7182C60058CE09 /* LoopFollowManager.swift */,
 				F8E0475D28CC8E330049D8C9 /* GlucoseData+LoopShare.swift */,
 				F8E51D5C2448D8B5001C9E5A /* LoopManager.swift */,
 			);
@@ -2750,6 +2785,7 @@
 		F8EA6C7D21B70DEA0082976B /* Constants */ = {
 			isa = PBXGroup;
 			children = (
+				F8EE3EA12B68332200B27B96 /* ConstantsHeartBeat.swift */,
 				476FE8FE2B2F1D1700537E0A /* ConstantsFollower.swift */,
 				F88EC279260120C000DF0EAF /* ConstantsAlerts.swift */,
 				F8A1585022EDB597007F5B5D /* ConstantsBGGraphBuilder.swift */,
@@ -2830,16 +2866,22 @@
 				F816E12B2439DFBA009EE65B /* DexcomG4+CoreDataProperties.swift */,
 				F8DF765223E34F4500063910 /* DexcomG5+CoreDataClass.swift */,
 				F8DF765423E34FD500063910 /* DexcomG5+CoreDataProperties.swift */,
+				F8EE3EAA2B6834FD00B27B96 /* DexcomG7HeartBeat+CoreDataClass.swift */,
+				F8EE3EA92B6834FD00B27B96 /* DexcomG7HeartBeat+CoreDataProperties.swift */,
 				F816E119243923B2009EE65B /* Droplet+CoreDataClass.swift */,
 				F816E11B2439243B009EE65B /* Droplet+CoreDataProperties.swift */,
 				F816E0F624367137009EE65B /* GNSEntry+CoreDataClass.swift */,
 				F816E0F424367131009EE65B /* GNSEntry+CoreDataProperties.swift */,
 				F80D916324F5B3DE006840B5 /* Libre2+CoreDataClass.swift */,
 				F80D916224F5B3DE006840B5 /* Libre2+CoreDataProperties.swift */,
+				F8EE3EA82B6834FD00B27B96 /* Libre2HeartBeat+CoreDataClass.swift */,
+				F8EE3EAB2B6834FD00B27B96 /* Libre2HeartBeat+CoreDataProperties.swift */,
 				F804870A2336D90200EBDDB7 /* M5Stack+CoreDataClass.swift */,
 				F804870B2336D90200EBDDB7 /* M5Stack+CoreDataProperties.swift */,
 				F8C97851242AA70C00A09483 /* MiaoMiao+CoreDataClass.swift */,
 				F8C97852242AA70C00A09483 /* MiaoMiao+CoreDataProperties.swift */,
+				F85542312B7573D20058CE09 /* OmniPodHeartBeat+CoreDataClass.swift */,
+				F85542332B7574330058CE09 /* OmniPodHeartBeat+CoreDataProperties.swift */,
 				F85DC2F121CFE3D400B9F74A /* Sensor+CoreDataClass.swift */,
 				F85DC2E921CFE2F500B9F74A /* Sensor+CoreDataProperties.swift */,
 				F85FF3D0252F9FF9004E6FF1 /* SnoozeParameters+CoreDataClass.swift */,
@@ -2863,6 +2905,36 @@
 				F8025E5221EE8CE500ECF0C0 /* Protocol */,
 			);
 			path = Calibration;
+			sourceTree = "<group>";
+		};
+		F8EE3E9B2B68312600B27B96 /* HeartBeat */ = {
+			isa = PBXGroup;
+			children = (
+				F8EE3E9C2B6831A200B27B96 /* DexcomG7HeartBeat+BluetoothPeripheral.swift */,
+				F8EE3E9D2B6831A200B27B96 /* Libre2HeartBeat+BluetoothPeripheral.swift */,
+				F855422F2B7573930058CE09 /* OmniPodHeartBeat+BluetoothPeripheral.swift */,
+			);
+			path = HeartBeat;
+			sourceTree = "<group>";
+		};
+		F8EE3EA02B68329300B27B96 /* HeartBeat */ = {
+			isa = PBXGroup;
+			children = (
+				F8EE3EB12B683B2100B27B96 /* DexcomG7HeartbeatBluetoothTransmitter.swift */,
+				F8EE3EB02B683B2100B27B96 /* Libre3HeartbeatBluetoothTransmitter.swift */,
+				F855422D2B756DF40058CE09 /* OmniPodHeartbeatBluetoothTransmitter.swift */,
+			);
+			path = HeartBeat;
+			sourceTree = "<group>";
+		};
+		F8EE3EA32B6833B400B27B96 /* HeartBeat */ = {
+			isa = PBXGroup;
+			children = (
+				F8EE3EA42B6833FA00B27B96 /* DexcomG7HeartBeatBluetoothPeripheralViewModel.swift */,
+				F8EE3EA52B6833FA00B27B96 /* Libre3HeartBeatBluetoothPeripheralViewModel.swift */,
+				F85542352B7575B40058CE09 /* OmniPodHeartBeatBluetoothPeripheralViewModel.swift */,
+			);
+			path = HeartBeat;
 			sourceTree = "<group>";
 		};
 		F8F1670F27274067001AA3D8 /* Generic */ = {
@@ -2922,6 +2994,7 @@
 		F8F971AD23A5914C00C3F17D /* BluetoothPeripheral */ = {
 			isa = PBXGroup;
 			children = (
+				F8EE3E9B2B68312600B27B96 /* HeartBeat */,
 				F8F971AE23A5914C00C3F17D /* CGM */,
 				F8F971B323A5914C00C3F17D /* Generic */,
 				F8F971AF23A5914C00C3F17D /* M5 */,
@@ -2977,6 +3050,7 @@
 		F8F971B923A5915900C3F17D /* BluetoothTransmitter */ = {
 			isa = PBXGroup;
 			children = (
+				F8EE3EA02B68329300B27B96 /* HeartBeat */,
 				F8F971BA23A5915900C3F17D /* CGM */,
 				F8F971FF23A5915900C3F17D /* Generic */,
 				F8F971F523A5915900C3F17D /* M5Stack */,
@@ -3175,6 +3249,7 @@
 		F8F9723623A5928D00C3F17D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				F8EE3EA32B6833B400B27B96 /* HeartBeat */,
 				F8DF766923ED9AF100063910 /* CGM */,
 				F8F9723723A5928D00C3F17D /* M5Stack */,
 				F8F9723A23A5934300C3F17D /* M5StickC */,
@@ -3562,6 +3637,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8BDD450221CAA64006EAB84 /* TextsCommon.swift in Sources */,
+				F8EE3EA72B6833FA00B27B96 /* Libre3HeartBeatBluetoothPeripheralViewModel.swift in Sources */,
 				F81D6D4E22BFC762005EFAE2 /* TextsDexcomShareTestResult.swift in Sources */,
 				F8A5EEC2257D18DC0085E660 /* LibreNFCDelegate.swift in Sources */,
 				F8F9720523A5915900C3F17D /* TransmitterMessage.swift in Sources */,
@@ -3593,10 +3669,12 @@
 				F8A2BC1A25DB0C28001D1E78 /* CGMAtomTransmitterDelegate.swift in Sources */,
 				47046EA42A6E8BA700A6F736 /* TextsBgReadings.swift in Sources */,
 				F8E0475E28CC8E330049D8C9 /* GlucoseData+LoopShare.swift in Sources */,
+				F85542322B7573D20058CE09 /* OmniPodHeartBeat+CoreDataClass.swift in Sources */,
 				F816E1002436734C009EE65B /* CGMGNSEntryTransmitterDelegate.swift in Sources */,
 				F82842322752CBE00097E0C9 /* DexcomSessionStopTxMessage.swift in Sources */,
 				F8C97853242AA70D00A09483 /* MiaoMiao+CoreDataClass.swift in Sources */,
 				F8F9720D23A5915900C3F17D /* ResetMessage.swift in Sources */,
+				F8EE3EA22B68332200B27B96 /* ConstantsHeartBeat.swift in Sources */,
 				F85FF3D7252FB1C0004E6FF1 /* SnoozeParametersAccessor.swift in Sources */,
 				F866974C28679A0100025441 /* LoopDelayScheduleViewController.swift in Sources */,
 				F8C97856242AA86B00A09483 /* CGMMiaoMiaoTransmitterDelegate.swift in Sources */,
@@ -3625,6 +3703,7 @@
 				F85DC2ED21CFE2F500B9F74A /* BgReading+CoreDataProperties.swift in Sources */,
 				F8A2BC0D25DB0B12001D1E78 /* Atom+BluetoothPeripheral.swift in Sources */,
 				F8F9723123A5915900C3F17D /* M5StackAuthenticateTXMessage.swift in Sources */,
+				F8EE3EAE2B6834FD00B27B96 /* DexcomG7HeartBeat+CoreDataClass.swift in Sources */,
 				F8F9721223A5915900C3F17D /* FirmwareVersionTxMessage.swift in Sources */,
 				F80D916824F7086D006840B5 /* Libre2BluetoothPeripheralViewModel.swift in Sources */,
 				F857A334253F6A7600951BB2 /* LibreCalibrationInfo.swift in Sources */,
@@ -3678,6 +3757,8 @@
 				4752B4062635878E0081D551 /* SettingsViewStatisticsSettingsViewModel.swift in Sources */,
 				F897AAF92200F2D200CDDD10 /* CBPeripheralState.swift in Sources */,
 				F858CCED25AE4CD100786B91 /* LibreOOPWebError.swift in Sources */,
+				F85542362B7575B40058CE09 /* OmniPodHeartBeatBluetoothPeripheralViewModel.swift in Sources */,
+				F8EE3EAC2B6834FD00B27B96 /* Libre2HeartBeat+CoreDataClass.swift in Sources */,
 				D4FD899727772F9100689788 /* TreatmentEntryAccessor.swift in Sources */,
 				F8F971B623A5914D00C3F17D /* M5Stack+BluetoothPeripheral.swift in Sources */,
 				F830992323C291EE005741DF /* Watlaa+BluetoothPeripheral.swift in Sources */,
@@ -3705,6 +3786,7 @@
 				F8A1587322EDC893007F5B5D /* ConstantsDexcomShare.swift in Sources */,
 				F8A1586F22EDC7EE007F5B5D /* ConstantsSuspensionPrevention.swift in Sources */,
 				F8B3A82D227F07D6004BA588 /* SettingsNavigationController.swift in Sources */,
+				F8EE3EA62B6833FA00B27B96 /* DexcomG7HeartBeatBluetoothPeripheralViewModel.swift in Sources */,
 				D482BD942776153F003C4FB2 /* TreatmentsNavigationController.swift in Sources */,
 				F80ED2EC236F68F90005C035 /* SettingsViewM5StackBluetoothSettingsViewModel.swift in Sources */,
 				F8BECB05235CE5D80060DAE1 /* GlucoseChartManager.swift in Sources */,
@@ -3737,6 +3819,7 @@
 				476FE8FF2B2F1D1700537E0A /* ConstantsFollower.swift in Sources */,
 				F8EEDD5422FF685400D2D610 /* NSMutableURLRequest.swift in Sources */,
 				F897AAFB2201018800CDDD10 /* String.swift in Sources */,
+				F85542342B7574330058CE09 /* OmniPodHeartBeat+CoreDataProperties.swift in Sources */,
 				F8B3A847227F090E004BA588 /* SettingsViewNightScoutSettingsViewModel.swift in Sources */,
 				F8B3A79622635A25004BA588 /* AlertEntry+CoreDataClass.swift in Sources */,
 				F8A2BC3725DB0D6D001D1E78 /* BluetoothPeripheralManager+CGMMiaoMiaoTransmitterDelegate.swift in Sources */,
@@ -3762,9 +3845,11 @@
 				4733B93E2AD17C99001D609D /* FollowerBgReading.swift in Sources */,
 				F85FB769255DE14600D1C39E /* ConstantsLibreSmoothing.swift in Sources */,
 				F8F1671B272B3E4F001AA3D8 /* DexcomBackfillStream.swift in Sources */,
+				F85542302B7573930058CE09 /* OmniPodHeartBeat+BluetoothPeripheral.swift in Sources */,
 				F8DF766023E38FC100063910 /* BLEPeripheral+CoreDataClass.swift in Sources */,
 				F80ED2EE236F68F90005C035 /* SettingsViewM5StackWiFiSettingsViewModel.swift in Sources */,
 				F8FDD6CB2553385000625B49 /* Array.swift in Sources */,
+				F8EE3EB32B683B2100B27B96 /* DexcomG7HeartbeatBluetoothTransmitter.swift in Sources */,
 				F8A389C823203E3E0010F405 /* ConstantsM5Stack.swift in Sources */,
 				F898EDEA233F53BF00BFB79B /* UIButton.swift in Sources */,
 				F81F9FF822861E6D0028C70F /* KeyValueObserverTimeKeeper.swift in Sources */,
@@ -3772,6 +3857,7 @@
 				F8E6C78C24CDDB83007C1199 /* SnoozeViewController.swift in Sources */,
 				F8AF11F824B1E6EE00AE5BA2 /* XdripError.swift in Sources */,
 				F830990523B94ED7005741DF /* TimeScheduleViewController.swift in Sources */,
+				F855422C2B7182C60058CE09 /* LoopFollowManager.swift in Sources */,
 				F8A2BC2F25DB0D6D001D1E78 /* BluetoothPeripheralManager+CGMBlueReaderTransmitterDelegate.swift in Sources */,
 				F8F9722123A5915900C3F17D /* LibreSensorSerialNumber.swift in Sources */,
 				F8A1586722EDB8BF007F5B5D /* ConstantsHomeView.swift in Sources */,
@@ -3795,6 +3881,7 @@
 				D484BC292774F783008490E9 /* TreatmentsInsertViewController.swift in Sources */,
 				F816E0FE24367338009EE65B /* GNSEntry+BluetoothPeripheral.swift in Sources */,
 				F8B3A808227A2933004BA588 /* SettingsSelectedRowAction.swift in Sources */,
+				F8EE3EAD2B6834FD00B27B96 /* DexcomG7HeartBeat+CoreDataProperties.swift in Sources */,
 				F8A5EEB2257CEC290085E660 /* LibreNFC.swift in Sources */,
 				F816E0F02433C31B009EE65B /* Blucon+CoreDataProperties.swift in Sources */,
 				F8A2BC3925DB0D6D001D1E78 /* BluetoothPeripheralManager+CGMLibre2TransmitterDelegate.swift in Sources */,
@@ -3810,6 +3897,8 @@
 				F8E3A2AB23DA520B00E5E98A /* ConstantsWatch.swift in Sources */,
 				F8F9721523A5915900C3F17D /* PairRequestTxMessage.swift in Sources */,
 				F8BECB12235CEA9B0060DAE1 /* TimeInterval.swift in Sources */,
+				F8EE3E9E2B6831A200B27B96 /* DexcomG7HeartBeat+BluetoothPeripheral.swift in Sources */,
+				F8EE3E9F2B6831A200B27B96 /* Libre2HeartBeat+BluetoothPeripheral.swift in Sources */,
 				F8F1670C27273774001AA3D8 /* GlucoseBackfillRxMessage.swift in Sources */,
 				F8F9720823A5915900C3F17D /* BatteryStatusTxMessage.swift in Sources */,
 				F8CB59C6273ECFE500BA199E /* DexcomG6GlucoseDataRxMessage.swift in Sources */,
@@ -3837,6 +3926,7 @@
 				F8B3A834227F08AC004BA588 /* PickerViewData.swift in Sources */,
 				F8177025248ED4DE00AA3600 /* Libre1DerivedAlgorithmParameters.swift in Sources */,
 				D40C3DA4277542C400111B73 /* TreatmentEntry+CoreDataClass.swift in Sources */,
+				F8EE3EB22B683B2100B27B96 /* Libre3HeartbeatBluetoothTransmitter.swift in Sources */,
 				F808592D23677D6A00F3829D /* ChartPoint.swift in Sources */,
 				F8A2BC0425DB093B001D1E78 /* Atom+CoreDataClass.swift in Sources */,
 				F8F9722823A5915900C3F17D /* BluconUtilities.swift in Sources */,
@@ -3883,6 +3973,7 @@
 				F8B3A81E227DEC92004BA588 /* BgReadingsAccessor.swift in Sources */,
 				D41F32942827332000861B3D /* DataExporter.swift in Sources */,
 				4733B9402AD17D15001D609D /* FollowerDelegate.swift in Sources */,
+				F8EE3EAF2B6834FD00B27B96 /* Libre2HeartBeat+CoreDataProperties.swift in Sources */,
 				F8F1671327274557001AA3D8 /* DexcomCalibrationRxMessage.swift in Sources */,
 				F8E51D63244B3386001C9E5A /* MiaoMiaoResponseType.swift in Sources */,
 				F821CF6B229FC22D005C1E43 /* Endpoint.swift in Sources */,
@@ -3891,6 +3982,7 @@
 				F8297F59238EE14E00D74D66 /* TextsBluetoothPeripheralsView.swift in Sources */,
 				47FB28082636B04200042FFB /* StatisticsManager.swift in Sources */,
 				F80D916424F5B3DE006840B5 /* Libre2+CoreDataProperties.swift in Sources */,
+				F855422E2B756DF40058CE09 /* OmniPodHeartbeatBluetoothTransmitter.swift in Sources */,
 				F898EDEC233F549100BFB79B /* UIBarButtonItem.swift in Sources */,
 				F816E0E42432A4FA009EE65B /* CGMBluconTransmitterDelegate.swift in Sources */,
 				F8A389CF232AE2EA0010F405 /* M5StackSettingsViewController.swift in Sources */,

--- a/xdrip.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xdrip.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "db51c407d3be4a051484a141bf0bff36c43d3b1e",
-        "version" : "1.8.0"
+        "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
+        "version" : "1.8.1"
       }
     },
     {

--- a/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralCategory.swift
+++ b/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralCategory.swift
@@ -9,6 +9,10 @@ enum BluetoothPeripheralCategory: String, CaseIterable {
     /// this is the category for M5Stack ad M5StickC
     case M5Stack = "M5Stack"
     
+    /// for using a a bluetooth device as heartbeat : whenever the device sends someting over a read characteristic, then xDrip4iOS will wake up
+    /// Heartbeat also works for connect and disconnect
+    case HeartBeat = "HeartBeat"
+    
     /// returns index in list of BluetoothPeripheralCategory's
     func index() -> Int {
         

--- a/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
+++ b/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
@@ -12,7 +12,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
     
     /// M5StickC
     case M5StickCType = "M5StickC"
-
+    
     /// Libre 2
     case Libre2Type = "Libre 2 Direct"
     
@@ -39,13 +39,21 @@ enum BluetoothPeripheralType: String, CaseIterable {
     
     /// GNSentry
     case GNSentryType = "GNSentry"
-      
+    
     /// watlaa master
     case WatlaaType = "Watlaa"
     
     /// Atom
     case AtomType = "Atom"
-
+    
+    /// to use a Libre 3 as heartbeat
+    case Libre3HeartBeatType = "Libre 3 HeartBeat"
+    
+    /// DexcomG7 heartbeat
+    case DexcomG7HeartBeatType = "Dexcom G7 HeartBeat"
+    
+    case OmniPodHeartBeatType = "OmniPod HeartBeat"
+    
     /// - returns: the BluetoothPeripheralViewModel. If nil then there's no specific settings for the tpe of bluetoothPeripheral
     func viewModel() -> BluetoothPeripheralViewModel? {
         
@@ -74,7 +82,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
             
         case .GNSentryType:
             return GNSEntryBluetoothPeripheralViewModel()
-         
+            
         case .BlueReaderType:
             return nil
             
@@ -90,23 +98,31 @@ enum BluetoothPeripheralType: String, CaseIterable {
         case .AtomType:
             return AtomBluetoothPeripheralViewModel()
             
+        case .Libre3HeartBeatType:
+            return Libre3HeartBeatBluetoothPeripheralViewModel()
+            
+        case .DexcomG7HeartBeatType:
+            return DexcomG7HeartBeatBluetoothPeripheralViewModel()
+            
+        case .OmniPodHeartBeatType:
+            return OmniPodHeartBeatBluetoothPeripheralViewModel()
         }
         
     }
     
     func createNewBluetoothPeripheral(withAddress address: String, withName name: String, nsManagedObjectContext: NSManagedObjectContext) -> BluetoothPeripheral {
-    
+        
         switch self {
             
         case .M5StackType:
             
-           let newM5Stack = M5Stack(address: address, name: name, textColor: UserDefaults.standard.m5StackTextColor ?? ConstantsM5Stack.defaultTextColor, backGroundColor: ConstantsM5Stack.defaultBackGroundColor, rotation: ConstantsM5Stack.defaultRotation, brightness: 100, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
+            let newM5Stack = M5Stack(address: address, name: name, textColor: UserDefaults.standard.m5StackTextColor ?? ConstantsM5Stack.defaultTextColor, backGroundColor: ConstantsM5Stack.defaultBackGroundColor, rotation: ConstantsM5Stack.defaultRotation, brightness: 100, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
             
             // assign password stored in UserDefaults (might be nil)
             newM5Stack.blepassword = UserDefaults.standard.m5StackBlePassword
-    
+            
             return newM5Stack
-
+            
         case .M5StickCType:
             
             return M5StickC(address: address, name: name, textColor: UserDefaults.standard.m5StackTextColor ?? ConstantsM5Stack.defaultTextColor, backGroundColor: ConstantsM5Stack.defaultBackGroundColor, rotation: ConstantsM5Stack.defaultRotation, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
@@ -134,7 +150,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
         case .GNSentryType:
             
             return GNSEntry(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
-  
+            
         case .BlueReaderType:
             
             return BlueReader(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
@@ -155,10 +171,20 @@ enum BluetoothPeripheralType: String, CaseIterable {
             
             return Atom(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
             
+        case .Libre3HeartBeatType:
+            
+            return Libre2HeartBeat(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
+            
+        case .DexcomG7HeartBeatType:
+            return DexcomG7HeartBeat(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
+            
+        case .OmniPodHeartBeatType:
+            return OmniPodHeartBeat(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
+            
         }
         
     }
-
+    
     /// to which category of bluetoothperipherals does this type belong (M5Stack, CGM, ...)
     func category() -> BluetoothPeripheralCategory {
         
@@ -170,6 +196,9 @@ enum BluetoothPeripheralType: String, CaseIterable {
         case .DexcomType, .BubbleType, .MiaoMiaoType, .BluconType, .GNSentryType, .BlueReaderType, .DropletType, .DexcomG4Type, .WatlaaType, .Libre2Type, .AtomType:
             return .CGM
             
+        case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
+            return .HeartBeat
+            
         }
         
     }
@@ -179,12 +208,12 @@ enum BluetoothPeripheralType: String, CaseIterable {
         
         switch self {
             
-        case .M5StackType, .M5StickCType, .WatlaaType, .BubbleType, .MiaoMiaoType, .GNSentryType, .BlueReaderType, .DropletType, .Libre2Type, .AtomType:
+        case .M5StackType, .M5StickCType, .WatlaaType, .BubbleType, .MiaoMiaoType, .GNSentryType, .BlueReaderType, .DropletType, .Libre2Type, .AtomType, .OmniPodHeartBeatType:
             return false
             
-        case .DexcomType, .BluconType, .DexcomG4Type:
+        case .DexcomType, .BluconType, .DexcomG4Type, .Libre3HeartBeatType, .DexcomG7HeartBeatType:
             return true
-
+            
         }
         
     }
@@ -212,7 +241,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
             return nil
             
         case .DexcomG4Type:
-
+            
             let regex = try! NSRegularExpression(pattern: "[a-zA-Z0-9]", options: .caseInsensitive)
             if !transmitterId.validate(withRegex: regex) {
                 return Texts_ErrorMessages.DexcomTransmitterIDInvalidCharacters
@@ -224,6 +253,10 @@ enum BluetoothPeripheralType: String, CaseIterable {
             
         case .M5StackType, .M5StickCType, .WatlaaType, .BubbleType, .MiaoMiaoType, .GNSentryType, .BlueReaderType, .DropletType, .Libre2Type, .AtomType:
             // no transmitter id means no validation to do
+            return nil
+            
+        case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
+            // transmitter id is used to create expected device name, could be anything apparently
             return nil
             
         case .BluconType:
@@ -241,7 +274,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
         }
         
     }
-    
+        
     /// is it web oop supported or not.
     func canWebOOP() -> Bool {
         
@@ -253,45 +286,51 @@ enum BluetoothPeripheralType: String, CaseIterable {
         case .BubbleType, .MiaoMiaoType, .AtomType, .DexcomType:
             return true
             
+        case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
+            // to be able to recalibrate values received from libreview
+            return false
+            
         case .Libre2Type:
             // oop web can still be used for Libre2 because in the end the data received is Libre 1 format, we can use oop web to get slope parameters
             return true
-                        
+            
         }
         
     }
     
     /// can use non fixed slopes or not
     func canUseNonFixedSlope() -> Bool {
-       
-       switch self {
-           
-       case .M5StackType, .M5StickCType, .DexcomG4Type, .DexcomType:
-           return false
-           
-       case .BubbleType, .MiaoMiaoType, .WatlaaType, .BluconType, .BlueReaderType, .DropletType , .GNSentryType, .AtomType:
-           return true
         
-       case .Libre2Type:
+        switch self {
+            
+        case .M5StackType, .M5StickCType, .DexcomG4Type, .DexcomType, .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
+            return false
+            
+        case .BubbleType, .MiaoMiaoType, .WatlaaType, .BluconType, .BlueReaderType, .DropletType , .GNSentryType, .AtomType:
             return true
-
-       }
-       
+            
+        case .Libre2Type:
+            return true
+            
+        }
+        
     }
     
     /// needs an NFC scan before connecting via BLE, or not
     func needsNFCScanToConnect() -> Bool {
-       
-       switch self {
-           
-       case .M5StackType, .M5StickCType, .DexcomG4Type, .DexcomType, .BubbleType, .MiaoMiaoType, .WatlaaType, .BluconType, .BlueReaderType, .DropletType , .GNSentryType, .AtomType:
-           return false
         
-       case .Libre2Type:
+        switch self {
+            
+        case .M5StackType, .M5StickCType, .DexcomG4Type, .DexcomType, .BubbleType, .MiaoMiaoType, .WatlaaType, .BluconType, .BlueReaderType, .DropletType , .GNSentryType, .AtomType, .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
+            return false
+            
+        case .Libre2Type:
             return true
-
-       }
-       
+            
+        }
+        
     }
     
 }
+
+

--- a/xdrip/BluetoothPeripheral/HeartBeat/DexcomG7HeartBeat+BluetoothPeripheral.swift
+++ b/xdrip/BluetoothPeripheral/HeartBeat/DexcomG7HeartBeat+BluetoothPeripheral.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension DexcomG7HeartBeat: BluetoothPeripheral {
+        
+    func bluetoothPeripheralType() -> BluetoothPeripheralType {
+        
+        return .DexcomG7HeartBeatType
+        
+    }
+    
+}

--- a/xdrip/BluetoothPeripheral/HeartBeat/Libre2HeartBeat+BluetoothPeripheral.swift
+++ b/xdrip/BluetoothPeripheral/HeartBeat/Libre2HeartBeat+BluetoothPeripheral.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Libre2HeartBeat: BluetoothPeripheral {
+        
+    func bluetoothPeripheralType() -> BluetoothPeripheralType {
+        
+        return .Libre3HeartBeatType
+        
+    }
+    
+}

--- a/xdrip/BluetoothPeripheral/HeartBeat/OmniPodHeartBeat+BluetoothPeripheral.swift
+++ b/xdrip/BluetoothPeripheral/HeartBeat/OmniPodHeartBeat+BluetoothPeripheral.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension OmniPodHeartBeat: BluetoothPeripheral {
+        
+    func bluetoothPeripheralType() -> BluetoothPeripheralType {
+        
+        return .OmniPodHeartBeatType
+        
+    }
+    
+}

--- a/xdrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
@@ -238,7 +238,7 @@ enum CGMTransmitterType:String, CaseIterable {
             return ""
             
         case .dexcom:
-            return "voltA"
+            return "voltB"
             
         case .miaomiao, .Bubble, .Droplet1:
             return "%"

--- a/xdrip/BluetoothTransmitter/CGM/Generic/TransmitterBatteryInfo.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Generic/TransmitterBatteryInfo.swift
@@ -33,9 +33,9 @@ enum TransmitterBatteryInfo: Equatable {
             return ("battery" , percentage)
             
             
-        case .DexcomG5(voltageA: let voltageA, voltageB: _, resist: _, runtime: _, temperature: _):
+        case .DexcomG5(voltageA: _, voltageB: let voltageB, resist: _, runtime: _, temperature: _):
             
-            return ("batteryVoltage" , voltageA)
+            return ("batteryVoltage" , voltageB)
 
             
         case .DexcomG4(level: let level):

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Libre2/CGMLibre2Transmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Libre2/CGMLibre2Transmitter.swift
@@ -10,13 +10,13 @@ class CGMLibre2Transmitter:BluetoothTransmitter, CGMTransmitter {
     // MARK: - properties
     
     /// service to be discovered
-    private let CBUUID_Service_Libre2: String = "FDE3"
+    private let CBUUID_Service_OmniPod: String = "FDE3"
     
     /// receive characteristic
-    private let CBUUID_ReceiveCharacteristic_Libre2: String = "F002"
+    private let CBUUID_ReceiveCharacteristic_OmniPod: String = "F002"
     
     /// write characteristic
-    private let CBUUID_WriteCharacteristic_Libre2: String = "F001"
+    private let CBUUID_WriteCharacteristic_OmniPod: String = "F001"
     
     /// how many bytes should we receive from Libre 2
     private let expectedBufferSize = 46
@@ -101,7 +101,7 @@ class CGMLibre2Transmitter:BluetoothTransmitter, CGMTransmitter {
         // initialize webOOPEnabled
         self.webOOPEnabled = webOOPEnabled ?? false
 
-        super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: nil, servicesCBUUIDs: [CBUUID(string: CBUUID_Service_Libre2)], CBUUID_ReceiveCharacteristic: CBUUID_ReceiveCharacteristic_Libre2, CBUUID_WriteCharacteristic: CBUUID_WriteCharacteristic_Libre2, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
+        super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: nil, servicesCBUUIDs: [CBUUID(string: CBUUID_Service_OmniPod)], CBUUID_ReceiveCharacteristic: CBUUID_ReceiveCharacteristic_OmniPod, CBUUID_WriteCharacteristic: CBUUID_WriteCharacteristic_OmniPod, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
         
     }
     
@@ -358,11 +358,11 @@ class CGMLibre2Transmitter:BluetoothTransmitter, CGMTransmitter {
     }
     
     func getCBUUID_Service() -> String {
-        return CBUUID_Service_Libre2
+        return CBUUID_Service_OmniPod
     }
     
     func getCBUUID_Receive() -> String {
-        return CBUUID_ReceiveCharacteristic_Libre2
+        return CBUUID_ReceiveCharacteristic_OmniPod
     }
 
 }

--- a/xdrip/BluetoothTransmitter/Generic/BluetoothTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/Generic/BluetoothTransmitter.swift
@@ -69,7 +69,7 @@ class BluetoothTransmitter: NSObject, CBCentralManagerDelegate, CBPeripheralDele
     ///     - CBUUID_ReceiveCharacteristic: receive characteristic uuid
     ///     - CBUUID_WriteCharacteristic: write characteristic uuid
     ///     - bluetoothTransmitterDelegate : a BluetoothTransmitterDelegate
-    init(addressAndName:BluetoothTransmitter.DeviceAddressAndName, CBUUID_Advertisement:String?, servicesCBUUIDs:[CBUUID], CBUUID_ReceiveCharacteristic:String, CBUUID_WriteCharacteristic:String, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate) {
+    init(addressAndName:BluetoothTransmitter.DeviceAddressAndName, CBUUID_Advertisement:String?, servicesCBUUIDs:[CBUUID]?, CBUUID_ReceiveCharacteristic:String, CBUUID_WriteCharacteristic:String, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate) {
         
         switch addressAndName {
             

--- a/xdrip/BluetoothTransmitter/Generic/BluetoothTransmitterDelegate.swift
+++ b/xdrip/BluetoothTransmitter/Generic/BluetoothTransmitterDelegate.swift
@@ -29,4 +29,7 @@ protocol BluetoothTransmitterDelegate: AnyObject {
     /// to pass some text error message, delegate can decide to show to user, log, ...
     func error(message: String)
 
+    /// peripheral used as heartbeat, this is the heartbeat
+    func heartBeat()
+    
 }

--- a/xdrip/BluetoothTransmitter/HeartBeat/DexcomG7HeartbeatBluetoothTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/HeartBeat/DexcomG7HeartbeatBluetoothTransmitter.swift
@@ -1,0 +1,82 @@
+//
+//  DexcomG7HeartbeatBluetoothTransmitter.swift
+//
+
+import Foundation
+import os
+import CoreBluetooth
+import AVFoundation
+
+/**
+ DexcomG7HeartbeatBluetoothTransmitter is not a real CGMTransmitter but used as workaround to make clear in bluetoothperipheral manager that libreview is used as CGM
+ */
+class DexcomG7HeartbeatBluetoothTransmitter: BluetoothTransmitter {
+    
+    // MARK: - properties
+    
+    /// service CBUUID
+    private let CBUUID_Service_G7: String = "F8083532-849E-531C-C594-30F1F86A4EA5"
+    
+    /// advertisement CBUUID
+    private let CBUUID_Advertisement_G7: String = "FEBC"
+
+    /// receive characteristic - this is the characteristic for the one minute reading
+    private let CBUUID_ReceiveCharacteristic_G7: String = "F8083535-849E-531C-C594-30F1F86A4EA5" // authentication characteristic
+    
+    /// not really useful
+    private let CBUUID_WriteCharacteristic_G7: String = "F8083535-849E-531C-C594-30F1F86A4EA5"
+    
+    /// for trace
+    private let log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryHeartBeatG7)
+    
+    /// when was the last heartbeat
+    private var lastHeartBeatTimeStamp: Date
+
+    // MARK: - Initialization
+    /// - parameters:
+    ///     - address: if already connected before, then give here the address that was received during previous connect, if not give nil
+    ///     - name : if already connected before, then give here the name that was received during previous connect, if not give nil
+    ///     - transmitterID: should be the name of the libre 3 transmitter as seen in the iOS settings, doesn't need to be the full name, 3-5 characters should be ok
+    ///     - bluetoothTransmitterDelegate : a bluetoothTransmitterDelegate
+    init(address:String?, name: String?, transmitterID:String, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate) {
+
+        var newAddressAndName:BluetoothTransmitter.DeviceAddressAndName = BluetoothTransmitter.DeviceAddressAndName.notYetConnected(expectedName: transmitterID)
+        
+        // if address not nil, then it's about connecting to a device that was already connected to before. We don't know the exact device name, so better to set it to nil. It will be assigned the real value during connection process
+        if let address = address {
+            newAddressAndName = BluetoothTransmitter.DeviceAddressAndName.alreadyConnectedBefore(address: address, name: nil)
+        }
+        
+        // initially last heartbeat was never (ie 1 1 1970)
+        self.lastHeartBeatTimeStamp = Date(timeIntervalSince1970: 0)
+
+        super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: CBUUID_Advertisement_G7, servicesCBUUIDs: [CBUUID(string: CBUUID_Service_G7)], CBUUID_ReceiveCharacteristic: CBUUID_ReceiveCharacteristic_G7, CBUUID_WriteCharacteristic: CBUUID_WriteCharacteristic_G7, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
+        
+    }
+    
+    // MARK: CBCentralManager overriden functions
+    
+    override func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+
+        //super.peripheral(peripheral, didUpdateValueFor: characteristic, error: error)
+
+        // trace the received value and uuid
+        if let value = characteristic.value {
+            trace("in peripheralDidUpdateValueFor, characteristic = %{public}@, data = %{public}@", log: log, category: ConstantsLog.categoryHeartBeatG7, type: .info, String(describing: characteristic.uuid), value.hexEncodedString())
+        }
+
+        // this is the trigger for calling the heartbeat
+        if (Date()).timeIntervalSince(lastHeartBeatTimeStamp) > ConstantsHeartBeat.minimumTimeBetweenTwoHeartBeats {
+            
+            // sleep for a second to allow Loop to read the readings and upload them to NS
+            Thread.sleep(forTimeInterval: 1)
+
+            self.bluetoothTransmitterDelegate?.heartBeat()
+
+            lastHeartBeatTimeStamp = Date()
+
+        }
+        
+    }
+            
+}

--- a/xdrip/BluetoothTransmitter/HeartBeat/Libre3HeartbeatBluetoothTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/HeartBeat/Libre3HeartbeatBluetoothTransmitter.swift
@@ -56,21 +56,6 @@ class Libre3HeartBeatBluetoothTransmitter: BluetoothTransmitter {
     
     // MARK: CBCentralManager overriden functions
     
-    override func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-
-        super.centralManager(central, didConnect: peripheral)
-        
-        // this is the trigger for calling the heartbeat
-        if (Date()).timeIntervalSince(lastHeartBeatTimeStamp) > ConstantsHeartBeat.minimumTimeBetweenTwoHeartBeats {
-            
-            bluetoothTransmitterDelegate?.heartBeat()
-            
-            lastHeartBeatTimeStamp = Date()
-            
-        }
-
-    }
-    
     override func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
 
         // trace the received value and uuid
@@ -80,6 +65,9 @@ class Libre3HeartBeatBluetoothTransmitter: BluetoothTransmitter {
 
         // this is the trigger for calling the heartbeat
         if (Date()).timeIntervalSince(lastHeartBeatTimeStamp) > ConstantsHeartBeat.minimumTimeBetweenTwoHeartBeats {
+            
+            // sleep for a second to allow the official app to upload to LibreView
+            Thread.sleep(forTimeInterval: 1)
             
             bluetoothTransmitterDelegate?.heartBeat()
             

--- a/xdrip/BluetoothTransmitter/HeartBeat/Libre3HeartbeatBluetoothTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/HeartBeat/Libre3HeartbeatBluetoothTransmitter.swift
@@ -1,0 +1,92 @@
+//
+//  Libre3HeartBeat+BluetoothPeripheral.swift
+//  xdrip
+//
+//  Created by Johan Degraeve on 06/08/2023.
+//  Copyright © 2023 Johan Degraeve. All rights reserved.
+//
+
+import Foundation
+import os
+import CoreBluetooth
+import AVFoundation
+
+class Libre3HeartBeatBluetoothTransmitter: BluetoothTransmitter {
+    
+    // MARK: - properties
+    
+    /// advertisement UUID unknown
+    private let CBUUID_Advertisement_Libre3: String? = nil
+
+    /// receive characteristic - this is the characteristic for the one minute reading
+    private let CBUUID_ReceiveCharacteristic_Libre3: String = "0898177A-EF89-11E9-81B4-2A2AE2DBCCE4"
+    
+    /// write characteristic - we will not write, but the parent class needs a write characteristic, use the same as the one used for Libre 3
+    private let CBUUID_WriteCharacteristic_Libre3: String = "F001"
+    
+    /// for trace
+    private let log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryHeartBeatLibre3)
+    
+    /// when was the last heartbeat
+    private var lastHeartBeatTimeStamp: Date
+
+    // MARK: - Initialization
+    /// - parameters:
+    ///     - address: if already connected before, then give here the address that was received during previous connect, if not give nil
+    ///     - name : if already connected before, then give here the name that was received during previous connect, if not give nil
+    ///     - transmitterID: should be the name of the libre 3 transmitter as seen in the iOS settings, doesn't need to be the full name, 3-5 characters should be ok
+    ///     - bluetoothTransmitterDelegate : a bluetoothTransmitterDelegate
+    init(address:String?, name: String?, transmitterID:String, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate) {
+
+        // if it's a new device being scanned for, then use name ABBOTT. It will connect to anything that starts with name ABBOTT
+        var newAddressAndName:BluetoothTransmitter.DeviceAddressAndName = BluetoothTransmitter.DeviceAddressAndName.notYetConnected(expectedName: transmitterID)
+        
+        // if address not nil, then it's about connecting to a device that was already connected to before. We don't know the exact device name, so better to set it to nil. It will be assigned the real value during connection process
+        if let address = address {
+            newAddressAndName = BluetoothTransmitter.DeviceAddressAndName.alreadyConnectedBefore(address: address, name: nil)
+        }
+        
+        // initially last heartbeat was never (ie 1 1 1970)
+        self.lastHeartBeatTimeStamp = Date(timeIntervalSince1970: 0)
+
+        // using nil as servicesCBUUIDs, that works.
+        super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: CBUUID_Advertisement_Libre3, servicesCBUUIDs: nil, CBUUID_ReceiveCharacteristic: CBUUID_ReceiveCharacteristic_Libre3, CBUUID_WriteCharacteristic: CBUUID_WriteCharacteristic_Libre3, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
+        
+    }
+    
+    // MARK: CBCentralManager overriden functions
+    
+    override func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+
+        super.centralManager(central, didConnect: peripheral)
+        
+        // this is the trigger for calling the heartbeat
+        if (Date()).timeIntervalSince(lastHeartBeatTimeStamp) > ConstantsHeartBeat.minimumTimeBetweenTwoHeartBeats {
+            
+            bluetoothTransmitterDelegate?.heartBeat()
+            
+            lastHeartBeatTimeStamp = Date()
+            
+        }
+
+    }
+    
+    override func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+
+        // trace the received value and uuid
+        if let value = characteristic.value {
+            trace("in peripheralDidUpdateValueFor, characteristic = %{public}@, data = %{public}@", log: log, category: ConstantsLog.categoryBlueToothTransmitter, type: .info, String(describing: characteristic.uuid), value.hexEncodedString())
+        }
+
+        // this is the trigger for calling the heartbeat
+        if (Date()).timeIntervalSince(lastHeartBeatTimeStamp) > ConstantsHeartBeat.minimumTimeBetweenTwoHeartBeats {
+            
+            bluetoothTransmitterDelegate?.heartBeat()
+            
+            lastHeartBeatTimeStamp = Date()
+            
+        }
+        
+    }
+    
+}

--- a/xdrip/BluetoothTransmitter/HeartBeat/OmniPodHeartbeatBluetoothTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/HeartBeat/OmniPodHeartbeatBluetoothTransmitter.swift
@@ -1,0 +1,92 @@
+//
+//  OmniPodHeartBeatTransmitter.swift
+//  xdrip
+//
+//  Created by Johan Degraeve on 06/08/2023.
+//  Copyright © 2023 Johan Degraeve. All rights reserved.
+//
+
+import Foundation
+import os
+import CoreBluetooth
+import AVFoundation
+
+class OmniPodHeartBeatTransmitter: BluetoothTransmitter {
+    
+    // MARK: - properties
+    
+    /// service to be discovered
+    private let CBUUID_Service_OmniPod: String = "1A7E4024-E3ED-4464-8B7E-751E03D0DC5F"
+
+    /// advertisement
+    private let CBUUID_Advertisement_OmniPod: String? = "00004024-0000-1000-8000-00805f9b34fb"
+
+    /// receive characteristic
+    private let CBUUID_ReceiveCharacteristic_OmniPod: String = "1A7E2442-E3ED-4464-8B7E-751E03D0DC5F"
+    
+    /// write characteristic - we will not write, but the parent class needs a write characteristic, use the same as the one used for Libre
+    private let CBUUID_WriteCharacteristic_OmniPod: String = "F001"
+    
+    /// for trace
+    private let log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryHeartBeatOmnipod)
+    
+    /// when was the last heartbeat
+    private var lastHeartBeatTimeStamp: Date
+
+    // MARK: - Initialization
+    /// - parameters:
+    ///     - address: if already connected before, then give here the address that was received during previous connect, if not give nil
+    ///     - name : if already connected before, then give here the name that was received during previous connect, if not give nil
+    ///     - bluetoothTransmitterDelegate : a bluetoothTransmitterDelegate
+    init(address:String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate) {
+
+        // then device name of each omnipod contains "TWI BOARD"
+        var newAddressAndName:BluetoothTransmitter.DeviceAddressAndName = BluetoothTransmitter.DeviceAddressAndName.notYetConnected(expectedName: "BOARD")
+        
+        // if address not nil, then it's about connecting to a device that was already connected to before. We don't know the exact device name, so better to set it to nil. It will be assigned the real value during connection process
+        if let address = address {
+            newAddressAndName = BluetoothTransmitter.DeviceAddressAndName.alreadyConnectedBefore(address: address, name: nil)
+        }
+        
+        // initially last heartbeat was never (ie 1 1 1970)
+        self.lastHeartBeatTimeStamp = Date(timeIntervalSince1970: 0)
+
+        super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: CBUUID_Advertisement_OmniPod, servicesCBUUIDs: [CBUUID(string: CBUUID_Service_OmniPod)], CBUUID_ReceiveCharacteristic: CBUUID_ReceiveCharacteristic_OmniPod, CBUUID_WriteCharacteristic: CBUUID_WriteCharacteristic_OmniPod, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
+        
+    }
+    
+    // MARK: CBCentralManager overriden functions
+    
+    override func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+
+        super.centralManager(central, didConnect: peripheral)
+        
+        // this is a trigger for calling the heartbeat
+        if (Date()).timeIntervalSince(lastHeartBeatTimeStamp) > ConstantsHeartBeat.minimumTimeBetweenTwoHeartBeats {
+            
+            bluetoothTransmitterDelegate?.heartBeat()
+            
+            lastHeartBeatTimeStamp = Date()
+            
+        }
+
+    }
+    
+
+    
+    override func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+
+        super.peripheral(peripheral, didUpdateValueFor: characteristic, error: error)
+
+        // this is a trigger for calling the heartbeat
+        if (Date()).timeIntervalSince(lastHeartBeatTimeStamp) > ConstantsHeartBeat.minimumTimeBetweenTwoHeartBeats {
+            
+            bluetoothTransmitterDelegate?.heartBeat()
+            
+            lastHeartBeatTimeStamp = Date()
+            
+        }
+        
+    }
+    
+}

--- a/xdrip/BluetoothTransmitter/M5Stack/M5StackBluetoothTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/M5Stack/M5StackBluetoothTransmitter.swift
@@ -410,6 +410,9 @@ final class M5StackBluetoothTransmitter: BluetoothTransmitter {
             // M5Stack is sending batteryLevel, which is in the second byte
             m5StackBluetoothTransmitterDelegate?.receivedBattery(level: receivedBatteryLevel, m5StackBluetoothTransmitter: self)
             
+        case .heartbeat:
+            // this is a trigger for calling the heartbeat
+            bluetoothTransmitterDelegate?.heartBeat()
         }
 
     }

--- a/xdrip/BluetoothTransmitter/M5Stack/M5StackTransmitterOpCode.swift
+++ b/xdrip/BluetoothTransmitter/M5Stack/M5StackTransmitterOpCode.swift
@@ -99,6 +99,9 @@ enum M5StackTransmitterOpCodeRx: UInt8, CaseIterable {
     /// M5Stack sending battery level
     case readBatteryLevelRx = 0x20
 
+    /// received heartbeat
+    case heartbeat = 0x21
+
 }
 
 extension M5StackTransmitterOpCodeRx: CustomStringConvertible {
@@ -121,6 +124,8 @@ extension M5StackTransmitterOpCodeRx: CustomStringConvertible {
             return "readAllParametersRx"
         case .readBatteryLevelRx:
             return "readBatteryLevelRx"
+        case .heartbeat:
+            return "heartbeat"
         }
     }
 }

--- a/xdrip/Constants/ConstantsDefaultAlertLevels.swift
+++ b/xdrip/Constants/ConstantsDefaultAlertLevels.swift
@@ -1,7 +1,7 @@
 /// default alert levels to be used when creating defalt alert entries
 enum ConstantsDefaultAlertLevels {
     // default battery alert level, below this level an alert should be generated - this default value will be used when changing transmittertype
-    static let defaultBatteryAlertLevelDexcomG5 = 300
+    static let defaultBatteryAlertLevelDexcomG5 = 270
     static let defaultBatteryAlertLevelDexcomG4 = 210
     static let defaultBatteryAlertLevelMiaoMiao = 20
     static let defaultBatteryAlertLevelBubble = 20

--- a/xdrip/Constants/ConstantsHeartBeat.swift
+++ b/xdrip/Constants/ConstantsHeartBeat.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum ConstantsHeartBeat {
+    
+    /// minimum time between two heartbeats
+    static let minimumTimeBetweenTwoHeartBeats = TimeInterval(30)
+    
+    
+}
+

--- a/xdrip/Constants/ConstantsLog.swift
+++ b/xdrip/Constants/ConstantsLog.swift
@@ -166,7 +166,7 @@ enum ConstantsLog {
 	/// for use in DataExporter
 	static let categoryDataExporter =                           "DataExporter             "
 
-    // for use in LoopManager
+    /// for use in LoopManager
     static let categoryLoopManager =                            "LoopManager              "
     
     /// for use in Bg Readings view
@@ -175,5 +175,16 @@ enum ConstantsLog {
     /// SettingsViewCalendarEventsSettingsViewModel logging
     static let categorySettingsViewDataSourceSettingsViewModel =         "SettingsViewDataSourceSettingsViewModel"
     
+    /// for use in Libre3HeartBeatTransmitter
+    static let categoryHeartBeatLibre3 =                       "HeartBeatLibre3          "
+    
+    /// for use in DexcomG7HeartBeatTransmitter
+    static let categoryHeartBeatG7 =                           "HeartBeatG7              "
+    
+    /// for use in LibreViewFollowManager
+    static let categoryLoopFollowManager =                     "LoopFollowManager        "
+    
+    /// for use in Omni¨PodHeartBeatTransmitter
+    static let categoryHeartBeatOmnipod =                      "HeartBeatOmnipod         "
 }
 

--- a/xdrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
@@ -68,6 +68,15 @@ extension BLEPeripheral {
     // a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
     @NSManaged public var atom: Atom?
     
+    // a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
+    @NSManaged public var libre2heartbeat: Libre2HeartBeat?
+    
+    // a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
+    @NSManaged public var dexcomG7HeartBeat: DexcomG7HeartBeat?
+    
+    // a BLEPeripheral should only have one of dexcomG5, watlaa, m5Stack, ...
+    @NSManaged public var omniPodHeartBeat: OmniPodHeartBeat?
+    
     /// sensorSerialNumber of last sensor that was read
     @NSManaged public var sensorSerialNumber: String?
 

--- a/xdrip/Core Data/classes/DexcomG7HeartBeat+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/DexcomG7HeartBeat+CoreDataClass.swift
@@ -1,0 +1,22 @@
+import Foundation
+import CoreData
+
+public class DexcomG7HeartBeat: NSManagedObject {
+    
+    /// create DexcomG7HeartBeat
+    /// - parameters:
+    init(address: String, name: String, alias: String?, nsManagedObjectContext:NSManagedObjectContext) {
+        
+        let entity = NSEntityDescription.entity(forEntityName: "DexcomG7HeartBeat", in: nsManagedObjectContext)!
+        
+        super.init(entity: entity, insertInto: nsManagedObjectContext)
+        
+        blePeripheral = BLEPeripheral(address: address, name: name, alias: nil, bluetoothPeripheralType: .DexcomG7HeartBeatType, nsManagedObjectContext: nsManagedObjectContext)
+        
+    }
+    
+    private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
+    
+}

--- a/xdrip/Core Data/classes/DexcomG7HeartBeat+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/DexcomG7HeartBeat+CoreDataProperties.swift
@@ -1,0 +1,20 @@
+//
+//  DexcomG7HeartBeat+CoreDataProperties.swift
+//
+//
+//  Created by Johan Degraeve on 08/02/2024
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension DexcomG7HeartBeat {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<DexcomG7HeartBeat> {
+        return NSFetchRequest<DexcomG7HeartBeat>(entityName: "DexcomG7HeartBeat")
+    }
+
+    @NSManaged public var blePeripheral: BLEPeripheral
+}

--- a/xdrip/Core Data/classes/Libre2HeartBeat+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/Libre2HeartBeat+CoreDataClass.swift
@@ -1,0 +1,22 @@
+import Foundation
+import CoreData
+
+public class Libre2HeartBeat: NSManagedObject {
+    
+    /// create Libre2HeartBeat
+    /// - parameters:
+    init(address: String, name: String, alias: String?, nsManagedObjectContext:NSManagedObjectContext) {
+        
+        let entity = NSEntityDescription.entity(forEntityName: "Libre2HeartBeat", in: nsManagedObjectContext)!
+        
+        super.init(entity: entity, insertInto: nsManagedObjectContext)
+        
+        blePeripheral = BLEPeripheral(address: address, name: name, alias: nil, bluetoothPeripheralType: .Libre3HeartBeatType, nsManagedObjectContext: nsManagedObjectContext)
+        
+    }
+    
+    private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
+    
+}

--- a/xdrip/Core Data/classes/Libre2HeartBeat+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/Libre2HeartBeat+CoreDataProperties.swift
@@ -1,0 +1,21 @@
+//
+//  Libre2HeartBeat+CoreDataProperties.swift
+//  
+//
+//  Created by Johan Degraeve on 06/08/2023.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Libre2HeartBeat {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Libre2HeartBeat> {
+        return NSFetchRequest<Libre2HeartBeat>(entityName: "Libre2HeartBeat")
+    }
+
+    @NSManaged public var blePeripheral: BLEPeripheral
+
+}

--- a/xdrip/Core Data/classes/OmniPodHeartBeat+CoreDataClass.swift
+++ b/xdrip/Core Data/classes/OmniPodHeartBeat+CoreDataClass.swift
@@ -1,0 +1,22 @@
+import Foundation
+import CoreData
+
+public class OmniPodHeartBeat: NSManagedObject {
+    
+    /// create OmniPodHeartBeat
+    /// - parameters:
+    init(address: String, name: String, alias: String?, nsManagedObjectContext:NSManagedObjectContext) {
+        
+        let entity = NSEntityDescription.entity(forEntityName: "OmniPodHeartBeat", in: nsManagedObjectContext)!
+        
+        super.init(entity: entity, insertInto: nsManagedObjectContext)
+        
+        blePeripheral = BLEPeripheral(address: address, name: name, alias: nil, bluetoothPeripheralType: .OmniPodHeartBeatType, nsManagedObjectContext: nsManagedObjectContext)
+        
+    }
+    
+    private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
+    
+}

--- a/xdrip/Core Data/classes/OmniPodHeartBeat+CoreDataProperties.swift
+++ b/xdrip/Core Data/classes/OmniPodHeartBeat+CoreDataProperties.swift
@@ -1,0 +1,20 @@
+//
+//  OmniPodHeartBeat+CoreDataProperties.swift
+//
+//
+//  Created by Johan Degraeve on 08/02/2024
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension OmniPodHeartBeat {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<OmniPodHeartBeat> {
+        return NSFetchRequest<OmniPodHeartBeat>(entityName: "OmniPodHeartBeat")
+    }
+
+    @NSManaged public var blePeripheral: BLEPeripheral
+}

--- a/xdrip/Core Data/xdrip.xcdatamodeld/xdrip v16.xcdatamodel/contents
+++ b/xdrip/Core Data/xdrip.xcdatamodeld/xdrip v16.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21C52" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="22G91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AlertEntry" representedClassName=".AlertEntry" syncable="YES">
         <attribute name="alertkind" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="start" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
@@ -51,17 +51,20 @@
         <attribute name="shouldconnect" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="transmitterId" optional="YES" attributeType="String"/>
         <attribute name="webOOPEnabled" attributeType="Boolean" usesScalarValueType="YES"/>
-        <relationship name="atom" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Atom" inverseName="blePeripheral" inverseEntity="Atom"/>
+        <relationship name="atom" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Atom" inverseName="blePeripheral" inverseEntity="Atom"/>
         <relationship name="blucon" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Blucon" inverseName="blePeripheral" inverseEntity="Blucon"/>
         <relationship name="blueReader" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BlueReader" inverseName="blePeripheral" inverseEntity="BlueReader"/>
         <relationship name="bubble" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Bubble" inverseName="blePeripheral" inverseEntity="Bubble"/>
         <relationship name="dexcomG4" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="DexcomG4" inverseName="blePeripheral" inverseEntity="DexcomG4"/>
         <relationship name="dexcomG5" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="DexcomG5" inverseName="blePeripheral" inverseEntity="DexcomG5"/>
-        <relationship name="droplet" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Droplet" inverseName="blePeripheral" inverseEntity="Droplet"/>
+        <relationship name="dexcomG7HeartBeat" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="DexcomG7HeartBeat" inverseName="blePeripheral" inverseEntity="DexcomG7HeartBeat"/>
+        <relationship name="droplet" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Droplet" inverseName="blePeripheral" inverseEntity="Droplet"/>
         <relationship name="gNSEntry" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="GNSEntry" inverseName="blePeripheral" inverseEntity="GNSEntry"/>
         <relationship name="libre2" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Libre2" inverseName="blePeripheral" inverseEntity="Libre2"/>
+        <relationship name="libre2heartbeat" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Libre2HeartBeat" inverseName="blePeripheral" inverseEntity="Libre2HeartBeat"/>
         <relationship name="m5Stack" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="M5Stack" inverseName="blePeripheral" inverseEntity="M5Stack"/>
         <relationship name="miaoMiao" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="MiaoMiao" inverseName="blePeripheral" inverseEntity="MiaoMiao"/>
+        <relationship name="omniPodHeartBeat" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OmniPodHeartBeat" inverseName="blePeripheral" inverseEntity="OmniPodHeartBeat"/>
         <relationship name="watlaa" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Watlaa" inverseName="blePeripheral" inverseEntity="Watlaa"/>
     </entity>
     <entity name="Blucon" representedClassName=".Blucon" syncable="YES">
@@ -113,6 +116,9 @@
         <attribute name="voltageB" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="blePeripheral" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="dexcomG5" inverseEntity="BLEPeripheral"/>
     </entity>
+    <entity name="DexcomG7HeartBeat" representedClassName=".DexcomG7HeartBeat" syncable="YES">
+        <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BLEPeripheral" inverseName="dexcomG7HeartBeat" inverseEntity="BLEPeripheral"/>
+    </entity>
     <entity name="Droplet" representedClassName=".Droplet" syncable="YES">
         <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="droplet" inverseEntity="BLEPeripheral"/>
     </entity>
@@ -124,6 +130,9 @@
     </entity>
     <entity name="Libre2" representedClassName=".Libre2" syncable="YES">
         <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="libre2" inverseEntity="BLEPeripheral"/>
+    </entity>
+    <entity name="Libre2HeartBeat" representedClassName=".Libre2HeartBeat" syncable="YES">
+        <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BLEPeripheral" inverseName="libre2heartbeat" inverseEntity="BLEPeripheral"/>
     </entity>
     <entity name="M5Stack" representedClassName=".M5Stack" syncable="YES">
         <attribute name="backGroundColor" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
@@ -139,6 +148,9 @@
         <attribute name="firmware" optional="YES" attributeType="String"/>
         <attribute name="hardware" optional="YES" attributeType="String"/>
         <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="miaoMiao" inverseEntity="BLEPeripheral"/>
+    </entity>
+    <entity name="OmniPodHeartBeat" representedClassName=".OmniPodHeartBeat" syncable="YES">
+        <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BLEPeripheral" inverseName="omniPodHeartBeat" inverseEntity="BLEPeripheral"/>
     </entity>
     <entity name="Sensor" representedClassName=".Sensor" syncable="YES">
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -167,26 +179,4 @@
         <attribute name="hardware" optional="YES" attributeType="String"/>
         <relationship name="blePeripheral" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="watlaa" inverseEntity="BLEPeripheral"/>
     </entity>
-    <elements>
-        <element name="AlertEntry" positionX="-648" positionY="189" width="128" height="28"/>
-        <element name="AlertType" positionX="-657" positionY="180" width="128" height="28"/>
-        <element name="Atom" positionX="-657" positionY="189" width="128" height="74"/>
-        <element name="BgReading" positionX="-285.87109375" positionY="31.9921875" width="128" height="298"/>
-        <element name="BLEPeripheral" positionX="-630" positionY="216" width="128" height="359"/>
-        <element name="Blucon" positionX="-657" positionY="189" width="128" height="58"/>
-        <element name="BlueReader" positionX="-639" positionY="207" width="128" height="58"/>
-        <element name="Bubble" positionX="-657" positionY="189" width="128" height="88"/>
-        <element name="Calibration" positionX="-859.21484375" positionY="46.21484375" width="128" height="299"/>
-        <element name="DexcomG4" positionX="-621" positionY="225" width="128" height="58"/>
-        <element name="DexcomG5" positionX="-648" positionY="198" width="128" height="224"/>
-        <element name="Droplet" positionX="-630" positionY="216" width="128" height="58"/>
-        <element name="GNSEntry" positionX="-648" positionY="198" width="128" height="103"/>
-        <element name="Libre2" positionX="-648" positionY="198" width="128" height="58"/>
-        <element name="M5Stack" positionX="-657" positionY="180" width="128" height="163"/>
-        <element name="MiaoMiao" positionX="-657" positionY="189" width="128" height="88"/>
-        <element name="Sensor" positionX="-603.0859375" positionY="482.2890625" width="128" height="133"/>
-        <element name="SnoozeParameters" positionX="-648" positionY="198" width="128" height="28"/>
-        <element name="TreatmentEntry" positionX="-657" positionY="189" width="128" height="134"/>
-        <element name="Watlaa" positionX="-639" positionY="207" width="128" height="88"/>
-    </elements>
 </model>

--- a/xdrip/Managers/Alerts/AlertKind.swift
+++ b/xdrip/Managers/Alerts/AlertKind.swift
@@ -359,8 +359,8 @@ public enum AlertKind:Int, CaseIterable {
                 switch transmitterBatteryInfo {
                 case .percentage(let percentage):
                     batteryLevelToCheck = percentage
-                case .DexcomG5(let voltageA, _, _, _, _):
-                    batteryLevelToCheck = voltageA
+                case .DexcomG5(_, let voltageB, _, _, _):
+                    batteryLevelToCheck = voltageB
                 case .DexcomG4(let level):
                     batteryLevelToCheck = level
                 }

--- a/xdrip/Managers/Alerts/AlertManager.swift
+++ b/xdrip/Managers/Alerts/AlertManager.swift
@@ -344,7 +344,7 @@ public class AlertManager:NSObject {
                                         // schedule missed reading alert with same content
                                         self.scheduleMissedReadingAlert(snoozePeriodInMinutes: snoozePeriod, content: content)
 
-                                    } else if UserDefaults.standard.isMaster || (!UserDefaults.standard.isMaster && UserDefaults.standard.followerBackgroundKeepAliveType != .disabled && UserDefaults.standard.activeSensorStartDate != nil) {
+                                    } else {
                                         
                                         _ = self.checkAlertAndFire(alertKind: .missedreading, lastBgReading: nil, lastButOneBgREading: nil, lastCalibration: nil, transmitterBatteryInfo: nil)
                                         
@@ -555,7 +555,7 @@ public class AlertManager:NSObject {
             
         }
         
-        if alertNeeded && (UserDefaults.standard.isMaster || (!UserDefaults.standard.isMaster && UserDefaults.standard.followerBackgroundKeepAliveType != .disabled)) {
+        if alertNeeded {
             
             // alert needs to be raised
             
@@ -720,15 +720,8 @@ public class AlertManager:NSObject {
             
         } else {
             
-            if !UserDefaults.standard.isMaster && UserDefaults.standard.followerBackgroundKeepAliveType == .disabled {
-                
-                trace("in checkAlert, there's no need to raise alert %{public}@ because we're in follower mode and keep-alive is disabled", log: self.log, category: ConstantsLog.categoryAlertManager, type: .info, alertKind.descriptionForLogging())
-                
-            } else {
-                
-                trace("in checkAlert, there's no need to raise alert %{public}@", log: self.log, category: ConstantsLog.categoryAlertManager, type: .info, alertKind.descriptionForLogging())
-                
-            }
+            trace("in checkAlert, there's no need to raise alert %{public}@", log: self.log, category: ConstantsLog.categoryAlertManager, type: .info, alertKind.descriptionForLogging())
+
             return false
         }
     }

--- a/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager+BluetoothTransmitterDelegate.swift
+++ b/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager+BluetoothTransmitterDelegate.swift
@@ -337,5 +337,14 @@ extension BluetoothPeripheralManager: BluetoothTransmitterDelegate {
         
     }
 
+    // to confirm to protocol BluetoothPeripheralDelegate
+    func heartBeat() {
+        // bluetooth peripheral's heart is beating
+        // if a heartBeat function is set, then call it
+        if let heartBeatFunction = heartBeatFunction {
+            heartBeatFunction()
+        }
+    }
+
 }
 

--- a/xdrip/Managers/LibreLinkUp/LibreLinkUpFollowManager.swift
+++ b/xdrip/Managers/LibreLinkUp/LibreLinkUpFollowManager.swift
@@ -203,7 +203,7 @@ class LibreLinkUpFollowManager: NSObject {
     
     
     /// download recent readings from LibreView, send result to delegate, and schedule new download
-    @objc private func download() {
+    @objc public func download() {
         
         trace("in download", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info)
         
@@ -214,6 +214,26 @@ class LibreLinkUpFollowManager: NSObject {
             UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
         }
         
+        guard !UserDefaults.standard.isMaster else {
+            trace("    not follower", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info)
+            return
+        }
+        
+        guard UserDefaults.standard.followerDataSourceType == .libreLinkUp else {
+            trace("    followerDataSourceType is not libreLinkUp", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info)
+            return
+        }
+
+        guard UserDefaults.standard.libreLinkUpEmail != nil else {
+            trace("    libreLinkUpEmail is nil", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info)
+            return
+        }
+
+        guard UserDefaults.standard.libreLinkUpPassword != nil else {
+            trace("    libreLinkUpPassword is nil", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info)
+            return
+        }
+
         Task {
             
             do {
@@ -311,9 +331,11 @@ class LibreLinkUpFollowManager: NSObject {
             // we do it here at the end of the function so that it is always rescheduled once a valid connection is established, irrespective of whether we get values.
             DispatchQueue.main.sync {
                 
-                // schedule new download
-                self.scheduleNewDownload()
-                
+                // schedule new download, only if followerBackgroundKeepAliveType != disabled
+                if UserDefaults.standard.followerBackgroundKeepAliveType != .disabled {
+                    self.scheduleNewDownload()
+                }
+
             }
         }
     }
@@ -786,14 +808,16 @@ class LibreLinkUpFollowManager: NSObject {
             
             // this will enable the suspension prevention sound playing if background keep-alive is enabled
             if UserDefaults.standard.followerBackgroundKeepAliveType != .disabled {
+                
                 enableSuspensionPrevention()
+                
+                // do initial download, this will also schedule future downloads
+                download()
+                
             } else {
                 disableSuspensionPrevention()
             }
-            
-            // do initial download, this will also schedule future downloads
-            download()
-            
+                        
         } else {
             
             // disable the suspension prevention

--- a/xdrip/Managers/LibreLinkUp/LibreLinkUpFollowManager.swift
+++ b/xdrip/Managers/LibreLinkUp/LibreLinkUpFollowManager.swift
@@ -355,7 +355,7 @@ class LibreLinkUpFollowManager: NSObject {
                     
                     let newRegion = LibreLinkUpRegion(from: region)
                     
-                    trace("    in checkLoginAndConnections, redirect flag received. Switching region from '%{public}@' to '%{public}@' and repeating checkLogin", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info, self.libreLinkUpRegion?.description ?? "nil", newRegion?.description ?? "nil")
+                    trace("    in checkLoginAndConnections, redirect flag received. Switching region from '%{public}@' to '%{public}@' and calling again checkLoginAndConnections()", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info, self.libreLinkUpRegion?.description ?? "nil", newRegion?.description ?? "nil")
                     
                     self.libreLinkUpRegion = newRegion
                     
@@ -757,7 +757,7 @@ class LibreLinkUpFollowManager: NSObject {
             trace("in eventhandler checking if audioplayer exists", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info)
             
             if let audioPlayer = self.audioPlayer, !audioPlayer.isPlaying {
-                trace("playing audio every %{public}@ seconds. %{public}@ keep-alive: %{public}@", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info, interval, UserDefaults.standard.followerDataSourceType.description, UserDefaults.standard.followerBackgroundKeepAliveType.description)
+                trace("playing audio every %{public}@ seconds. %{public}@ keep-alive: %{public}@", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info, interval.description, UserDefaults.standard.followerDataSourceType.description, UserDefaults.standard.followerBackgroundKeepAliveType.description)
                 audioPlayer.play()
             }
         })

--- a/xdrip/Managers/LibreLinkUp/LibreLinkUpModels.swift
+++ b/xdrip/Managers/LibreLinkUp/LibreLinkUpModels.swift
@@ -50,7 +50,7 @@ public enum LibreLinkUpRegion: Int, CaseIterable {
             self = .de
         case "eu":
             self = .eu
-        case "gb":
+        case "eu2":
             self = .eu2
         case "fr":
             self = .fr
@@ -83,7 +83,7 @@ public enum LibreLinkUpRegion: Int, CaseIterable {
         case .eu:
             return "Europe"
         case .eu2:
-            return "United Kingdom"
+            return "Great Britain"
         case .fr:
             return "France"
         case .jp:

--- a/xdrip/Managers/Loop/LoopFollowManager.swift
+++ b/xdrip/Managers/Loop/LoopFollowManager.swift
@@ -1,0 +1,57 @@
+import Foundation
+import os
+import AVFoundation
+
+class LoopFollowManager: NSObject {
+    
+    // MARK: - private properties
+    
+    /// for logging
+    private var log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryLoopFollowManager)
+    
+    /// delegate to pass back glucosedata
+    private (set) weak var followerDelegate:FollowerDelegate?
+    
+    // MARK: - initializer
+        
+    /// initializer
+    public init(coreDataManager: CoreDataManager, followerDelegate: FollowerDelegate) {
+        
+        // initialize non optional private properties
+        self.followerDelegate  = followerDelegate
+        
+        // call super.init
+        super.init()
+    }
+    
+    // MARK: - public functions
+    
+    /// get reading from shared user defaults
+    public func getReading() {
+        
+        // check that app is in follower mode
+        guard !UserDefaults.standard.isMaster else {return}
+        
+        guard let sharedUserDefaults = UserDefaults(suiteName: Bundle.main.appGroupSuiteName) else {return}
+        
+        guard let encodedLatestReadings = sharedUserDefaults.data(forKey: "latestReadingsFromLoop") else {return}
+
+        let decodedLatestReadings = try? JSONSerialization.jsonObject(with: encodedLatestReadings, options: [])
+        
+        guard let latestReadings = decodedLatestReadings as? Array<AnyObject> else {return}
+        
+        var followGlucoseDataArray = [FollowerBgReading]()
+        
+        for reading in latestReadings {
+            
+            guard let date = reading["date"] as? Double, let sgv = reading["sgv"] as? Double else {return}
+            
+            followGlucoseDataArray.append(FollowerBgReading(timeStamp: Date(timeIntervalSince1970: date/1000), sgv: sgv))
+            
+        }
+
+        self.followerDelegate?.followerInfoReceived(followGlucoseDataArray: &followGlucoseDataArray)
+
+    }
+
+}

--- a/xdrip/Managers/NightScout/NightScoutFollowManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutFollowManager.swift
@@ -118,35 +118,9 @@ class NightScoutFollowManager: NSObject {
         
     }
     
-    // MARK: - private functions
-    
-    /// taken from xdripplus
-    ///
-    /// updates bgreading
-    ///
-    private func findSlope() -> (calculatedValueSlope:Double, hideSlope:Bool) {
-        
-        // init returnvalues
-        var hideSlope = true
-        var calculatedValueSlope = 0.0
-
-        // get last readings
-        let last2Readings = bgReadingsAccessor.getLatestBgReadings(limit: 3, howOld: 1, forSensor: nil, ignoreRawData: true, ignoreCalculatedValue: false)
-        
-        // if more thant 2 readings, calculate slope and hie
-        if last2Readings.count >= 2 {
-            let (slope, hide) = last2Readings[0].calculateSlope(lastBgReading:last2Readings[1]);
-            calculatedValueSlope = slope
-            hideSlope = hide
-        }
-
-        return (calculatedValueSlope, hideSlope)
-        
-    }
-
-    
-    /// download recent readings from nightScout, send result to delegate, and schedule new download
-    @objc private func download() {
+    /// - download recent readings from nightScout, send result to delegate, and schedule new download (if followerBackgroundKeepAliveType != disabled)
+    /// - no download is done if latest reading is less than 30 seconds old
+    @objc public func download() {
         
         trace("in download", log: self.log, category: ConstantsLog.categoryNightScoutFollowManager, type: .info)
 
@@ -155,7 +129,22 @@ class NightScoutFollowManager: NSObject {
         DispatchQueue.main.async {
             UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
         }
+
+        guard UserDefaults.standard.nightScoutEnabled else {
+            trace("    nightscout not enabled", log: self.log, category: ConstantsLog.categoryNightScoutFollowManager, type: .info)
+            return
+        }
+
+        guard !UserDefaults.standard.isMaster else {
+            trace("    not follower", log: self.log, category: ConstantsLog.categoryNightScoutFollowManager, type: .info)
+            return
+        }
         
+        guard UserDefaults.standard.followerDataSourceType == .nightscout else {
+            trace("    followerDataSourceType is not nightscout", log: self.log, category: ConstantsLog.categoryNightScoutFollowManager, type: .info)
+            return
+        }
+
         // nightscout URl must be non-nil - could be that url is not valid, this is not checked here, the app will just retry every x minutes
         guard let nightScoutUrl = UserDefaults.standard.nightScoutUrl else {return}
         
@@ -166,6 +155,19 @@ class NightScoutFollowManager: NSObject {
         let latestBgReadings = bgReadingsAccessor.getLatestBgReadings(limit: nil, howOld: 1, forSensor: nil, ignoreRawData: true, ignoreCalculatedValue: false)
         if latestBgReadings.count > 0 {
             timeStampOfFirstBgReadingToDowload = max(latestBgReadings[0].timeStamp, timeStampOfFirstBgReadingToDowload)
+        }
+        
+        // to handle case where a reading was already fetched by LoopFollowManger right before the call to this function. In that case there should already be a reading available, and it's not necessary to download from NS
+        guard abs(timeStampOfFirstBgReadingToDowload.timeIntervalSinceNow) > 30.0 else {
+            
+            trace("    last reading is less than 30 seconds old, will not download now", log: self.log, category: ConstantsLog.categoryNightScoutFollowManager, type: .info)
+            
+            // schedule new download, only if followerBackgroundKeepAliveType != disabled
+            if UserDefaults.standard.followerBackgroundKeepAliveType != .disabled {
+                self.scheduleNewDownload()
+            }
+            
+            return
         }
         
         // calculate count, which is a parameter in the nightscout API - divide by 300, we're assuming readings every 5 minutes = 300 seconds
@@ -202,8 +204,10 @@ class NightScoutFollowManager: NSObject {
                         followerDelegate.followerInfoReceived(followGlucoseDataArray: &followGlucoseDataArray)
                     }
 
-                    // schedule new download
-                    self.scheduleNewDownload()
+                    // schedule new download, only if followerBackgroundKeepAliveType != disabled
+                    if UserDefaults.standard.followerBackgroundKeepAliveType != .disabled {
+                        self.scheduleNewDownload()
+                    }
 
                 }
                 
@@ -215,6 +219,33 @@ class NightScoutFollowManager: NSObject {
         }
 
     }
+    
+    // MARK: - private functions
+    
+    /// taken from xdripplus
+    ///
+    /// updates bgreading
+    ///
+    private func findSlope() -> (calculatedValueSlope:Double, hideSlope:Bool) {
+        
+        // init returnvalues
+        var hideSlope = true
+        var calculatedValueSlope = 0.0
+
+        // get last readings
+        let last2Readings = bgReadingsAccessor.getLatestBgReadings(limit: 3, howOld: 1, forSensor: nil, ignoreRawData: true, ignoreCalculatedValue: false)
+        
+        // if more thant 2 readings, calculate slope and hie
+        if last2Readings.count >= 2 {
+            let (slope, hide) = last2Readings[0].calculateSlope(lastBgReading:last2Readings[1]);
+            calculatedValueSlope = slope
+            hideSlope = hide
+        }
+
+        return (calculatedValueSlope, hideSlope)
+        
+    }
+
     
     /// schedule new download with timer, when timer expires download() will be called
     private func scheduleNewDownload() {
@@ -384,13 +415,15 @@ class NightScoutFollowManager: NSObject {
             
             // this will enable the suspension prevention sound playing if background keep-alive is enabled
             if UserDefaults.standard.followerBackgroundKeepAliveType != .disabled {
+
                 enableSuspensionPrevention()
+
+                // do initial download, this will also schedule future downloads
+                download()
+                
             } else {
                 disableSuspensionPrevention()
             }
-            
-            // do initial download, this will also schedule future downloads
-            download()
             
         } else {
             

--- a/xdrip/Managers/NightScout/NightScoutFollowManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutFollowManager.swift
@@ -354,7 +354,7 @@ class NightScoutFollowManager: NSObject {
             trace("in eventhandler checking if audioplayer exists", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info)
             
             if let audioPlayer = self.audioPlayer, !audioPlayer.isPlaying {
-                trace("playing audio every %{public}@ seconds. %{public}@ keep-alive: %{public}@", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info, interval, UserDefaults.standard.followerDataSourceType.description, UserDefaults.standard.followerBackgroundKeepAliveType.description)
+                trace("playing audio every %{public}@ seconds. %{public}@ keep-alive: %{public}@", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info, interval.description, UserDefaults.standard.followerDataSourceType.description, UserDefaults.standard.followerBackgroundKeepAliveType.description)
                 audioPlayer.play()
             }
         })

--- a/xdrip/Managers/NightScout/NightScoutUploadManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutUploadManager.swift
@@ -164,7 +164,7 @@ public class NightScoutUploadManager: NSObject, ObservableObject {
     }
     
     /// synchronize treatments with NightScout
-    public func syncTreatmentsWithNightScout() {
+    private func syncTreatmentsWithNightScout() {
         
         // check that NightScout is enabled
         // and nightScoutUrl exists

--- a/xdrip/Utilities/Trace.swift
+++ b/xdrip/Utilities/Trace.swift
@@ -634,6 +634,26 @@ class Trace {
                             
                         }
                         
+                    case .Libre3HeartBeatType:
+                        if blePeripheral.libre2heartbeat != nil {
+                            
+                            traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
+                            
+                        }
+                        
+                    case .DexcomG7HeartBeatType:
+                        if blePeripheral.dexcomG7HeartBeat != nil {
+                            
+                            traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
+                            
+                        }
+                        
+                    case .OmniPodHeartBeatType:
+                        if blePeripheral.omniPodHeartBeat != nil {
+                            
+                            traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
+                            
+                        }
                     }
                 }
                 

--- a/xdrip/Utilities/Trace.swift
+++ b/xdrip/Utilities/Trace.swift
@@ -317,166 +317,168 @@ class Trace {
     static func getAppInfoFileAsData() -> (Data?, String) {
         
         var traceInfo = ""
-
+             
+        traceInfo.appendStringAndNewLine(paragraphSeperator)
+        
+        traceInfo.appendStringAndNewLine("Date + timezone: " + Date().toString(timeStyle: .full, dateStyle: .medium))
+        
+        traceInfo.appendStringAndNewLine(paragraphSeperator)
+        
         // app name, version and build
         traceInfo.appendStringAndNewLine("App name: " + ConstantsHomeView.applicationName)
         traceInfo.appendStringAndNewLine("Version: " + applicationVersion)
-        traceInfo.appendStringAndNewLine("Build number: " + buildNumber + " (" + timeStampAppBuild.toString(timeStyle: .none, dateStyle: .long) + ")\n")
+        traceInfo.appendStringAndNewLine("Build number: " + buildNumber + " (" + timeStampAppBuild.toString(timeStyle: .none, dateStyle: .medium) + ")\n")
         
         // app install and open timestamps
-        traceInfo.appendStringAndNewLine("App first installed on: " + timeStampAppInstall.toString(timeStyle: .long, dateStyle: .long))
+        traceInfo.appendStringAndNewLine("App first installed on: " + timeStampAppInstall.toString(timeStyle: .short, dateStyle: .medium))
                 
         if let timeStampAppLaunch = UserDefaults.standard.timeStampAppLaunch {
-            traceInfo.appendStringAndNewLine("App last opened on: " + timeStampAppLaunch.toString(timeStyle: .long, dateStyle: .long))
+            traceInfo.appendStringAndNewLine("App last opened on: " + timeStampAppLaunch.toString(timeStyle: .short, dateStyle: .medium))
         }
         
         traceInfo.appendStringAndNewLine(paragraphSeperator)
-        
-        // nightscout info
-        if UserDefaults.standard.nightScoutEnabled {
-            
-            traceInfo.appendStringAndNewLine("Nightscout: Enabled")
-            
-            if UserDefaults.standard.nightScoutUrl != nil {
-                
-                traceInfo.appendStringAndNewLine("    URL: Present")
-                
-            } else {
-                
-                traceInfo.appendStringAndNewLine("    URL: Missing")
-                
-            }
-            
-            if UserDefaults.standard.nightScoutAPIKey != nil {
-                
-                traceInfo.appendStringAndNewLine("    API_SECRET: Present")
-                
-            } else {
-                
-                traceInfo.appendStringAndNewLine("    API_SECRET: Missing")
-                
-            }
-            
-            if UserDefaults.standard.nightscoutToken != nil {
-                
-                traceInfo.appendStringAndNewLine("    Token: Present")
-                
-            } else {
-                
-                traceInfo.appendStringAndNewLine("    Token: Missing")
-                
-            }
-        
-        } else {
-            
-            traceInfo.appendStringAndNewLine("Nightscout: Disabled")
-            
-        }
-        
-        traceInfo.appendStringAndNewLine("")
-        
-        // cgm transmitter type from UserDefaults
-        if let cgmTransmitterTypeAsString = UserDefaults.standard.cgmTransmitterTypeAsString {
-            traceInfo.appendStringAndNewLine("Transmitter type: " + cgmTransmitterTypeAsString + "\n")
-        }
-        
-        traceInfo.appendStringAndNewLine("App settings:")
 
         // master or follower mode?
-        traceInfo.appendStringAndNewLine("    Data Source Mode: " + (UserDefaults.standard.isMaster ? "Master" : UserDefaults.standard.followerDataSourceType.descriptionForLogging()))
+        traceInfo.appendStringAndNewLine("Data Source Mode: " + (UserDefaults.standard.isMaster ? "Master" : UserDefaults.standard.followerDataSourceType.descriptionForLogging()))
         
-        // if follower mode, is background keep-alive enabled?
-        if !UserDefaults.standard.isMaster {
+        if UserDefaults.standard.isMaster {
             
-            traceInfo.appendStringAndNewLine("       Background follower keep-alive type: " + UserDefaults.standard.followerBackgroundKeepAliveType.description)
-            
-        }
-                
-        // if follower mode, what is the data source selected
-        if !UserDefaults.standard.isMaster && UserDefaults.standard.followerDataSourceType == .libreLinkUp {
-            
-            if UserDefaults.standard.libreLinkUpEmail != nil {
-                traceInfo.appendStringAndNewLine("    Username: Present")
-            } else {
-                traceInfo.appendStringAndNewLine("    Username: Missing")
+            if let cgmTransmitterTypeAsString = UserDefaults.standard.cgmTransmitterTypeAsString {
+                traceInfo.appendStringAndNewLine("    Transmitter type: " + cgmTransmitterTypeAsString)
             }
             
-            if UserDefaults.standard.libreLinkUpPassword != nil {
-                traceInfo.appendStringAndNewLine("    Password: Present")
-            } else {
-                traceInfo.appendStringAndNewLine("    Password: Missing")
+        } else {
+            
+            traceInfo.appendStringAndNewLine("    Keep-alive type: " + UserDefaults.standard.followerBackgroundKeepAliveType.description)
+            traceInfo.appendStringAndNewLine("    Patient name: " + (UserDefaults.standard.followerPatientName?.description ?? "nil"))
+            
+            // if follower mode, what is the data source selected
+            if UserDefaults.standard.followerDataSourceType == .libreLinkUp {
+                traceInfo.appendStringAndNewLine("    Username: " + ((UserDefaults.standard.libreLinkUpEmail?.description ?? "") != "" ? "present" : "missing"))
+                traceInfo.appendStringAndNewLine("    Password: " + ((UserDefaults.standard.libreLinkUpPassword?.description ?? "") != "" ? "present" : "missing"))
+                traceInfo.appendStringAndNewLine("    Upload to Nightscout: " + UserDefaults.standard.followerUploadDataToNightscout.description)
             }
         }
-
-        // is help icon hidden on or off
+        
+        traceInfo.appendStringAndNewLine("\nHelp settings:")
+        traceInfo.appendStringAndNewLine("    Translate automatically: " + UserDefaults.standard.translateOnlineHelp.description)
         traceInfo.appendStringAndNewLine("    Show help icon: " + UserDefaults.standard.showHelpIcon.description)
-
-        // is translate help on or off
-        traceInfo.appendStringAndNewLine("    Translate help: " + UserDefaults.standard.translateOnlineHelp.description)
-
-        // is showReadingInNotification on or off
-        traceInfo.appendStringAndNewLine("    Show BG in notification: " + UserDefaults.standard.showReadingInNotification.description)
-
-        // minimum interval between notifications
+        
+        traceInfo.appendStringAndNewLine("\nGeneral settings:")
+        traceInfo.appendStringAndNewLine("    Measurement unit: " + (UserDefaults.standard.bloodGlucoseUnitIsMgDl ? Texts_Common.mgdl : Texts_Common.mmol))
+        traceInfo.appendStringAndNewLine("    Show BG in notifications: " + UserDefaults.standard.showReadingInNotification.description)
         traceInfo.appendStringAndNewLine("    Notification interval: " + UserDefaults.standard.notificationInterval.description + " minutes")
-
-        // show BG in app badge on or off
         traceInfo.appendStringAndNewLine("    Show BG in app badge: " + UserDefaults.standard.showReadingInAppBadge.description)
-
-        // allow chart rotation
+                
+        traceInfo.appendStringAndNewLine("\nHome screen settings:")
         traceInfo.appendStringAndNewLine("    Allow chart rotation: " + UserDefaults.standard.allowScreenRotation.description)
-        
-        // screen dimming type
         traceInfo.appendStringAndNewLine("    Screen dimming type when locked: " + UserDefaults.standard.screenLockDimmingType.description)
-
-        // is use statistics on or off
+        traceInfo.appendStringAndNewLine("    Show mini-chart: " + UserDefaults.standard.showMiniChart.description)
+        traceInfo.appendStringAndNewLine("    Urgent high: " + UserDefaults.standard.urgentHighMarkValueInUserChosenUnitRounded.description)
+        traceInfo.appendStringAndNewLine("    High: " + UserDefaults.standard.highMarkValueInUserChosenUnitRounded.description)
+        traceInfo.appendStringAndNewLine("    Low: " + UserDefaults.standard.lowMarkValueInUserChosenUnitRounded.description)
+        traceInfo.appendStringAndNewLine("    Urgent low: " + UserDefaults.standard.urgentLowMarkValueInUserChosenUnitRounded.description)
+        traceInfo.appendStringAndNewLine("    Show objectives: " + UserDefaults.standard.useObjectives.description)
+        traceInfo.appendStringAndNewLine("    Show target line: " + UserDefaults.standard.showTarget.description)
+        traceInfo.appendStringAndNewLine("    Target: " + UserDefaults.standard.targetMarkValueInUserChosenUnitRounded.description)
+        
+        traceInfo.appendStringAndNewLine("\nTreatments settings:")
+        traceInfo.appendStringAndNewLine("    Show treatments: " + UserDefaults.standard.showTreatmentsOnChart.description)
+        traceInfo.appendStringAndNewLine("    Micro-bolus threshold: " + UserDefaults.standard.smallBolusTreatmentThreshold.description)
+        traceInfo.appendStringAndNewLine("    Show micro-bolus: " + UserDefaults.standard.showSmallBolusTreatmentsOnChart.description)
+        traceInfo.appendStringAndNewLine("    Offset carbs on chart: " + UserDefaults.standard.offsetCarbTreatmentsOnChart.description)
+        
+        traceInfo.appendStringAndNewLine("\nStatistics settings:")
         traceInfo.appendStringAndNewLine("    Show statistics: " + UserDefaults.standard.showStatistics.description)
-        
-        // how many days is the user using to calculation the statistics
-        traceInfo.appendStringAndNewLine("    Days to use for statistics calculations: " + UserDefaults.standard.daysToUseStatistics.description)
-        
-        // how many hours are selected for the chart width
-        traceInfo.appendStringAndNewLine("    Selected chart width: " + UserDefaults.standard.chartWidthInHours.description)
-  
-        // are calendar events on or off
-        traceInfo.appendStringAndNewLine("    Write calendar events: " + UserDefaults.standard.createCalendarEvent.description)
-        
-        if let calendarId = UserDefaults.standard.calenderId {
-            
-            traceInfo.appendStringAndNewLine("    Calendar to use: " + calendarId)
-        
+        traceInfo.appendStringAndNewLine("    Time in Range type: " + UserDefaults.standard.timeInRangeType.description)
+        traceInfo.appendStringAndNewLine("    Show HbA1c in mmols/mol: " + UserDefaults.standard.useIFCCA1C.description)
+          
+        traceInfo.appendStringAndNewLine("\nNightscout settings:")
+        traceInfo.appendStringAndNewLine("    Nightscout enabled: " + UserDefaults.standard.nightScoutEnabled.description)
+        if UserDefaults.standard.nightScoutEnabled {
+            traceInfo.appendStringAndNewLine("    URL: " + ((UserDefaults.standard.nightScoutUrl?.description ?? "") != "" ? "present" : "missing"))
+            traceInfo.appendStringAndNewLine("    API_SECRET: " + ((UserDefaults.standard.nightScoutAPIKey?.description ?? "") != "" ? "present" : "missing"))
+            traceInfo.appendStringAndNewLine("    Token: " + ((UserDefaults.standard.nightscoutToken?.description ?? "") != "" ? "present" : "missing"))
+            if UserDefaults.standard.nightScoutPort != 0 {
+                traceInfo.appendStringAndNewLine("    Port: " + UserDefaults.standard.nightScoutPort.description)
+            } else {
+                traceInfo.appendStringAndNewLine("    Port: Missing")
+            }
         }
-
-        // is Apple Health on or off
+        
+        traceInfo.appendStringAndNewLine("\nDexcom Share settings:")
+        traceInfo.appendStringAndNewLine("    Upload to Dexcom Share: " + UserDefaults.standard.uploadReadingstoDexcomShare.description)
+        if UserDefaults.standard.uploadReadingstoDexcomShare {
+            traceInfo.appendStringAndNewLine("    Account name: " + ((UserDefaults.standard.dexcomShareAccountName?.description ?? "") != "" ? "present" : "missing"))
+            traceInfo.appendStringAndNewLine("    Password: " + ((UserDefaults.standard.dexcomSharePassword?.description ?? "") != "" ? "present" : "missing"))
+            traceInfo.appendStringAndNewLine("    Use US servers: " + UserDefaults.standard.useUSDexcomShareurl .description)
+            traceInfo.appendStringAndNewLine("    Receiver serial number: " + (UserDefaults.standard.dexcomShareSerialNumber?.description ?? "nil"))
+            traceInfo.appendStringAndNewLine("    Use upload schedule: " + UserDefaults.standard.dexcomShareUseSchedule.description)
+        }
+                                             
+        traceInfo.appendStringAndNewLine("\nApple Health settings:")
         traceInfo.appendStringAndNewLine("    Write to Apple Health: " + UserDefaults.standard.storeReadingsInHealthkit.description)
-
-        // is speak readings on or off
+                                             
+        traceInfo.appendStringAndNewLine("\nCalendar events settings:")
+        traceInfo.appendStringAndNewLine("    Create calendar events: " + UserDefaults.standard.createCalendarEvent.description)
+        if UserDefaults.standard.createCalendarEvent {
+            if let calendarId = UserDefaults.standard.calenderId {
+                traceInfo.appendStringAndNewLine("    Calendar to use: " + calendarId)
+            }
+            traceInfo.appendStringAndNewLine("    Display trend: " + UserDefaults.standard.displayTrendInCalendarEvent.description)
+            traceInfo.appendStringAndNewLine("    Display delta: " + UserDefaults.standard.displayDeltaInCalendarEvent.description)
+            traceInfo.appendStringAndNewLine("    Display unit: " + UserDefaults.standard.displayUnitInCalendarEvent.description)
+            traceInfo.appendStringAndNewLine("    Display visual indicator: " + UserDefaults.standard.displayVisualIndicatorInCalendarEvent.description)
+            traceInfo.appendStringAndNewLine("    Event interval: " + UserDefaults.standard.calendarInterval.description + " minutes")
+        }
+                                             
+        traceInfo.appendStringAndNewLine("\nVoice settings:")
         traceInfo.appendStringAndNewLine("    Speak BG readings: " + UserDefaults.standard.speakReadings.description)
+        if UserDefaults.standard.speakReadings {
+            //if let languageCode = UserDefaults.standard.speakReadingLanguageCode {
+                traceInfo.appendStringAndNewLine("    Language: " + Texts_SpeakReading.languageName.description)
+            //}
+            traceInfo.appendStringAndNewLine("    Speak trend: " + UserDefaults.standard.speakTrend.description)
+            traceInfo.appendStringAndNewLine("    Speak delta: " + UserDefaults.standard.speakDelta.description)
+            traceInfo.appendStringAndNewLine("    Speak interval: " + UserDefaults.standard.speakInterval.description + " minutes")
+        }
+        
+        traceInfo.appendStringAndNewLine("\nData management settings:")
+        traceInfo.appendStringAndNewLine("    Retention period: " + UserDefaults.standard.retentionPeriodInDays.description + " days")
         
         // developer settings
-        traceInfo.appendStringAndNewLine("    Hide screen lock warning?: " + UserDefaults.standard.lockScreenDontShowAgain.description)
+        traceInfo.appendStringAndNewLine("\nDeveloper settings:")
         traceInfo.appendStringAndNewLine("    NS log enabled: " + UserDefaults.standard.NSLogEnabled.description)
         traceInfo.appendStringAndNewLine("    OS log enabled: " + UserDefaults.standard.OSLogEnabled.description)
-        traceInfo.appendStringAndNewLine("    Smooth Libre Readings: " + UserDefaults.standard.smoothLibreValues.description)
-        traceInfo.appendStringAndNewLine("    Suppress Unlock Payload Libre Readings: " + UserDefaults.standard.suppressUnLockPayLoad.description)
-        traceInfo.appendStringAndNewLine("    Suppress Loop Share: " + UserDefaults.standard.suppressLoopShare.description)
-        traceInfo.appendStringAndNewLine("    LibreLinkUp version: " + (UserDefaults.standard.libreLinkUpVersion?.description ?? "nil") + "\n")
-
-        // BG chart threshold values
-        traceInfo.appendStringAndNewLine("Chart threshold values:")
-        traceInfo.appendStringAndNewLine("    Urgent low: " + UserDefaults.standard.urgentLowMarkValueInUserChosenUnitRounded.description)
-        traceInfo.appendStringAndNewLine("    Low: " + UserDefaults.standard.lowMarkValueInUserChosenUnitRounded.description)
-        traceInfo.appendStringAndNewLine("    Target: " + UserDefaults.standard.targetMarkValueInUserChosenUnitRounded.description)
-        traceInfo.appendStringAndNewLine("    High: " + UserDefaults.standard.highMarkValueInUserChosenUnitRounded.description)
-        traceInfo.appendStringAndNewLine("    Urgent high: " + UserDefaults.standard.urgentHighMarkValueInUserChosenUnitRounded.description + "\n")
+        traceInfo.appendStringAndNewLine("    Smooth Libre readings: " + UserDefaults.standard.smoothLibreValues.description)
+        traceInfo.appendStringAndNewLine("    Suppress unlock payload: " + UserDefaults.standard.suppressUnLockPayLoad.description)
+        traceInfo.appendStringAndNewLine("    Suppress Loop share: " + UserDefaults.standard.suppressLoopShare.description)
+        traceInfo.appendStringAndNewLine("    LibreLinkUp version: " + (UserDefaults.standard.libreLinkUpVersion?.description ?? "nil"))
+        
+        traceInfo.appendStringAndNewLine(paragraphSeperator)
+        
+        traceInfo.appendStringAndNewLine("General flags/variables:\n")
+        // how many hours are selected for the chart width
+        traceInfo.appendStringAndNewLine("    Selected chart width: " + UserDefaults.standard.chartWidthInHours.description + " hours")
+        traceInfo.appendStringAndNewLine("    Hide screen lock warning: " + UserDefaults.standard.lockScreenDontShowAgain.description)
+        traceInfo.appendStringAndNewLine("    Days to use for statistics calculations: " + UserDefaults.standard.daysToUseStatistics.description)
+        
         
         // show the active sensor information from coredata
         traceInfo.appendStringAndNewLine(paragraphSeperator)
-        traceInfo.appendStringAndNewLine("Active Sensor Information (stored in Core Data):\n")
-        traceInfo.appendStringAndNewLine("    Active Sensor Description: " + (UserDefaults.standard.activeSensorDescription?.description ?? "nil"))
-        traceInfo.appendStringAndNewLine("    Active Sensor Start Date: " + (UserDefaults.standard.activeSensorStartDate?.description ?? "nil"))
-        traceInfo.appendStringAndNewLine("    Active Sensor Max Days: " + (UserDefaults.standard.activeSensorMaxSensorAgeInDays?.description ?? "nil"))
-        traceInfo.appendStringAndNewLine("    Active Transmitter ID (optional): " + (UserDefaults.standard.activeSensorTransmitterId?.description ?? "nil") + "\n")
+        traceInfo.appendStringAndNewLine("Active Sensor Information (from UserDefaults):\n")
+        if !(!UserDefaults.standard.isMaster && UserDefaults.standard.followerDataSourceType == .nightscout) {
+            traceInfo.appendStringAndNewLine("    Description: " + (UserDefaults.standard.activeSensorDescription?.description ?? "nil"))
+            if let startDate = UserDefaults.standard.activeSensorStartDate {
+                traceInfo.appendStringAndNewLine("    Sensor start date: " + startDate.toString(timeStyle: .short, dateStyle: .medium) + " (" + startDate.daysAndHoursAgo(appendAgo: true) + ")")
+            } else {
+                traceInfo.appendStringAndNewLine("    Sensor start date: nil")
+            }
+            traceInfo.appendStringAndNewLine("    Sensor max days: " + (UserDefaults.standard.activeSensorMaxSensorAgeInDays?.description ?? "nil"))
+            traceInfo.appendStringAndNewLine("    Transmitter ID: " + (UserDefaults.standard.activeSensorTransmitterId?.description ?? "nil"))
+        } else {
+            traceInfo.appendStringAndNewLine("    Not used in Nightscout follower mode")
+        }
         
         
         // Info from coredata
@@ -499,7 +501,7 @@ class Trace {
                 if let alias = blePeripheral.alias {
                     traceInfo.appendStringAndNewLine("        Alias: " + alias)
                 }
-                traceInfo.appendStringAndNewLine("        " + ConstantsHomeView.applicationName + " will " + (blePeripheral.shouldconnect ? "try":"*not* try") + " to connect to this peripheral")
+                traceInfo.appendStringAndNewLine("        " + ConstantsHomeView.applicationName + (blePeripheral.shouldconnect ? " is set" : " is *not* set") + " to try and connect to this peripheral")
                 
                 if let libreSensorType = blePeripheral.libreSensorType {
                     traceInfo.appendStringAndNewLine("Last known libreSensorType: " + libreSensorType.description)
@@ -542,9 +544,21 @@ class Trace {
                             
                             traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
                             
+                            traceInfo.appendStringAndNewLine("        Transmitter start date: " + (dexcomG5.transmitterStartDate?.toString(timeStyle: .short, dateStyle: .medium) ?? "nil") + " (" + (UserDefaults.standard.activeSensorStartDate?.daysAndHoursAgo(appendAgo: true) ?? "nil") + ")")
+                            
+                            traceInfo.appendStringAndNewLine("        Sensor start date: " + (dexcomG5.sensorStartDate?.toString(timeStyle: .short, dateStyle: .medium) ?? "nil") + " (" + (UserDefaults.standard.activeSensorStartDate?.daysAndHoursAgo(appendAgo: true) ?? "nil") + ")")
+                            
+                            traceInfo.appendStringAndNewLine("        Sensor status: " + (dexcomG5.sensorStatus?.description ?? "nil"))
+                            
+                            traceInfo.appendStringAndNewLine("        Firmware: " + (dexcomG5.firmwareVersion?.description ?? "nil"))
+                            
+                            traceInfo.appendStringAndNewLine("        Read from Dexcom app: " + dexcomG5.useOtherApp.description)
+                            
+                            traceInfo.appendStringAndNewLine("        Last reset: " + (dexcomG5.lastResetTimeStamp?.toString(timeStyle: .short, dateStyle: .medium) ?? "nil") + " (" + (UserDefaults.standard.activeSensorStartDate?.daysAndHoursAgo(appendAgo: true) ?? "nil") + ")")
+                            
                             // if needed additional specific info can be added
-                            traceInfo.appendStringAndNewLine("        Voltage A: " + dexcomG5.voltageA.description)
-                            traceInfo.appendStringAndNewLine("        Voltage B: " + dexcomG5.voltageB.description)
+                            traceInfo.appendStringAndNewLine("        Voltage A: " + dexcomG5.voltageA.description + "0mV")
+                            traceInfo.appendStringAndNewLine("        Voltage B: " + dexcomG5.voltageB.description + "0mV")
                             
                         }
                         
@@ -623,23 +637,23 @@ class Trace {
                     }
                 }
                 
-                traceInfo.appendStringAndNewLine("")
-                
             }
             
             traceInfo.appendStringAndNewLine(paragraphSeperator)
             
             // all alertentries
-            traceInfo.appendStringAndNewLine("List of Alarms:\n")
+            traceInfo.appendStringAndNewLine("List of Alarms:")
             
             for alertKind in AlertKind.allCases {
                 
-                traceInfo.appendStringAndNewLine("    Name: " + alertKind.descriptionForLogging())
+                traceInfo.appendStringAndNewLine("")
+                
+                traceInfo.appendStringAndNewLine("    " + alertKind.descriptionForLogging())
                 
                 let alertEntries = alertEntriesAccessor.getAllEntries(forAlertKind: alertKind, alertTypesAccessor: alertTypesAccessor)
                 
                 for alertEntry in alertEntries {
-                    traceInfo.appendStringAndNewLine("        start: " + alertEntry.start.convertMinutesToTimeAsString() + " / value: " + alertEntry.value.description + " / alarm type: " + alertEntry.alertType.description)
+                    traceInfo.appendStringAndNewLine("        -> start: " + alertEntry.start.convertMinutesToTimeAsString() + " / value: " +  alertEntry.value.description + " / alarm type: " + alertEntry.alertType.description)
                     
                 }
                 
@@ -654,7 +668,8 @@ class Trace {
                 
                 traceInfo.appendStringAndNewLine("    Name: " + alertType.description)
                 traceInfo.appendStringAndNewLine("        Enabled: " + alertType.enabled.description)
-                traceInfo.appendStringAndNewLine("        Override Mute: " + alertType.overridemute.description)
+                traceInfo.appendStringAndNewLine("        Override mute: " + alertType.overridemute.description)
+                traceInfo.appendStringAndNewLine("        Vibrate: " + alertType.vibrate.description)
                 traceInfo.appendStringAndNewLine("        Snooze via notification: " + alertType.snooze.description)
                 traceInfo.appendStringAndNewLine("        Default snooze period: " + alertType.snoozeperiod.description)
                 if let soundname = alertType.soundname {

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/BluetoothPeripheralViewController.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/BluetoothPeripheralViewController.swift
@@ -1582,6 +1582,12 @@ extension BluetoothPeripheralViewController: UITableViewDataSource, UITableViewD
 // MARK: - extension BluetoothTransmitterDelegate
 
 extension BluetoothPeripheralViewController: BluetoothTransmitterDelegate {
+
+    func heartBeat() {
+        
+        bluetoothPeripheralManager?.heartBeat()
+        
+    }
     
     func transmitterNeedsPairing(bluetoothTransmitter: BluetoothTransmitter) {
         

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/HeartBeat/DexcomG7HeartBeatBluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/HeartBeat/DexcomG7HeartBeatBluetoothPeripheralViewModel.swift
@@ -1,0 +1,68 @@
+//
+//  DexcomG7HeartBeatBluetoothPeripheralViewModel.swift
+//  xdrip
+//
+//  Created by Johan Degraeve on 05/08/2023.
+//  Copyright © 2024 Johan Degraeve. All rights reserved.
+//
+
+import Foundation
+
+class DexcomG7HeartBeatBluetoothPeripheralViewModel {
+    
+    /// reference to bluetoothPeripheralManager
+    private weak var bluetoothPeripheralManager: BluetoothPeripheralManaging?
+    
+    /// temporary reference to bluetoothPerpipheral, will be set in configure function.
+    private var bluetoothPeripheral: BluetoothPeripheral?
+
+}
+
+// MARK: - conform to BluetoothPeripheralViewModel
+
+extension DexcomG7HeartBeatBluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
+
+    func configure(bluetoothPeripheral: BluetoothPeripheral?, bluetoothPeripheralManager: BluetoothPeripheralManaging, tableView: UITableView, bluetoothPeripheralViewController: BluetoothPeripheralViewController) {
+        
+        self.bluetoothPeripheralManager = bluetoothPeripheralManager
+        
+        self.bluetoothPeripheral = bluetoothPeripheral
+        
+    }
+    
+    func screenTitle() -> String {
+        return BluetoothPeripheralType.DexcomG7HeartBeatType.rawValue
+    }
+    
+    func sectionTitle(forSection section: Int) -> String {
+        
+        // there's no section specific for this type of transmitter, this function will not be called
+        return "Dexcom G7 Heartbeat"
+        
+    }
+    
+    func update(cell: UITableViewCell, forRow rawValue: Int, forSection section: Int, for bluetoothPeripheral: BluetoothPeripheral) {
+    }
+    
+    
+    func userDidSelectRow(withSettingRawValue rawValue: Int, forSection section: Int, for bluetoothPeripheral: BluetoothPeripheral, bluetoothPeripheralManager: BluetoothPeripheralManaging) -> SettingsSelectedRowAction {
+        
+        // there's no section specific for this type of transmitter, so user won't click anything, this function will not be called
+        return .nothing
+        
+    }
+    
+    func numberOfSettings(inSection section: Int) -> Int {
+        
+        return 0
+        
+    }
+    
+    func numberOfSections() -> Int {
+        
+        // one specific section
+        return 0
+        
+    }
+    
+}

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/HeartBeat/Libre3HeartBeatBluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/HeartBeat/Libre3HeartBeatBluetoothPeripheralViewModel.swift
@@ -1,0 +1,68 @@
+//
+//  Libre3HeartBeatBluetoothPeripheralViewModel.swift
+//  xdrip
+//
+//  Created by Johan Degraeve on 05/08/2023.
+//  Copyright © 2024 Johan Degraeve. All rights reserved.
+//
+
+import Foundation
+
+class Libre3HeartBeatBluetoothPeripheralViewModel {
+    
+    /// reference to bluetoothPeripheralManager
+    private weak var bluetoothPeripheralManager: BluetoothPeripheralManaging?
+    
+    /// temporary reference to bluetoothPerpipheral, will be set in configure function.
+    private var bluetoothPeripheral: BluetoothPeripheral?
+
+}
+
+// MARK: - conform to BluetoothPeripheralViewModel
+
+extension Libre3HeartBeatBluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
+    
+    func configure(bluetoothPeripheral: BluetoothPeripheral?, bluetoothPeripheralManager: BluetoothPeripheralManaging, tableView: UITableView, bluetoothPeripheralViewController: BluetoothPeripheralViewController) {
+        
+        self.bluetoothPeripheralManager = bluetoothPeripheralManager
+        
+        self.bluetoothPeripheral = bluetoothPeripheral
+        
+    }
+    
+    func screenTitle() -> String {
+        return BluetoothPeripheralType.Libre3HeartBeatType.rawValue
+    }
+    
+    func sectionTitle(forSection section: Int) -> String {
+        
+        // there's no section specific for this type of transmitter, this function will not be called
+        return "Libre 3 Heartbeat"
+        
+    }
+    
+    func update(cell: UITableViewCell, forRow rawValue: Int, forSection section: Int, for bluetoothPeripheral: BluetoothPeripheral) {
+    }
+    
+    
+    func userDidSelectRow(withSettingRawValue rawValue: Int, forSection section: Int, for bluetoothPeripheral: BluetoothPeripheral, bluetoothPeripheralManager: BluetoothPeripheralManaging) -> SettingsSelectedRowAction {
+        
+        // there's no section specific for this type of transmitter, so user won't click anything, this function will not be called
+        return .nothing
+        
+    }
+    
+    func numberOfSettings(inSection section: Int) -> Int {
+        
+        return 0
+        
+    }
+    
+    func numberOfSections() -> Int {
+        
+        // one specific section
+        return 0
+        
+    }
+    
+}

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/HeartBeat/OmniPodHeartBeatBluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/HeartBeat/OmniPodHeartBeatBluetoothPeripheralViewModel.swift
@@ -1,0 +1,69 @@
+//
+//  OmniPodHeartBeatBluetoothPeripheralViewModel.swift
+//  xdrip
+//
+//  Created by Johan Degraeve on 08/02/2024.
+//  Copyright © 2024 Johan Degraeve. All rights reserved.
+//
+
+import Foundation
+
+class OmniPodHeartBeatBluetoothPeripheralViewModel {
+    
+    /// reference to bluetoothPeripheralManager
+    private weak var bluetoothPeripheralManager: BluetoothPeripheralManaging?
+    
+    /// temporary reference to bluetoothPerpipheral, will be set in configure function.
+    private var bluetoothPeripheral: BluetoothPeripheral?
+
+}
+
+// MARK: - conform to BluetoothPeripheralViewModel
+
+extension OmniPodHeartBeatBluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
+    
+    func configure(bluetoothPeripheral: BluetoothPeripheral?, bluetoothPeripheralManager: BluetoothPeripheralManaging, tableView: UITableView, bluetoothPeripheralViewController: BluetoothPeripheralViewController) {
+        
+        self.bluetoothPeripheralManager = bluetoothPeripheralManager
+        
+        self.bluetoothPeripheral = bluetoothPeripheral
+        
+    }
+    
+    func screenTitle() -> String {
+        return BluetoothPeripheralType.OmniPodHeartBeatType.rawValue
+    }
+    
+    func sectionTitle(forSection section: Int) -> String {
+        
+        // there's no section specific for this type of transmitter, this function will not be called
+        return "OmniPod Heartbeat"
+        
+    }
+    
+    func update(cell: UITableViewCell, forRow rawValue: Int, forSection section: Int, for bluetoothPeripheral: BluetoothPeripheral) {
+    }
+    
+    
+    func userDidSelectRow(withSettingRawValue rawValue: Int, forSection section: Int, for bluetoothPeripheral: BluetoothPeripheral, bluetoothPeripheralManager: BluetoothPeripheralManaging) -> SettingsSelectedRowAction {
+        
+        // there's no section specific for this type of transmitter, so user won't click anything, this function will not be called
+        return .nothing
+        
+    }
+    
+    func numberOfSettings(inSection section: Int) -> Int {
+        
+        return 0
+        
+    }
+    
+    func numberOfSections() -> Int {
+        
+        // one specific section
+        return 0
+        
+    }
+    
+}
+

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralsViewController.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralsViewController.swift
@@ -367,6 +367,12 @@ extension BluetoothPeripheralsViewController: UITableViewDataSource, UITableView
 
 extension BluetoothPeripheralsViewController: BluetoothTransmitterDelegate {
     
+    func heartBeat() {
+        
+        bluetoothPeripheralManager?.heartBeat()
+        
+    }
+
     func transmitterNeedsPairing(bluetoothTransmitter: BluetoothTransmitter) {
        
         // forward this call to bluetoothPeripheralManager who will handle it

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -3008,7 +3008,9 @@ final class RootViewController: UIViewController, ObservableObject {
         // if there is a transmitter connected, pull the current maxSensorAgeInDays and store in in UserDefaults
         if let cgmTransmitter = self.bluetoothPeripheralManager?.getCGMTransmitter(), let maxDays = cgmTransmitter.maxSensorAgeInDays() {
             
-            UserDefaults.standard.activeSensorMaxSensorAgeInDays = maxDays
+            if maxDays > 0 {
+                UserDefaults.standard.activeSensorMaxSensorAgeInDays = maxDays
+            }
             
             UserDefaults.standard.activeSensorDescription = cgmTransmitter.cgmTransmitterType().detailedDescription()
             

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -525,6 +525,8 @@ final class RootViewController: UIViewController, ObservableObject {
     /// libreLinkUpFollowManager instance
     private var libreLinkUpFollowManager: LibreLinkUpFollowManager?
     
+    private var loopFollowManager: LoopFollowManager?
+    
     /// dexcomShareUploadManager instance
     private var dexcomShareUploadManager: DexcomShareUploadManager?
     
@@ -1073,6 +1075,9 @@ final class RootViewController: UIViewController, ObservableObject {
         // setup nightscoutmanager
         libreLinkUpFollowManager = LibreLinkUpFollowManager(coreDataManager: coreDataManager, followerDelegate: self)
         
+        // setup loop follow manager
+        loopFollowManager = LoopFollowManager(coreDataManager: coreDataManager, followerDelegate: self)
+        
         // setup healthkitmanager
         healthKitManager = HealthKitManager(coreDataManager: coreDataManager)
         
@@ -1153,7 +1158,15 @@ final class RootViewController: UIViewController, ObservableObject {
         }
         
         // setup bluetoothPeripheralManager
-        bluetoothPeripheralManager = BluetoothPeripheralManager(coreDataManager: coreDataManager, cgmTransmitterDelegate: self, uIViewController: self, cgmTransmitterInfoChanged: cgmTransmitterInfoChanged)
+        bluetoothPeripheralManager = BluetoothPeripheralManager(coreDataManager: coreDataManager, cgmTransmitterDelegate: self, uIViewController: self, heartBeatFunction: {
+            
+            self.loopFollowManager?.getReading()
+            
+            self.nightScoutFollowManager?.download()
+        
+            self.libreLinkUpFollowManager?.download()
+
+        }, cgmTransmitterInfoChanged: cgmTransmitterInfoChanged)
         
         // to initialize UserDefaults.standard.transmitterTypeAsString
         cgmTransmitterInfoChanged()
@@ -1539,7 +1552,7 @@ final class RootViewController: UIViewController, ObservableObject {
             
             // if showReadingInAppBadge = false, means user set it from true to false
             // set the app badge to 0. This will cause removal of the badge counter, but also removal of any existing notification on the screen
-            if !UserDefaults.standard.showReadingInAppBadge || (!UserDefaults.standard.isMaster && UserDefaults.standard.followerBackgroundKeepAliveType == .disabled) {
+            if !UserDefaults.standard.showReadingInAppBadge {
                 
                 // applicationIconBadgeNumber has been deprecated for iOS17 but as we currently have a minimum deployment target of iOS15, let's add a conditional check
                 if #available(iOS 16.0, *) {
@@ -1547,13 +1560,6 @@ final class RootViewController: UIViewController, ObservableObject {
                 } else {
                     UIApplication.shared.applicationIconBadgeNumber = 0
                 }
-                
-            }
-            
-            // make sure that any pending (i.e. already scheduled in the future) missed reading notifications are removed
-            if !UserDefaults.standard.isMaster && UserDefaults.standard.followerBackgroundKeepAliveType == .disabled {
-                
-                UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [ConstantsNotifications.NotificationIdentifiersForAlerts.missedReadingAlert])
                 
             }
             
@@ -2093,8 +2099,8 @@ final class RootViewController: UIViewController, ObservableObject {
             // Create Notification Content
             let notificationContent = UNMutableNotificationContent()
             
-            // set value in badge if required and also only if master, or when background keep alive is enabled for followers
-            if UserDefaults.standard.showReadingInAppBadge && (UserDefaults.standard.isMaster || (!UserDefaults.standard.isMaster &&  UserDefaults.standard.followerBackgroundKeepAliveType != .disabled)) {
+            // set value in badge if required
+            if UserDefaults.standard.showReadingInAppBadge {
                 
                 // rescale if unit is mmol
                 if !UserDefaults.standard.bloodGlucoseUnitIsMgDl {
@@ -2137,7 +2143,7 @@ final class RootViewController: UIViewController, ObservableObject {
             
             // notification shouldn't be shown, but maybe the badge counter. Here the badge value needs to be shown in another way and also only if master, or when background keep alive is enabled for followers
             
-            if UserDefaults.standard.showReadingInAppBadge && (UserDefaults.standard.isMaster || (!UserDefaults.standard.isMaster && UserDefaults.standard.followerBackgroundKeepAliveType != .disabled)) {
+            if UserDefaults.standard.showReadingInAppBadge {
                 
                 // rescale of unit is mmol
                 readingValueForBadge = readingValueForBadge.mgdlToMmol(mgdl: UserDefaults.standard.bloodGlucoseUnitIsMgDl)


### PR DESCRIPTION
Libre3 and/or Dexcom G7 and/or OmniPod as heartbeat

- Libre 3 or Dexcom G7 as heartbeat
  - Libre 3 as heartbeat: avoids the need for audioPlayer that keeps the app alive in the background. When Libre 3 sends data, xDrip4iOS will wake up and fetch a reading from LibreView
  - Dexcom G7 as heartbeat: only useful in combination with Loop. Loop must read the Dexcom G7 readings and upload to NightScout. xDrip4iOS will wake up when G7 sends data and will fetch the latest reading from NightScout. This occurs with a delay (Thread.sleep) of 1 second, to give time to loop to upload the reading to NightScout. Sometimes xDrip4iOS is still to early to fetch the reading. In that case, it may help to delete the heartbeat and recreate it.
  - OmniPod as heartbeat: for OmniPod users, this is a useful additional heartbeat. OmniPod has the interesting 'feature' to disconnect and reconnect every few minutes. Which allows to call the heartbeat function.
  - M5Stack as heartbeat: this is implemented as part of the M5Stack transmitter, it does not appear in the list of heartbeat devices. M5Stack will wake up xDrip4iOS if it didn't receive a reading from xDrip4iOS for more than 5 minutes. This allows xDrip4iOS to download the latest reading and send it to the M5Stack. Needs the latest release of M5stack or M5Stick-C software : https://github.com/JohanDegraeve/M5_NightscoutMon or https://github.com/JohanDegraeve/M5_StickC_xdrip_iOS 


- the change required also to re-enable alarms, notifications, badge counter, ... when user has chosen followerBackgroundKeepAliveType disabled

- To use Libre 3 has heartbeat:
  - First connect to Libre 3 with official Libre 3 app
  - when connected, go to the iOS settings and read and note the name of the Libre (it's not something with ABBOTT in it, it's more like a random string)
  - force close the Libre 3 app
  - in xDrip4iOS, go to the bluetooth section
  - add a new transmitter of type HeartBeat
  - select Libre 3
  - as transmitter id, fill in the name you read in the iOS settings, just 4 or 5 characters is enough. It's case insensitive.
  - click the scan button. (you will not be asked to do NFC scan)
  - wait till connected
  - now reopen the official Libre 3 app

- To use Dexcom G7 as heartbeat:
  - make sure you connected at least once to the Dexcom G7 with the official Dexcom app and/or Loop.
  - Not necessary to force close other apps (like Official Dexcom G7 app and Loop)
  - go to the iOS settings and read and note the name of the Dexcom G7. It's case insensitive.
  - in xDrip4iOS, go to the bluetooth section
  - add a new transmitter of type HeartBeat
  - select Dexcom G7
  - as transmitter id, fill in the name you read in the iOS settings.
  - click the scan button. (you will not be asked to do NFC scan)
  - wait till connected

- To use OmniPod as heartbeat:
  - Force close any other app that connects to the OmniPod (that should only be Loop)
  - in xDrip4iOS, go to the bluetooth section
  - add a new transmitter of type HeartBeat
  - select OmniPod
  - click the scan button
  - wait till connected
  - you can now reopen Loop



