### PR TITLE
update background color for Watch accessoryRegular complication

### DIFF
--- a/xdrip/Constants/ConstantsGlucoseChartSwiftUI.swift
+++ b/xdrip/Constants/ConstantsGlucoseChartSwiftUI.swift
@@ -76,6 +76,7 @@ enum ConstantsGlucoseChartSwiftUI {
     static let viewHeightWatchAccessoryRectangular: CGFloat = 55
     static let hoursToShowWatchAccessoryRectangular: Double = 5
     static let glucoseCircleDiameterWatchAccessoryRectangular: Double = 14
+    static let backgroundColorWatchAccessoryRectangular: Color = .clear
     
     // watch complication sizes for smaller watches
     static let viewWidthWatchAccessoryRectangularSmall: CGFloat = 160

--- a/xdrip/Managers/Charts/GlucoseChartType.swift
+++ b/xdrip/Managers/Charts/GlucoseChartType.swift
@@ -144,6 +144,8 @@ public enum GlucoseChartType: Int, CaseIterable {
         switch self {
         case .siriGlucoseIntent:
             return ConstantsGlucoseChartSwiftUI.backgroundColorSiriGlucoseIntent
+        case .watchAccessoryRectangular:
+            return ConstantsGlucoseChartSwiftUI.backgroundColorWatchAccessoryRectangular
         default:
             return .black
         }


### PR DESCRIPTION
- the previous/default black background wouldn't render correctly on Watchfaces that had a colour scheme applied.

Now rendering correctly with color scheme:
![Simulator Screenshot - Apple Watch Series 9 (45mm) - 2024-05-05 at 11 41 41](https://github.com/JohanDegraeve/xdripswift/assets/37302780/41b8a248-fd98-4512-abe8-f5813c6ef72b)

And also with the standard multicolor scheme:
![Simulator Screenshot - Apple Watch Series 9 (45mm) - 2024-05-05 at 11 42 21](https://github.com/JohanDegraeve/xdripswift/assets/37302780/b76c6f35-3e5e-4321-a133-e59b080b1350)

Also renders correctly with the Modular Ultra face in Night mode:
<img width="643" alt="image" src="https://github.com/JohanDegraeve/xdripswift/assets/37302780/d88565e0-c54a-4fb2-994c-ae8fd964d6ee">
