### PR TITLE
Workaround for Xcode 16; new LLU `la` subdomain and 4.11 Account-Id header

### DIFF
--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFC.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFC.swift
@@ -459,7 +459,7 @@ class LibreNFC: NSObject, NFCTagReaderSessionDelegate {
                                     
                                     tag.customCommand(requestFlags: .highDataRate, customCommandCode: Int(cmd.code), customRequestParameters:  cmd.parameters) { response, error in
                                         
-                                        let debugInfo = "NFC: '" + subCmd.description + " command response " + response.count.description + " bytes : 0x" + response.toHexString() + ", error: " +  (error?.localizedDescription ?? "none")
+                                        let debugInfo = "NFC: '" + subCmd.description + " command response " + response.count.description + " bytes : 0x" + response.toHexString() + ", error: " + error.debugDescription
                                         
                                         xdrip.trace("%{public}@", log: self.log, category: ConstantsLog.categoryLibreNFC, type: .info, debugInfo)
                                         

--- a/xdrip/Constants/ConstantsLibreLinkUp.swift
+++ b/xdrip/Constants/ConstantsLibreLinkUp.swift
@@ -11,7 +11,7 @@ import Foundation
 enum ConstantsLibreLinkUp {
     
     /// string to hold the default LibreLinkUp version number
-    static let libreLinkUpVersionDefault: String = "4.7.0"
+    static let libreLinkUpVersionDefault: String = "4.11.0"
     
     /// double to hold maximum sensor days for Libre sensors that upload to LibreLinkUp
     /// currently easy as they are all the same at 14 days exactly (LibreLink doesn't upload the extra 12 hours)

--- a/xdrip/Extensions/String.swift
+++ b/xdrip/Extensions/String.swift
@@ -61,6 +61,11 @@ extension String {
         // sha1() here is a function in CryptoSwift Library
         return Data(self.utf8).sha1().hexEncodedString()
     }
+        
+    func sha256() -> String {
+        // sha256() here is a function in CryptoSwift Library
+        return Data(self.utf8).sha256().hexEncodedString()
+    }
     
     /// creates uicolor interpreting hex as hex color code, example #CED430
     func hexStringToUIColor () -> UIColor {

--- a/xdrip/Managers/LibreLinkUp/LibreLinkUpFollowManager.swift
+++ b/xdrip/Managers/LibreLinkUp/LibreLinkUpFollowManager.swift
@@ -572,6 +572,7 @@ class LibreLinkUpFollowManager: NSObject {
         // this is pretty much the same request as done in requestLogin()
         var request = URLRequest(url: url)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue((libreLinkUpId ?? "").sha256(), forHTTPHeaderField: "Account-Id")
         
         for (header, value) in libreLinkUpRequestHeaders {
             request.setValue(value, forHTTPHeaderField: header)
@@ -627,6 +628,7 @@ class LibreLinkUpFollowManager: NSObject {
         // this is pretty much the same request as done in loginRequest()
         var request = URLRequest(url: url)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue((libreLinkUpId ?? "").sha256(), forHTTPHeaderField: "Account-Id")
         
         for (header, value) in libreLinkUpRequestHeaders {
             request.setValue(value, forHTTPHeaderField: header)

--- a/xdrip/Managers/LibreLinkUp/LibreLinkUpModels.swift
+++ b/xdrip/Managers/LibreLinkUp/LibreLinkUpModels.swift
@@ -27,7 +27,8 @@ public enum LibreLinkUpRegion: Int, CaseIterable {
     case eu2 = 7
     case fr = 8
     case jp = 9
-    case us = 10
+    case la = 10
+    case us = 11
     
     
     init?() {
@@ -56,6 +57,8 @@ public enum LibreLinkUpRegion: Int, CaseIterable {
             self = .fr
         case "jp":
             self = .jp
+        case "la":
+            self = .la
         case "us":
             self = .us
         default:
@@ -88,6 +91,8 @@ public enum LibreLinkUpRegion: Int, CaseIterable {
             return "France"
         case .jp:
             return "Japan"
+        case .la:
+            return "Latin America"
         case .us:
             return "United States"
             
@@ -165,8 +170,10 @@ public enum LibreLinkUpRegion: Int, CaseIterable {
             return 8
         case 9:// jp
             return 9
-        case 10:// us
+        case 10:// la
             return 10
+        case 11:// us
+            return 11
         default:
             fatalError("in libreLinkUpRawValue, unknown case")
         }


### PR DESCRIPTION
With the beta of Xcode 16 compilation fails by reporting the error “The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions.” regarding the line

https://github.com/JohanDegraeve/xdripswift/blob/fec1005899893ddf20e36675f3aad96547e8c99c/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFC.swift#L462

Simply replacing the final  `+  (error?.localizedDescription ?? "none”)` with `+ error.debugDescription` makes xDrip compilable again.

It was reported as successful on FB:

![450545818_2979998748820013_6748091525888983595_n](https://github.com/user-attachments/assets/84e687c0-921b-485d-95b5-cb1e6f39628b)
