### PR TITLE
fix: fix issue where bluetooth peripheral view controller doesn't display...

### DIFF
--- a/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/BluetoothPeripheralViewController.swift
+++ b/xdrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/BluetoothPeripheralViewController.swift
@@ -624,13 +624,11 @@ class BluetoothPeripheralViewController: UIViewController {
     
     /// setup datasource, delegate, seperatorInset
     private func setupTableView() {
-        DispatchQueue.main.async {
-            if let tableView = self.tableView {
-                // insert slightly the separator text so that it doesn't touch the safe area limit
-                tableView.separatorInset = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
-                tableView.dataSource = self
-                tableView.delegate = self
-            }
+        if let tableView = self.tableView {
+            // insert slightly the separator text so that it doesn't touch the safe area limit
+            tableView.separatorInset = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+            tableView.dataSource = self
+            tableView.delegate = self
         }
     }
     


### PR DESCRIPTION
... correctly when using older iPhones (iPhone 8 / SE etc).

No idea why but it seems to be a UIKit bug.

Tested and working correctly again for both G7 and G6 view controllers on iPhone 8.

![image](https://github.com/user-attachments/assets/5b59538c-36b4-4e4f-aff3-268b36a75142)
