### PR TITLE
5.1.4 staging

### DIFF
--- a/xDrip Watch App/Views/MainView.swift
+++ b/xDrip Watch App/Views/MainView.swift
@@ -133,9 +133,9 @@ struct ContentView_Previews: PreviewProvider {
         
         watchState.bgReadingValues = bgValueArray()
         watchState.bgReadingDates = bgDateArray()
-        watchState.isMgDl = true
-        watchState.slopeOrdinal = 5
-        watchState.deltaChangeInMgDl = 0
+        watchState.isMgDl = false
+        watchState.slopeOrdinal = 3
+        watchState.deltaChangeInMgDl = 2
         watchState.urgentLowLimitInMgDl = 60
         watchState.lowLimitInMgDl = 80
         watchState.highLimitInMgDl = 140

--- a/xDrip Watch App/Views/SubViews/HeaderView.swift
+++ b/xDrip Watch App/Views/SubViews/HeaderView.swift
@@ -17,7 +17,7 @@ struct HeaderView: View {
     var body: some View {
         HStack(alignment: .lastTextBaseline) {
             Text("\(watchState.bgValueStringInUserChosenUnit())\(watchState.trendArrow())")
-                .font(.system(size: isSmallScreen ? 45 : 55)).fontWeight(.semibold)
+                .font(.system(size: isSmallScreen ? 40 : 50)).fontWeight(.semibold)
                 .foregroundStyle(watchState.bgTextColor())
                 .scaledToFill()
                 .minimumScaleFactor(0.5)

--- a/xDrip Widget/DataModels/XDripWidgetAttributes.swift
+++ b/xDrip Widget/DataModels/XDripWidgetAttributes.swift
@@ -15,19 +15,23 @@ struct XDripWidgetAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
 
         // Store values with a 16 bit precision to save payload bytes
-        private var _bgReadingValues: [Float16]
+        private var bgReadingFloats: [Float16]
         // Expose those conveniently as Doubles
-        var bgReadingValues: [Double] { _bgReadingValues.map(Double.init) }
+        var bgReadingValues: [Double] {
+            bgReadingFloats.map(Double.init)
+        }
 
         // To save those precious payload bytes, store only the earliest date as Date
-        private var _firstDate: Date
+        private var firstDate: Date
         // ...and all other as seconds from that moment.
         // No need for floating points, a second is precise enough for the graph
         // UInt16 maximum value is 65535 so that means 18.2 hours.
         // This would need to be changed if wishing to present a 24 hour chart.
-        private var _secondsSinceFirstDate: [UInt16]
+        private var secondsSinceFirstDate: [UInt16]
         // Expose the dates conveniently
-        var bgReadingDates: [Date] { _secondsSinceFirstDate.map { Date(timeInterval: Double($0), since: _firstDate) } }
+        var bgReadingDates: [Date] {
+            secondsSinceFirstDate.map { Date(timeInterval: Double($0), since: firstDate) }
+        }
 
         var isMgDl: Bool
         var slopeOrdinal: Int
@@ -40,19 +44,30 @@ struct XDripWidgetAttributes: ActivityAttributes {
         var warnUserToOpenApp: Bool = true
         var liveActivitySize: LiveActivitySize
         var dataSourceDescription: String
-        
-        // computed properties
-        var bgUnitString: String
-        var bgValueInMgDl: Double?
-        var bgReadingDate: Date?
-        var bgValueStringInUserChosenUnit: String
-        
-        init(bgReadingValues: [Double], bgReadingDates: [Date], isMgDl: Bool, slopeOrdinal: Int, deltaChangeInMgDl: Double?, urgentLowLimitInMgDl: Double, lowLimitInMgDl: Double, highLimitInMgDl: Double, urgentHighLimitInMgDl: Double, liveActivitySize: LiveActivitySize, dataSourceDescription: String? = "") {
 
-            self._bgReadingValues = bgReadingValues.map(Float16.init)
+        var bgUnitString: String {
+            isMgDl ? Texts_Common.mgdl : Texts_Common.mmol
+        }
+        /// the latest bg reading
+        var bgValueInMgDl: Double? {
+            bgReadingValues[0]
+        }
+        /// the latest bg reading date
+        var bgReadingDate: Date? {
+            bgReadingDates[0]
+        }
+
+        var bgValueStringInUserChosenUnit: String {
+            bgReadingValues[0].mgdlToMmolAndToString(mgdl: isMgDl)
+        }
+
+        init(bgReadingValues: [Double], bgReadingDates: [Date], isMgDl: Bool, slopeOrdinal: Int, deltaChangeInMgDl: Double?, urgentLowLimitInMgDl: Double, lowLimitInMgDl: Double, highLimitInMgDl: Double, urgentHighLimitInMgDl: Double, liveActivitySize: LiveActivitySize, dataSourceDescription: String? = "") {
+        
+            self.bgReadingFloats = bgReadingValues.map(Float16.init)
+
             let firstDate = bgReadingDates.last ?? .now
-            self._firstDate = firstDate
-            self._secondsSinceFirstDate = bgReadingDates.map { UInt16(truncatingIfNeeded: Int($0.timeIntervalSince(firstDate))) }
+            self.firstDate = firstDate
+            self.secondsSinceFirstDate = bgReadingDates.map { UInt16(truncatingIfNeeded: Int($0.timeIntervalSince(firstDate))) }
             
             self.isMgDl = isMgDl
             self.slopeOrdinal = slopeOrdinal
@@ -63,13 +78,6 @@ struct XDripWidgetAttributes: ActivityAttributes {
             self.urgentHighLimitInMgDl = urgentHighLimitInMgDl            
             self.liveActivitySize = liveActivitySize
             self.dataSourceDescription = dataSourceDescription ?? ""
-            
-            self.bgUnitString = isMgDl ? Texts_Common.mgdl : Texts_Common.mmol
-            
-            // the last bg reading (used for other functions)
-            self.bgValueInMgDl = bgReadingValues[0]
-            self.bgReadingDate = bgReadingDates[0]
-            self.bgValueStringInUserChosenUnit = bgReadingValues[0].mgdlToMmolAndToString(mgdl: isMgDl)
         }
         
         /// Blood glucose color dependant on the user defined limit values and based upon the time since the last reading

--- a/xdrip.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xdrip.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "20a19467224593c1dcb0789843c73f4580a23d8227b26f5a2c54d6c62c75927e",
   "pins" : [
     {
       "identity" : "actionclosurable",
@@ -37,5 +38,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralCategory.swift
+++ b/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralCategory.swift
@@ -11,7 +11,7 @@ enum BluetoothPeripheralCategory: String, CaseIterable {
     
     /// for using a a bluetooth device as heartbeat : whenever the device sends someting over a read characteristic, then xDrip4iOS will wake up
     /// Heartbeat also works for connect and disconnect
-    case HeartBeat = "HeartBeat"
+    case HeartBeat = "HeartBeat ♥"
     
     /// returns index in list of BluetoothPeripheralCategory's
     func index() -> Int {

--- a/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
+++ b/xdrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
@@ -50,7 +50,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
     case AtomType = "Atom"
     
     /// to use a Libre 3 as heartbeat
-    case Libre3HeartBeatType = "Libre 3 HeartBeat"
+    case Libre3HeartBeatType = "Libre HeartBeat"
     
     /// DexcomG7 heartbeat
     case DexcomG7HeartBeatType = "Dexcom G7 HeartBeat"

--- a/xdrip/Constants/ConstantsGlucoseChartSwiftUI.swift
+++ b/xdrip/Constants/ConstantsGlucoseChartSwiftUI.swift
@@ -62,7 +62,7 @@ enum ConstantsGlucoseChartSwiftUI {
     static let viewHeightWatchApp: CGFloat = 90
     
     // watch chart sizes for smaller watches
-    static let viewWidthWatchAppSmall: CGFloat = 175
+    static let viewWidthWatchAppSmall: CGFloat = 155
     static let viewHeightWatchAppSmall: CGFloat = 75
     
     static let lowHighLineColorWatchApp = Color(white: 0.6)

--- a/xdrip/Constants/ConstantsNightScout.swift
+++ b/xdrip/Constants/ConstantsNightScout.swift
@@ -24,5 +24,7 @@ enum ConstantsNightScout {
     
     /// the text used by Nightscout for the "unit" json attribute for BG Checks stored in mmol/l
     static let mmolNightscoutUnitString = "mmol"
-
+    
+    /// how many seconds should we force the app to wait between treatment sync attempts
+    static let minimiumTimeBetweenTwoTreatmentSyncsInSeconds: Double = 10
 }

--- a/xdrip/Extensions/UserDefaults.swift
+++ b/xdrip/Extensions/UserDefaults.swift
@@ -292,6 +292,8 @@ extension UserDefaults {
         // Nightscout
         /// timestamp lastest reading uploaded to NightScout
         case timeStampLatestNSUploadedBgReadingToNightScout = "timeStampLatestUploadedBgReading"
+        /// timestamp lastest treatment sync request to NightScout
+        case timeStampLatestNightScoutTreatmentSyncRequest = "timeStampLatestNightScoutTreatmentSyncRequest"
         /// timestamp latest calibration uploaded to NightScout
         case timeStampLatestNSUploadedCalibrationToNightScout = "timeStampLatestUploadedCalibration"
         
@@ -1373,6 +1375,16 @@ extension UserDefaults {
         }
         set {
             set(newValue, forKey: Key.nightScoutSyncTreatmentsRequired.rawValue)
+        }
+    }
+    
+    /// timestamp lastest reading uploaded to NightScout
+    var timeStampLatestNightScoutTreatmentSyncRequest: Date? {
+        get {
+            return object(forKey: Key.timeStampLatestNightScoutTreatmentSyncRequest.rawValue) as? Date
+        }
+        set {
+            set(newValue, forKey: Key.timeStampLatestNightScoutTreatmentSyncRequest.rawValue)
         }
     }
     

--- a/xdrip/Managers/Alerts/AlertManager.swift
+++ b/xdrip/Managers/Alerts/AlertManager.swift
@@ -720,7 +720,7 @@ public class AlertManager:NSObject {
             
         } else {
             if !UserDefaults.standard.isMaster && !UserDefaults.standard.followerBackgroundKeepAliveType.shouldKeepAlive {
-                trace("in checkAlert, there's no need to raise alert %{public}@ because we're in follower mode and keep-alive is: %[public]@", log: self.log, category: ConstantsLog.categoryAlertManager, type: .info, alertKind.descriptionForLogging(), UserDefaults.standard.followerBackgroundKeepAliveType.description)
+                trace("in checkAlert, there's no need to raise alert %{public}@ because we're in follower mode and keep-alive is: %{public}@", log: self.log, category: ConstantsLog.categoryAlertManager, type: .info, alertKind.descriptionForLogging(), UserDefaults.standard.followerBackgroundKeepAliveType.description)
             } else {
                 trace("in checkAlert, there's no need to raise alert %{public}@", log: self.log, category: ConstantsLog.categoryAlertManager, type: .info, alertKind.descriptionForLogging())
             }

--- a/xdrip/Managers/LibreLinkUp/LibreLinkUpFollowManager.swift
+++ b/xdrip/Managers/LibreLinkUp/LibreLinkUpFollowManager.swift
@@ -24,9 +24,6 @@ class LibreLinkUpFollowManager: NSObject {
     /// for logging
     private var log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryLibreLinkUpFollowManager)
     
-    /// when to do next download
-    private var nextFollowDownloadTimeStamp: Date
-    
     /// reference to coredatamanager
     private var coreDataManager: CoreDataManager
     
@@ -92,9 +89,6 @@ class LibreLinkUpFollowManager: NSObject {
     
     /// initializer
     public init(coreDataManager:CoreDataManager, followerDelegate: FollowerDelegate) {
-        
-        // initialize nextFollowDownloadTimeStamp to now, which is at the moment FollowManager is instantiated
-        nextFollowDownloadTimeStamp = Date()
         
         // initialize non optional private properties
         self.coreDataManager = coreDataManager
@@ -207,10 +201,10 @@ class LibreLinkUpFollowManager: NSObject {
         
         trace("in download", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info)
         
-        trace("    setting nightScoutSyncTreatmentsRequired to true, this will also initiate a treatments sync", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info)
-
-        // TODO: crash here sometimes
-        DispatchQueue.main.async {
+        if (UserDefaults.standard.timeStampLatestNightScoutTreatmentSyncRequest ?? Date.distantPast).timeIntervalSinceNow > 15 {
+            trace("    setting nightScoutSyncTreatmentsRequired to true, this will also initiate a treatments sync", log: self.log, category: ConstantsLog.categoryLibreLinkUpFollowManager, type: .info)
+            
+            UserDefaults.standard.timeStampLatestNightScoutTreatmentSyncRequest = .now
             UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
         }
         
@@ -312,7 +306,7 @@ class LibreLinkUpFollowManager: NSObject {
                         }
                         
                         // schedule new download
-                        self.scheduleNewDownload()
+                        //self.scheduleNewDownload()
                         
                     }
                     

--- a/xdrip/Managers/Loop/LoopManager.swift
+++ b/xdrip/Managers/Loop/LoopManager.swift
@@ -210,7 +210,9 @@ public class LoopManager:NSObject {
             sharedUserDefaults.set(data, forKey: "latestReadings")
             
             // store in local userdefaults
-            UserDefaults.standard.readingsStoredInSharedUserDefaultsAsDictionary = dictionary
+            if !dictionary.isEmpty {
+                UserDefaults.standard.readingsStoredInSharedUserDefaultsAsDictionary = dictionary
+            }
             
             // initially set timeStampLatestLoopSharedBgReading to timestamp of first reading - may get another value later, in case loopdelay > 0
             // add 5 seconds to last Readings timestamp, because due to the way timestamp for libre readings is calculated, it may happen that the same reading shifts 1 or 2 seconds in next reading cycle

--- a/xdrip/Managers/NightScout/NightScoutFollowManager.swift
+++ b/xdrip/Managers/NightScout/NightScoutFollowManager.swift
@@ -123,16 +123,17 @@ class NightScoutFollowManager: NSObject {
     @objc public func download() {
         
         trace("in download", log: self.log, category: ConstantsLog.categoryNightScoutFollowManager, type: .info)
-
-        trace("    setting nightScoutSyncTreatmentsRequired to true, this will also initiate a treatments sync", log: self.log, category: ConstantsLog.categoryNightScoutFollowManager, type: .info)
         
-        DispatchQueue.main.async {
-            UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
-        }
-
         guard UserDefaults.standard.nightScoutEnabled else {
             trace("    nightscout not enabled", log: self.log, category: ConstantsLog.categoryNightScoutFollowManager, type: .info)
             return
+        }
+        
+        if (UserDefaults.standard.timeStampLatestNightScoutTreatmentSyncRequest ?? Date.distantPast).timeIntervalSinceNow < -ConstantsNightScout.minimiumTimeBetweenTwoTreatmentSyncsInSeconds {
+            trace("    setting nightScoutSyncTreatmentsRequired to true, this will also initiate a treatments sync", log: self.log, category: ConstantsLog.categoryNightScoutFollowManager, type: .info)
+            
+            UserDefaults.standard.timeStampLatestNightScoutTreatmentSyncRequest = .now
+            UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
         }
 
         guard !UserDefaults.standard.isMaster else {

--- a/xdrip/Texts/TextsSettingsView.swift
+++ b/xdrip/Texts/TextsSettingsView.swift
@@ -371,6 +371,18 @@ class Texts_SettingsView {
         return NSLocalizedString("settingsviews_transmitterid", tableName: filename, bundle: Bundle.main, value: "Transmitter ID:", comment: "transmitter settings, just the words that explain that the settings is about transmitter id")
     }()
     
+    static let labelBluetoothDeviceName:String = {
+        return NSLocalizedString("settingsviews_bluetoothDeviceName", tableName: filename, bundle: Bundle.main, value: "Device Name", comment: "transmitter settings, just the words that explain that the settings is about the bluetooth device name")
+    }()
+    
+    static let heartbeatLibreMessage:String = {
+        return NSLocalizedString("settingsviews_heartbeatLibreMessage", tableName: filename, bundle: Bundle.main, value: "IMPORTANT: You MUST force-close the Libre app first.\n\nEnter the device name shown in the iPhone Settings -> Bluetooth devices list.\n\nOnce you have connected, you can reopen the Libre app.", comment: "transmitter settings, instructions for adding a Libre heartbeat")
+    }()
+    
+    static let heartbeatG7Message:String = {
+        return NSLocalizedString("settingsviews_heartbeatG7Message", tableName: filename, bundle: Bundle.main, value: "IMPORTANT: Make sure the Dexcom app is running.\n\nEnter the Dexcom G7 bluetooth name shown in the iPhone Settings -> Bluetooth devices list.", comment: "transmitter settings, instructions for adding a G7 heartbeat")
+    }()
+    
     static let labelTransmitterIdTextForButton:String = {
         return NSLocalizedString("settingsviews_transmitterid_text_for_button", tableName: filename, bundle: Bundle.main, value: "Transmitter ID", comment: "transmitter settings, this is for the button, when clicked then user will be requested to give transmitter id. The only difference with settingsviews_transmitterid is that ':' is not added")
     }()

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/BluetoothPeripheralViewController.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/BluetoothPeripheralViewController.swift
@@ -973,7 +973,26 @@ class BluetoothPeripheralViewController: UIViewController {
         // unwrap bluetoothPeripheralManager
         guard let bluetoothPeripheralManager = bluetoothPeripheralManager else {return}
         
-        SettingsViewUtilities.runSelectedRowAction(selectedRowAction: SettingsSelectedRowAction.askText(title: Texts_SettingsView.labelTransmitterId, message: Texts_SettingsView.labelGiveTransmitterId, keyboardType: UIKeyboardType.alphabet, text: transmitterIdTempValue, placeHolder: "00000", actionTitle: nil, cancelTitle: nil, actionHandler:
+        // set default text strings. These will be overwritten if needed.
+        var transmitterIdTitleText = Texts_SettingsView.labelTransmitterId
+        var transmitterIdMessageText = Texts_SettingsView.labelGiveTransmitterId
+        var placeHolder = "00000"
+        
+        // if using a special case (like a heartbeat), adapt the strings to include relevant instructions and information
+        switch expectedBluetoothPeripheralType {
+        case .Libre3HeartBeatType:
+            transmitterIdTitleText = Texts_SettingsView.labelBluetoothDeviceName
+            transmitterIdMessageText = Texts_SettingsView.heartbeatLibreMessage
+            placeHolder = "000000000000"
+        case .DexcomG7HeartBeatType:
+            transmitterIdTitleText = Texts_SettingsView.labelBluetoothDeviceName
+            transmitterIdMessageText = Texts_SettingsView.heartbeatG7Message
+            placeHolder = "DXCM00"
+        default:
+            break
+        }
+        
+        SettingsViewUtilities.runSelectedRowAction(selectedRowAction: SettingsSelectedRowAction.askText(title: transmitterIdTitleText, message: transmitterIdMessageText, keyboardType: UIKeyboardType.alphabet, text: transmitterIdTempValue, placeHolder: placeHolder, actionTitle: nil, cancelTitle: nil, actionHandler:
             {(transmitterId:String) in
                 
                 // convert to uppercase

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/BluetoothPeripheralViewController.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/BluetoothPeripheralViewController.swift
@@ -1325,7 +1325,7 @@ extension BluetoothPeripheralViewController: UITableViewDataSource, UITableViewD
             case .nonFixedSlopeEnabled:
                 
                 cell.textLabel?.text = Texts_SettingsView.labelNonFixedTransmitter
-                cell.detailTextLabel?.text = nil
+                cell.detailTextLabel?.text = ""
                 
                 var currentStatus = false
                 if let bluetoothPeripheral = bluetoothPeripheral {
@@ -1377,9 +1377,9 @@ extension BluetoothPeripheralViewController: UITableViewDataSource, UITableViewD
                 
             case .webOOPEnabled:
                 
-                // set row text and set default row label to nil
+                // set row text and set default row label to an empty string
                 cell.textLabel?.text = Texts_SettingsView.labelWebOOPTransmitter
-                cell.detailTextLabel?.text = nil
+                cell.detailTextLabel?.text = ""
                 
                 // get current value of webOOPEnabled, default false
                 var currentWebOOPEnabledValue = false

--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/HeartBeat/Libre3HeartBeatBluetoothPeripheralViewModel.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/HeartBeat/Libre3HeartBeatBluetoothPeripheralViewModel.swift
@@ -37,7 +37,7 @@ extension Libre3HeartBeatBluetoothPeripheralViewModel: BluetoothPeripheralViewMo
     func sectionTitle(forSection section: Int) -> String {
         
         // there's no section specific for this type of transmitter, this function will not be called
-        return "Libre 3 Heartbeat ♥"
+        return "Libre Heartbeat ♥"
         
     }
     

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -860,7 +860,7 @@ final class RootViewController: UIViewController, ObservableObject {
             }
             
             // launch Nightscout sync
-            UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
+            self.setNightscoutSyncTreatmentsRequiredToTrue()
             
             self.updateLiveActivityAndWidgets(forceRestart: false)
             
@@ -1031,7 +1031,7 @@ final class RootViewController: UIViewController, ObservableObject {
         
         // launch nightscout treatment sync whenever the app comes to the foreground
         ApplicationManager.shared.addClosureToRunWhenAppWillEnterForeground(key: applicationManagerKeyStartNightScoutTreatmentSync, closure: {
-            UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
+            self.setNightscoutSyncTreatmentsRequiredToTrue()
         })
         
     }
@@ -2229,10 +2229,7 @@ final class RootViewController: UIViewController, ObservableObject {
     ///     - forceReset : if true, then force the update to be done even if the main chart is panned back in time (used for the double tap gesture)
     @objc private func updateLabelsAndChart(overrideApplicationState: Bool = false, forceReset: Bool = false) {
         
-        // TODO: Still crashing here...
-        DispatchQueue.main.async {
-            UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
-        }
+        setNightscoutSyncTreatmentsRequiredToTrue()
         
         // if glucoseChartManager not nil, then check if panned backward and if so then don't update the chart
         if let glucoseChartManager = glucoseChartManager  {
@@ -3487,43 +3484,39 @@ final class RootViewController: UIViewController, ObservableObject {
     /// also update the widget data stored in user defaults
     private func updateLiveActivityAndWidgets(forceRestart: Bool) {
         if #available(iOS 16.2, *) {
-            if (!UserDefaults.standard.isMaster && UserDefaults.standard.followerBackgroundKeepAliveType != .heartbeat) || UserDefaults.standard.liveActivityType == .disabled {
-                LiveActivityManager.shared.endAllActivities()
-            }
-            
-            DispatchQueue.main.async {
-                if let bgReadingsAccessor = self.bgReadingsAccessor {
+            if let bgReadingsAccessor = self.bgReadingsAccessor {
+                
+                // create two simple arrays to send to the live activiy. One with the bg values in mg/dL and another with the corresponding timestamps
+                // this is needed due to the not being able to pass structs that are not codable/hashable
+                let hoursOfBgReadingsToSend: Double = 12
+                
+                let bgReadings = bgReadingsAccessor.getLatestBgReadings(limit: nil, fromDate: Date().addingTimeInterval(-3600 * hoursOfBgReadingsToSend), forSensor: nil, ignoreRawData: true, ignoreCalculatedValue: false)
+                
+                if bgReadings.count > 0 {
                     
-                    // create two simple arrays to send to the live activiy. One with the bg values in mg/dL and another with the corresponding timestamps
-                    // this is needed due to the not being able to pass structs that are not codable/hashable
-                    let hoursOfBgReadingsToSend: Double = 12
+                    var slopeOrdinal: Int = 0
+                    var deltaChangeInMgDl: Double = 0
+                    var bgReadingValues: [Double] = []
+                    var bgReadingDates: [Date] = []
+                    let bgValueInMgDl = bgReadings[0].calculatedValue
                     
-                    let bgReadings = bgReadingsAccessor.getLatestBgReadings(limit: nil, fromDate: Date().addingTimeInterval(-3600 * hoursOfBgReadingsToSend), forSensor: nil, ignoreRawData: true, ignoreCalculatedValue: false)
+                    // add delta if available
+                    if bgReadings.count > 1 {
+                        deltaChangeInMgDl = bgReadings[0].currentSlope(previousBgReading: bgReadings[1]) * bgReadings[0].timeStamp.timeIntervalSince(bgReadings[1].timeStamp) * 1000;
+                        
+                        slopeOrdinal = bgReadings[0].slopeOrdinal()
+                    }
                     
-                    if bgReadings.count > 0 {
-                        
-                        var slopeOrdinal: Int = 0
-                        var deltaChangeInMgDl: Double = 0
-                        var bgReadingValues: [Double] = []
-                        var bgReadingDates: [Date] = []
-                        let bgValueInMgDl = bgReadings[0].calculatedValue
-                        
-                        // add delta if available
-                        if bgReadings.count > 1 {
-                            deltaChangeInMgDl = bgReadings[0].currentSlope(previousBgReading: bgReadings[1]) * bgReadings[0].timeStamp.timeIntervalSince(bgReadings[1].timeStamp) * 1000;
-                            
-                            slopeOrdinal = bgReadings[0].slopeOrdinal()
-                        }
-                        
-                        for bgReading in bgReadings {
-                            bgReadingValues.append(bgReading.calculatedValue)
-                            bgReadingDates.append(bgReading.timeStamp)
-                        }
-                        
-                        let dataSourceDescription = UserDefaults.standard.isMaster ? UserDefaults.standard.activeSensorDescription ?? "" : UserDefaults.standard.followerDataSourceType.fullDescription
-                        
-                        var showLiveActivity: Bool = false
-                        
+                    for bgReading in bgReadings {
+                        bgReadingValues.append(bgReading.calculatedValue)
+                        bgReadingDates.append(bgReading.timeStamp)
+                    }
+                    
+                    let dataSourceDescription = UserDefaults.standard.isMaster ? UserDefaults.standard.activeSensorDescription ?? "" : UserDefaults.standard.followerDataSourceType.fullDescription
+                    
+                    var showLiveActivity: Bool = UserDefaults.standard.isMaster || (!UserDefaults.standard.isMaster && UserDefaults.standard.followerBackgroundKeepAliveType == .heartbeat)
+                    
+                    if showLiveActivity {
                         // now that we've got the current BG value, let's refine the check to see if we should run/show the live activity
                         switch UserDefaults.standard.liveActivityType {
                         case .always:
@@ -3539,34 +3532,42 @@ final class RootViewController: UIViewController, ObservableObject {
                         case .urgentLowHigh:
                             showLiveActivity = ((bgValueInMgDl <= UserDefaults.standard.urgentLowMarkValue) || (bgValueInMgDl >= UserDefaults.standard.urgentHighMarkValue)) ? true : false
                         }
-                        
-                        // if we should show it, then let's continue processing the lastReading array to create a valid contentState
-                        if showLiveActivity {
-                            // create the contentState that will update the dynamic attributes of the Live Activity Widget
-                            let contentState = XDripWidgetAttributes.ContentState( bgReadingValues: bgReadingValues, bgReadingDates: bgReadingDates, isMgDl: UserDefaults.standard.bloodGlucoseUnitIsMgDl, slopeOrdinal: slopeOrdinal, deltaChangeInMgDl: deltaChangeInMgDl, urgentLowLimitInMgDl: UserDefaults.standard.urgentLowMarkValue, lowLimitInMgDl: UserDefaults.standard.lowMarkValue, highLimitInMgDl: UserDefaults.standard.highMarkValue, urgentHighLimitInMgDl: UserDefaults.standard.urgentHighMarkValue, liveActivitySize: UserDefaults.standard.liveActivitySize, dataSourceDescription: dataSourceDescription)
-                            
-                            LiveActivityManager.shared.runActivity(contentState: contentState, forceRestart: forceRestart)
-                        } else {
-                            LiveActivityManager.shared.endAllActivities()
-                        }
-                        
-                        // update the widget data stored in user defaults
-                        let bgReadingDatesAsDouble = bgReadingDates.map { date in
-                            date.timeIntervalSince1970
-                        }
-                                                
-                        let widgetSharedUserDefaultsModel = WidgetSharedUserDefaultsModel(bgReadingValues: bgReadingValues, bgReadingDatesAsDouble: bgReadingDatesAsDouble, isMgDl: UserDefaults.standard.bloodGlucoseUnitIsMgDl, slopeOrdinal: slopeOrdinal, deltaChangeInMgDl: deltaChangeInMgDl, urgentLowLimitInMgDl: UserDefaults.standard.urgentLowMarkValue, lowLimitInMgDl: UserDefaults.standard.lowMarkValue, highLimitInMgDl: UserDefaults.standard.highMarkValue, urgentHighLimitInMgDl: UserDefaults.standard.urgentHighMarkValue, dataSourceDescription: dataSourceDescription)
-                                                
-                        // store the model in the shared user defaults using a name that is uniquely specific to this copy of the app as installed on
-                        // the user's device - this allows several copies of the app to be installed without cross-contamination of widget data
-                        if let widgetData = try? JSONEncoder().encode(widgetSharedUserDefaultsModel) {
-                            UserDefaults.storeInSharedUserDefaults(value: widgetData, forKey: "widgetSharedUserDefaults.\(Bundle.main.mainAppBundleIdentifier)")
-                        }
-                        
-                        WidgetCenter.shared.reloadAllTimelines()
                     }
+                    
+                    // if we should show it, then let's continue processing the lastReading array to create a valid contentState
+                    if showLiveActivity {
+                        // create the contentState that will update the dynamic attributes of the Live Activity Widget
+                        let contentState = XDripWidgetAttributes.ContentState( bgReadingValues: bgReadingValues, bgReadingDates: bgReadingDates, isMgDl: UserDefaults.standard.bloodGlucoseUnitIsMgDl, slopeOrdinal: slopeOrdinal, deltaChangeInMgDl: deltaChangeInMgDl, urgentLowLimitInMgDl: UserDefaults.standard.urgentLowMarkValue, lowLimitInMgDl: UserDefaults.standard.lowMarkValue, highLimitInMgDl: UserDefaults.standard.highMarkValue, urgentHighLimitInMgDl: UserDefaults.standard.urgentHighMarkValue, liveActivitySize: UserDefaults.standard.liveActivitySize, dataSourceDescription: dataSourceDescription)
+                        
+                        LiveActivityManager.shared.runActivity(contentState: contentState, forceRestart: forceRestart)
+                    } else {
+                        LiveActivityManager.shared.endAllActivities()
+                    }
+                    
+                    // update the widget data stored in user defaults
+                    let bgReadingDatesAsDouble = bgReadingDates.map { date in
+                        date.timeIntervalSince1970
+                    }
+                    
+                    let widgetSharedUserDefaultsModel = WidgetSharedUserDefaultsModel(bgReadingValues: bgReadingValues, bgReadingDatesAsDouble: bgReadingDatesAsDouble, isMgDl: UserDefaults.standard.bloodGlucoseUnitIsMgDl, slopeOrdinal: slopeOrdinal, deltaChangeInMgDl: deltaChangeInMgDl, urgentLowLimitInMgDl: UserDefaults.standard.urgentLowMarkValue, lowLimitInMgDl: UserDefaults.standard.lowMarkValue, highLimitInMgDl: UserDefaults.standard.highMarkValue, urgentHighLimitInMgDl: UserDefaults.standard.urgentHighMarkValue, dataSourceDescription: dataSourceDescription)
+                    
+                    // store the model in the shared user defaults using a name that is uniquely specific to this copy of the app as installed on
+                    // the user's device - this allows several copies of the app to be installed without cross-contamination of widget data
+                    if let widgetData = try? JSONEncoder().encode(widgetSharedUserDefaultsModel) {
+                        UserDefaults.storeInSharedUserDefaults(value: widgetData, forKey: "widgetSharedUserDefaults.\(Bundle.main.mainAppBundleIdentifier)")
+                    }
+                } else {
+                    LiveActivityManager.shared.endAllActivities()
                 }
+                WidgetCenter.shared.reloadAllTimelines()
             }
+        }
+    }
+    
+    private func setNightscoutSyncTreatmentsRequiredToTrue() {
+        if (UserDefaults.standard.timeStampLatestNightScoutTreatmentSyncRequest ?? Date.distantPast).timeIntervalSinceNow < -ConstantsNightScout.minimiumTimeBetweenTwoTreatmentSyncsInSeconds {
+            UserDefaults.standard.timeStampLatestNightScoutTreatmentSyncRequest = .now
+            UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
         }
     }
 }

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -3494,7 +3494,7 @@ final class RootViewController: UIViewController, ObservableObject {
                 
                 // Live Activities have maximum payload size of 4kB.
                 // This value is selected by testing how much we can send before getting the "Payload maximum size exceeded" error.
-                let maxNumberOfReadings = 275
+                let maxNumberOfReadings = 260
                 
                 // If there are more readings than we can send to the Live Activity, downsample the values to fit.
                 let bgReadings = allBgReadings.count > maxNumberOfReadings
@@ -3502,7 +3502,6 @@ final class RootViewController: UIViewController, ObservableObject {
                 : allBgReadings
                 
                 if bgReadings.count > 0 {
-                    
                     var slopeOrdinal: Int = 0
                     var deltaChangeInMgDl: Double = 0
                     var bgReadingValues: [Double] = []

--- a/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsInsertViewController.swift
@@ -217,8 +217,7 @@ class TreatmentsInsertViewController : UIViewController {
                         treatMentEntryToUpdate.uploaded = false
 
                         // trigger nightscoutsync
-                        UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
-
+                        self.setNightscoutSyncTreatmentsRequiredToTrue()
                     }
                     
                 } else {
@@ -233,7 +232,7 @@ class TreatmentsInsertViewController : UIViewController {
                         treatMentEntryToUpdate.uploaded = false
                         
                         // trigger nightscoutsync
-                        UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
+                        self.setNightscoutSyncTreatmentsRequiredToTrue()
                         
                         self.treatMentEntryToUpdate = nil
                         
@@ -296,7 +295,7 @@ class TreatmentsInsertViewController : UIViewController {
                     _ = TreatmentEntry(date: Date(timeInterval: dateOffset, since: datePicker.date), value: value, treatmentType: treatmentType, nightscoutEventType: nil, nsManagedObjectContext: self.coreDataManager.mainManagedObjectContext)
                     
                     // trigger nightscoutsync
-                    UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
+                    setNightscoutSyncTreatmentsRequiredToTrue()
                     
                     // save to coredata
                     coreDataManager.saveChanges()
@@ -368,5 +367,14 @@ class TreatmentsInsertViewController : UIViewController {
 	@objc private func dismissKeyboardTouchOutside() {
 	   view.endEditing(true)
 	}
+    
+    // set the flag to sync Nightscout treatments if a short time has passed since the last time
+    // as accessing userdefaults is not thread-safe
+    private func setNightscoutSyncTreatmentsRequiredToTrue() {
+        if (UserDefaults.standard.timeStampLatestNightScoutTreatmentSyncRequest ?? Date.distantPast).timeIntervalSinceNow < -ConstantsNightScout.minimiumTimeBetweenTwoTreatmentSyncsInSeconds {
+            UserDefaults.standard.timeStampLatestNightScoutTreatmentSyncRequest = .now
+            UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
+        }
+    }
 	
 }

--- a/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
+++ b/xdrip/View Controllers/Treatments/TreatmentsViewController.swift
@@ -330,7 +330,8 @@ extension TreatmentsViewController: UITableViewDelegate, UITableViewDataSource {
             coreDataManager.saveChanges()
             
             // trigger nightscoutsync
-            DispatchQueue.main.async {
+            if (UserDefaults.standard.timeStampLatestNightScoutTreatmentSyncRequest ?? Date.distantPast).timeIntervalSinceNow < -ConstantsNightScout.minimiumTimeBetweenTwoTreatmentSyncsInSeconds {
+                UserDefaults.standard.timeStampLatestNightScoutTreatmentSyncRequest = .now
                 UserDefaults.standard.nightScoutSyncTreatmentsRequired = true
             }
             


### PR DESCRIPTION
- watch app/complications should now correctly scale for 40mm watches (https://www.facebook.com/groups/853994615056838/posts/1884748995314723/)
- changes to the way we write to userdefaults when performing NightscoutSyncRequired to try and minimise crashes due to memory access exceptions. This was especially noticeable when background keep-alive was enabled and new downloads were scheduled
- "Libre 3 Heartbeat" descriptions changed to show "Libre Heartbeat" (no internal changes)
- instructions are now added to the heartbeat screen, specific for the type of heartbeat being added
- changes to live activities to limit payload size to <4Kb and prevent issues for Libre 2 Direct users. (@stami)
- various small bug fixes