### PR TITLE
Fix `Payload maximum size exceeded` error when starting Live Activity

### DIFF
--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -3497,9 +3497,18 @@ final class RootViewController: UIViewController, ObservableObject {
                     // create two simple arrays to send to the live activiy. One with the bg values in mg/dL and another with the corresponding timestamps
                     // this is needed due to the not being able to pass structs that are not codable/hashable
                     let hoursOfBgReadingsToSend: Double = 12
-                    
-                    let bgReadings = bgReadingsAccessor.getLatestBgReadings(limit: nil, fromDate: Date().addingTimeInterval(-3600 * hoursOfBgReadingsToSend), forSensor: nil, ignoreRawData: true, ignoreCalculatedValue: false)
-                    
+
+                    let allBgReadings = bgReadingsAccessor.getLatestBgReadings(limit: nil, fromDate: Date().addingTimeInterval(-3600 * hoursOfBgReadingsToSend), forSensor: nil, ignoreRawData: true, ignoreCalculatedValue: false)
+
+                    // Live Activities have maximum payload size of 4kB.
+                    // This value is selected by testing how much we can send before getting the "Payload maximum size exceeded" error.
+                    let maxNumberOfReadings = 100
+
+                    // If there are more readings than we can send to the Live Activity, downsample the values to fit.
+                    let bgReadings = allBgReadings.count > maxNumberOfReadings
+                      ? (0 ..< maxNumberOfReadings).map { allBgReadings[$0 * allBgReadings.count / maxNumberOfReadings] }
+                      : allBgReadings
+
                     if bgReadings.count > 0 {
                         
                         var slopeOrdinal: Int = 0


### PR DESCRIPTION
Live Activities have maximum payload size of 4kB.

At least Libre 2 EU produces so many values over 12 hours (some 400 readings for me) that they cannot be pushed to Live Activity unfiltered, causing Live Activity start to fail with error: `Payload maximum size exceeded`.

Fix by downsampling (just pick every nth reading) to maximum of 100 readings. 

The threshold value is got by trial and error, then tuning it down a bit to leave some room for different length strings.