### PR TITLE
5.3.3

### DIFF
--- a/xdrip/BluetoothTransmitter/CGM/Dexcom/G7/CGMG7Transmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Dexcom/G7/CGMG7Transmitter.swift
@@ -371,24 +371,6 @@ class CGMG7Transmitter: BluetoothTransmitter, CGMTransmitter {
         return CBUUID_Characteristic_UUID.CBUUID_Receive_Authentication.rawValue
     }
     
-    func setWebOOPEnabled(enabled: Bool) {
-        
-        if webOOPEnabled != enabled {
-            
-            webOOPEnabled = enabled
-            
-            trace("in setWebOOPEnabled, new value for webOOPEnabled = %{public}@", log: log, category: ConstantsLog.categoryCGMG7, type: .info, webOOPEnabled.description)
-            
-            // reset sensor start date, because changing webOOPEnabled value stops the sensor
-            sensorStartDate = nil
-            
-            // as sensor is stopped, also set sensorStatus to nil
-            cGMG7TransmitterDelegate?.received(sensorStatus: nil, cGMG7Transmitter: self)
-            
-        }
-        
-    }
-    
     func isWebOOPEnabled() -> Bool {
         
         return webOOPEnabled

--- a/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
+++ b/xdrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
@@ -719,7 +719,7 @@ class BluetoothPeripheralManager: NSObject {
     ///  for use with xdrip-client-swift
     private func setCGMTransmitterInSharedUserDefaults() {
      
-        if let sharedUserDefaults = UserDefaults(suiteName: Bundle.main.appGroupSuiteName) {
+        if let sharedUserDefaults = UserDefaults(suiteName: UserDefaults.standard.loopShareType.sharedUserDefaultsSuiteName) {
             
             if let cgmTransmitter = getCGMTransmitter(), let cgmtransmitterAddress = currentCgmTransmitterAddress {
 

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -2030,7 +2030,7 @@ final class RootViewController: UIViewController, ObservableObject {
             
             calibrator = DexcomCalibrator()
             
-        case .dexcom, .dexcomG7:
+        case .dexcom:
             
             if cgmTransmitter.isWebOOPEnabled() {
                 
@@ -2051,6 +2051,11 @@ final class RootViewController: UIViewController, ObservableObject {
                 calibrator = DexcomCalibrator()
                 
             }
+            
+        case .dexcomG7:
+            
+            // received values are already calibrated
+            calibrator = NoCalibrator()
 
             
         case .miaomiao, .GNSentry, .Blucon, .Bubble, .Droplet1, .blueReader, .watlaa, .Libre2, .Atom:


### PR DESCRIPTION
- add correction to force NoCalibrator() for Dexcom G7 in RootViewController
- CGM heartbeat corrected in share-client to push cgmTransmitter_CBUUID and cgmTransmitterDeviceAddress changes to the chosen shared app group