### PR TITLE
Live Activity downsampling: improvements

### DIFF
--- a/xDrip Widget/DataModels/XDripWidgetAttributes.swift
+++ b/xDrip Widget/DataModels/XDripWidgetAttributes.swift
@@ -40,13 +40,23 @@ struct XDripWidgetAttributes: ActivityAttributes {
         var warnUserToOpenApp: Bool = true
         var liveActivitySize: LiveActivitySize
         var dataSourceDescription: String
-        
-        // computed properties
-        var bgUnitString: String
-        var bgValueInMgDl: Double?
-        var bgReadingDate: Date?
-        var bgValueStringInUserChosenUnit: String
-        
+
+        var bgUnitString: String {
+            isMgDl ? Texts_Common.mgdl : Texts_Common.mmol
+        }
+        /// the latest bg reading
+        var bgValueInMgDl: Double? {
+            bgReadingValues[0]
+        }
+        /// the latest bg reading date
+        var bgReadingDate: Date? {
+            bgReadingDates[0]
+        }
+
+        var bgValueStringInUserChosenUnit: String {
+            bgReadingValues[0].mgdlToMmolAndToString(mgdl: isMgDl)
+        }
+
         init(bgReadingValues: [Double], bgReadingDates: [Date], isMgDl: Bool, slopeOrdinal: Int, deltaChangeInMgDl: Double?, urgentLowLimitInMgDl: Double, lowLimitInMgDl: Double, highLimitInMgDl: Double, urgentHighLimitInMgDl: Double, liveActivitySize: LiveActivitySize, dataSourceDescription: String? = "") {
 
             self._bgReadingValues = bgReadingValues.map(Float16.init)
@@ -63,13 +73,6 @@ struct XDripWidgetAttributes: ActivityAttributes {
             self.urgentHighLimitInMgDl = urgentHighLimitInMgDl            
             self.liveActivitySize = liveActivitySize
             self.dataSourceDescription = dataSourceDescription ?? ""
-            
-            self.bgUnitString = isMgDl ? Texts_Common.mgdl : Texts_Common.mmol
-            
-            // the last bg reading (used for other functions)
-            self.bgValueInMgDl = bgReadingValues[0]
-            self.bgReadingDate = bgReadingDates[0]
-            self.bgValueStringInUserChosenUnit = bgReadingValues[0].mgdlToMmolAndToString(mgdl: isMgDl)
         }
         
         /// Blood glucose color dependant on the user defined limit values and based upon the time since the last reading

--- a/xDrip Widget/DataModels/XDripWidgetAttributes.swift
+++ b/xDrip Widget/DataModels/XDripWidgetAttributes.swift
@@ -15,19 +15,23 @@ struct XDripWidgetAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
 
         // Store values with a 16 bit precision to save payload bytes
-        private var _bgReadingValues: [Float16]
+        private var bgReadingFloats: [Float16]
         // Expose those conveniently as Doubles
-        var bgReadingValues: [Double] { _bgReadingValues.map(Double.init) }
+        var bgReadingValues: [Double] {
+            bgReadingFloats.map(Double.init)
+        }
 
         // To save those precious payload bytes, store only the earliest date as Date
-        private var _firstDate: Date
+        private var firstDate: Date
         // ...and all other as seconds from that moment.
         // No need for floating points, a second is precise enough for the graph
         // UInt16 maximum value is 65535 so that means 18.2 hours.
         // This would need to be changed if wishing to present a 24 hour chart.
-        private var _secondsSinceFirstDate: [UInt16]
+        private var secondsSinceFirstDate: [UInt16]
         // Expose the dates conveniently
-        var bgReadingDates: [Date] { _secondsSinceFirstDate.map { Date(timeInterval: Double($0), since: _firstDate) } }
+        var bgReadingDates: [Date] {
+            secondsSinceFirstDate.map { Date(timeInterval: Double($0), since: firstDate) }
+        }
 
         var isMgDl: Bool
         var slopeOrdinal: Int
@@ -58,11 +62,12 @@ struct XDripWidgetAttributes: ActivityAttributes {
         }
 
         init(bgReadingValues: [Double], bgReadingDates: [Date], isMgDl: Bool, slopeOrdinal: Int, deltaChangeInMgDl: Double?, urgentLowLimitInMgDl: Double, lowLimitInMgDl: Double, highLimitInMgDl: Double, urgentHighLimitInMgDl: Double, liveActivitySize: LiveActivitySize, dataSourceDescription: String? = "") {
+        
+            self.bgReadingFloats = bgReadingValues.map(Float16.init)
 
-            self._bgReadingValues = bgReadingValues.map(Float16.init)
             let firstDate = bgReadingDates.last ?? .now
-            self._firstDate = firstDate
-            self._secondsSinceFirstDate = bgReadingDates.map { UInt16(truncatingIfNeeded: Int($0.timeIntervalSince(firstDate))) }
+            self.firstDate = firstDate
+            self.secondsSinceFirstDate = bgReadingDates.map { UInt16(truncatingIfNeeded: Int($0.timeIntervalSince(firstDate))) }
             
             self.isMgDl = isMgDl
             self.slopeOrdinal = slopeOrdinal

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -3502,7 +3502,7 @@ final class RootViewController: UIViewController, ObservableObject {
 
                     // Live Activities have maximum payload size of 4kB.
                     // This value is selected by testing how much we can send before getting the "Payload maximum size exceeded" error.
-                    let maxNumberOfReadings = 275
+                    let maxNumberOfReadings = 260
 
                     // If there are more readings than we can send to the Live Activity, downsample the values to fit.
                     let bgReadings = allBgReadings.count > maxNumberOfReadings


### PR DESCRIPTION
- change private property naming to match conventions
- change the computed properties to be Swift computed properties and not stored in init
- lower the target number of readings for downsampling

I don't know why, but the 275 that was yesterday fine, was today morning too much. I need to use this a while on my device before I trust the value is low enough to not to fail.