### PR TITLE
Use macos-15 and Xcode 16.2 in workflows

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -12,11 +12,11 @@ jobs:
   identifiers:
     name: Add Identifiers
     needs: validate
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       # Uncomment to manually select latest Xcode if needed
       #- name: Select Latest Xcode
-      #  run: "sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer"
+      #  run: "sudo xcode-select --switch /Applications/Xcode_16.2.app/Contents/Developer"
       
       # Checks-out the repo
       - name: Checkout Repo

--- a/.github/workflows/build_xdrip.yml
+++ b/.github/workflows/build_xdrip.yml
@@ -156,7 +156,7 @@ jobs:
   build:
     name: Build
     needs: [validate, check_alive_and_permissions, check_latest_from_upstream]
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       contents: write
     if: | # runs if started manually, or if sync schedule is set and enabled and scheduled on the first Saturday each month, or if sync schedule is set and enabled and new commits were found
@@ -167,7 +167,7 @@ jobs:
         )
     steps:
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode_16.2.app/Contents/Developer"
       
       - name: Checkout Repo for syncing
         if: |

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -12,11 +12,11 @@ jobs:
   certificates:
     name: Create Certificates
     needs: validate
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       # Uncomment to manually select latest Xcode if needed
       #- name: Select Latest Xcode
-      #  run: "sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer"
+      #  run: "sudo xcode-select --switch /Applications/Xcode_16.2.app/Contents/Developer"
       
       # Checks-out the repo
       - name: Checkout Repo

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -5,7 +5,7 @@ on: [workflow_call, workflow_dispatch]
 jobs:
   validate-access-token:
     name: Access
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       GH_PAT: ${{ secrets.GH_PAT }}
       GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -74,7 +74,7 @@ jobs:
   validate-match-secrets:
     name: Match-Secrets
     needs: validate-access-token
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       GH_TOKEN: ${{ secrets.GH_PAT }}
     steps:
@@ -112,7 +112,7 @@ jobs:
   validate-fastlane-secrets:
     name: Fastlane
     needs: [validate-access-token, validate-match-secrets]
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       GH_PAT: ${{ secrets.GH_PAT }}
       GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
On April 24, we will no longer be able to do browser builds with Xcode 15:

> ITMS-90725: SDK version issue - This app was built with the iOS 17.5 SDK. Starting April 24, 2025, all iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution

This PR will take care of this by bumping to macos-15 and Xcode 16.2. This has already been used for some time in Loop Follow etc, and is well tested. The same PR has also been made to Trio.

All of the four workflows that run on macos runners are updated here.