### PR TITLE
Add `Account-Id` HTTP header (patientId’s SHA256) required by LLU 4.11

### DIFF
--- a/xdrip/Constants/ConstantsLibreLinkUp.swift
+++ b/xdrip/Constants/ConstantsLibreLinkUp.swift
@@ -11,7 +11,7 @@ import Foundation
 enum ConstantsLibreLinkUp {
     
     /// string to hold the default LibreLinkUp version number
-    static let libreLinkUpVersionDefault: String = "4.7.0"
+    static let libreLinkUpVersionDefault: String = "4.11.0"
     
     /// double to hold maximum sensor days for Libre sensors that upload to LibreLinkUp
     /// currently easy as they are all the same at 14 days exactly (LibreLink doesn't upload the extra 12 hours)

--- a/xdrip/Extensions/String.swift
+++ b/xdrip/Extensions/String.swift
@@ -61,7 +61,12 @@ extension String {
         // sha1() here is a function in CryptoSwift Library
         return Data(self.utf8).sha1().hexEncodedString()
     }
-    
+
+    func sha256() -> String {
+        // sha256() here is a function in CryptoSwift Library
+        return Data(self.utf8).sha256().hexEncodedString()
+    }
+
     /// creates uicolor interpreting hex as hex color code, example #CED430
     func hexStringToUIColor () -> UIColor {
         var cString:String = self.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()

--- a/xdrip/Managers/LibreLinkUp/LibreLinkUpFollowManager.swift
+++ b/xdrip/Managers/LibreLinkUp/LibreLinkUpFollowManager.swift
@@ -572,7 +572,8 @@ class LibreLinkUpFollowManager: NSObject {
         // this is pretty much the same request as done in requestLogin()
         var request = URLRequest(url: url)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        
+        request.setValue((libreLinkUpPatientId ?? libreLinkUpId ?? "").sha256(), forHTTPHeaderField: "Account-Id")
+
         for (header, value) in libreLinkUpRequestHeaders {
             request.setValue(value, forHTTPHeaderField: header)
         }
@@ -627,7 +628,8 @@ class LibreLinkUpFollowManager: NSObject {
         // this is pretty much the same request as done in loginRequest()
         var request = URLRequest(url: url)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        
+        request.setValue((libreLinkUpPatientId ?? libreLinkUpId ?? "").sha256(), forHTTPHeaderField: "Account-Id")
+
         for (header, value) in libreLinkUpRequestHeaders {
             request.setValue(value, forHTTPHeaderField: header)
         }


### PR DESCRIPTION
If you set “4.11.0” as the LibreLinkUp version in the Developer Settings, you receive the reply `{“message":"RequiredHeaderMissing”}` (status 400) since the recent update of the last week requires a new `Account-Id` HTTP header and you have to pass the SHA256 digest of the `patientId` as a 64-char hexadecimal string.