### PR TITLE
add LLU Russia as new follower data source

### DIFF
--- a/xdrip.xcodeproj/project.pbxproj
+++ b/xdrip.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		4716A5052B40709E00419052 /* XDripWidgetAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4716A5042B40709E00419052 /* XDripWidgetAttributes.swift */; };
 		4716A50D2B416EE100419052 /* ConstantsGlucoseChartSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4716A50C2B416EE100419052 /* ConstantsGlucoseChartSwiftUI.swift */; };
 		4716A5142B41CAD000419052 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4716A5132B41CAD000419052 /* LiveActivityManager.swift */; };
-		471C9BFF2B932952005E1326 /* LibreLinkUpModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DB06E82A715FD900267BE3 /* LibreLinkUpModels.swift */; };
-		471C9C002B932957005E1326 /* LibreLinkUpModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DB06E82A715FD900267BE3 /* LibreLinkUpModels.swift */; };
 		471C9C082B94F0F0005E1326 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E51D602448E695001C9E5A /* Bundle.swift */; };
 		472134DD2BC6A63100729850 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8AC426621ADEBD70078C348 /* Assets.xcassets */; };
 		472134DE2BC6A63100729850 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8AC426621ADEBD70078C348 /* Assets.xcassets */; };
@@ -4227,7 +4225,6 @@
 			files = (
 				47A6AC2A2B7D3DE30047A4BA /* GlucoseChartView.swift in Sources */,
 				47A6AC2D2B7D3E170047A4BA /* Date.swift in Sources */,
-				471C9C002B932957005E1326 /* LibreLinkUpModels.swift in Sources */,
 				47CA61E42B965E7100C2A597 /* AccessoryCircularView.swift in Sources */,
 				471C9C082B94F0F0005E1326 /* Bundle.swift in Sources */,
 				4746067E2B962FBD00AC9214 /* SystemLargeView.swift in Sources */,
@@ -4285,7 +4282,6 @@
 				4715C3302C9ED5E10052215F /* LiveActivityType.swift in Sources */,
 				474606892B9637F600AC9214 /* TextsSettingsView.swift in Sources */,
 				47EDD15A2BE01E9000C5A286 /* ConstantsWatchComplication.swift in Sources */,
-				471C9BFF2B932952005E1326 /* LibreLinkUpModels.swift in Sources */,
 				478A923E2B8B64DE0084C394 /* ConstantsHomeView.swift in Sources */,
 				4796C6072B9516FD00DE2210 /* Bundle.swift in Sources */,
 				47E91BBA2B9A43F20063181B /* FollowerBackgroundKeepAliveType.swift in Sources */,

--- a/xdrip/Managers/Followers/FollowerDataSourceType.swift
+++ b/xdrip/Managers/Followers/FollowerDataSourceType.swift
@@ -17,6 +17,7 @@ public enum FollowerDataSourceType: Int, CaseIterable {
 
     case nightscout = 0
     case libreLinkUp = 1
+    case libreLinkUpRussia = 2
     
     public var rawValue: Int {
         switch self {
@@ -24,6 +25,8 @@ public enum FollowerDataSourceType: Int, CaseIterable {
             return 0
         case .libreLinkUp:
             return 1
+        case .libreLinkUpRussia:
+            return 2
         }
     }
     
@@ -33,6 +36,8 @@ public enum FollowerDataSourceType: Int, CaseIterable {
             return "Nightscout"
         case .libreLinkUp:
             return "LibreLinkUp"
+        case .libreLinkUpRussia:
+            return "LibreLinkUp Russia"
         }
     }
     
@@ -44,6 +49,8 @@ public enum FollowerDataSourceType: Int, CaseIterable {
             return "Nightscout"
         case .libreLinkUp:
             return "LibreLinkUp"
+        case .libreLinkUpRussia:
+            return "LibreLinkUp Russia"
         }
     }
     
@@ -51,7 +58,7 @@ public enum FollowerDataSourceType: Int, CaseIterable {
         switch self {
         case .nightscout:
             return "NS"
-        case .libreLinkUp:
+        case .libreLinkUp, .libreLinkUpRussia:
             return "LL"
         }
     }
@@ -60,7 +67,7 @@ public enum FollowerDataSourceType: Int, CaseIterable {
         switch self {
         case .nightscout:
             return ConstantsFollower.secondsUntilFollowerDisconnectWarningNightscout
-        case .libreLinkUp:
+        case .libreLinkUp, .libreLinkUpRussia:
             return ConstantsFollower.secondsUntilFollowerDisconnectWarningLibreLinkUp
         }
     }
@@ -70,7 +77,7 @@ public enum FollowerDataSourceType: Int, CaseIterable {
         switch self {
         case .nightscout:
             return false
-        case .libreLinkUp:
+        case .libreLinkUp, .libreLinkUpRussia:
             return true
         }
     }
@@ -83,6 +90,8 @@ public enum FollowerDataSourceType: Int, CaseIterable {
             return "Nightscout Follower"
         case .libreLinkUp:
             return "LibreLinkUp Follower"
+        case .libreLinkUpRussia:
+            return "LibreLinkUp Russia Follower"
         }
     }
     

--- a/xdrip/Managers/LibreLinkUp/LibreLinkUpModels.swift
+++ b/xdrip/Managers/LibreLinkUp/LibreLinkUpModels.swift
@@ -12,7 +12,6 @@ import Foundation
 
 /// different regions for LibreLinkUp
 public enum LibreLinkUpRegion: Int, CaseIterable {
-    
     // when adding regions, add new cases at the end (ie 11, ...)
     // if this is done in the middle then a database migration would be required, because the rawvalue is stored as Int16 in the coredata
     // the order of the data source types will in the uiview is determined by the initializer init(forRowAt row: Int)
@@ -30,15 +29,13 @@ public enum LibreLinkUpRegion: Int, CaseIterable {
     case la = 10
     case us = 11
     
-    
     init?() {
         self = .notConfigured
     }
     
     /// optional initializer from string - this is used to set the new region when the server response has a redirect with a "country" value
     init?(from string: String) {
-        
-        switch (string.lowercased()) {
+        switch string.lowercased() {
         case "ae":
             self = .ae
         case "ap":
@@ -68,9 +65,7 @@ public enum LibreLinkUpRegion: Int, CaseIterable {
     
     /// text description of the region as a string
     var description: String {
-        
         switch self {
-            
         case .notConfigured:
             return "Global"
         case .ae:
@@ -95,98 +90,90 @@ public enum LibreLinkUpRegion: Int, CaseIterable {
             return "Latin America"
         case .us:
             return "United States"
-            
         }
-        
     }
     
     // MARK: URLs per LibreLinkUpRegion
     
     /// returns the URL for the login request based upon self (i.e. the region)
     var urlLogin: String {
-        
-        switch self {
-            
-        case .notConfigured:
-            return "https://api.libreview.io/llu/auth/login"
-        default:
-            return "https://api-\(self).libreview.io/llu/auth/login"
-            
+        if UserDefaults.standard.followerDataSourceType != .libreLinkUpRussia {
+            switch self {
+            case .notConfigured:
+                return "https://api.libreview.io/llu/auth/login"
+            default:
+                return "https://api-\(self).libreview.io/llu/auth/login"
+            }
+        } else {
+            return "https://api.libreview.ru/llu/auth/login"
         }
-        
     }
-    
     
     /// returns the URL for the connections request based upon self (i.e. the region)
     var urlConnections: String {
-        
-        switch self {
-            
-        case .notConfigured:
-            return "https://api.libreview.io/llu/connections"
-        default:
-            return "https://api-\(self).libreview.io/llu/connections"
-            
+        if UserDefaults.standard.followerDataSourceType != .libreLinkUpRussia {
+            switch self {
+            case .notConfigured:
+                return "https://api.libreview.io/llu/connections"
+            default:
+                return "https://api-\(self).libreview.io/llu/connections"
+            }
+        } else {
+            return "https://api.libreview.ru/llu/connections"
         }
-        
     }
     
     /// returns the URL for the graph request based upon self (i.e. the region) and also the passed patient Id
     func urlGraph(patientId: String) -> String {
-        
-        switch self {
-            
-        case .notConfigured:
-            return "https://api.libreview.io/llu/connections/\(patientId)/graph"
-        default:
-            return "https://api-\(self).libreview.io/llu/connections/\(patientId)/graph"
-            
+        if UserDefaults.standard.followerDataSourceType != .libreLinkUpRussia {
+            switch self {
+            case .notConfigured:
+                return "https://api.libreview.io/llu/connections/\(patientId)/graph"
+            default:
+                return "https://api-\(self).libreview.io/llu/connections/\(patientId)/graph"
+            }
+        } else {
+            return "https://api.libreview.ru/llu/connections/\(patientId)/graph"
         }
-        
     }
     
     /// gives the raw value of the libreLinkUpRegion for a specific section in a uitableview, is the opposite of the initializer
     static func libreLinkUpRegionRawValue(rawValue: Int) -> Int {
-        
         switch rawValue {
-            
-        case 0:// notConfigured
+        case 0: // notConfigured
             return 0
-        case 1:// ae
+        case 1: // ae
             return 1
-        case 2:// ap
+        case 2: // ap
             return 2
-        case 3:// au
+        case 3: // au
             return 3
-        case 4:// ca
+        case 4: // ca
             return 4
-        case 5:// de
+        case 5: // de
             return 5
-        case 6:// eu
+        case 6: // eu
             return 6
-        case 7:// eu2
+        case 7: // eu2
             return 7
-        case 8:// fr
+        case 8: // fr
             return 8
-        case 9:// jp
+        case 9: // jp
             return 9
-        case 10:// la
+        case 10: // la
             return 10
-        case 11:// us
+        case 11: // us
             return 11
         default:
             fatalError("in libreLinkUpRawValue, unknown case")
         }
     }
-    
 }
-
 
 // MARK: JSON Struct Generic Server Response
 
 /// Generic struct to handle all HTTP responses
 struct Response<T: Codable>: Codable {
-    
     // status is used to catch the server response
     // status 2 means that the user credentials were wrong
     // status 4 means that the user needs to accept the latest privacy policy or other document change
@@ -194,15 +181,12 @@ struct Response<T: Codable>: Codable {
     
     // data is where the main payload of the response is held
     let data: T?
-    
 }
-
 
 // MARK: JSON Structs Login Response
 
 /// struct to define data.xxxxxx
 struct RequestLoginResponse: Codable {
-    
     let user: RequestLoginResponseUser?
     
     let authTicket: RequestLoginResponseAuthTicket?
@@ -212,63 +196,51 @@ struct RequestLoginResponse: Codable {
     let redirect: Bool?
     
     let region: String?
-    
 }
 
 /// struct to define data.user.xxxxxx
 struct RequestLoginResponseUser: Codable {
-    
     let id: String?
     
     // we'll use this to display the country abbreviation ("ES", "DE", GB") just for interest as sometimes the servers do not force a redirect to the "correct" region (which is fine, but it's interesting to note)
     let country: String?
-    
 }
 
 /// struct to define data.authTicket.xxxxxx
 struct RequestLoginResponseAuthTicket: Codable {
-    
     // not optional as the server always returns them even if the token is nil
     let token: String
     
     let expires: Double
-    
 }
-
 
 // MARK: JSON Structs Connections Response
 
 /// struct to define data.xxxxxx
 struct RequestConnectionsResponse: Codable {
-
     let patientId: String?
-    
 }
-
 
 // MARK: JSON Structs Graph Response
 
 /// struct to define data.xxxxxx
 struct RequestGraphResponse: Codable {
-    
     let connection: RequestGraphResponseConnection?
     
     let activeSensors: [RequestGraphResponseActiveSensors]?
     
     let graphData: [RequestGraphResponseGlucoseMeasurement]?
-    
 }
 
 /// struct to define data.connection.xxxxx
 struct RequestGraphResponseConnection: Codable {
-    
     let glucoseMeasurement: RequestGraphResponseGlucoseMeasurement?
     
+    let sensor: RequestGraphResponseSensor?
 }
 
 /// struct to define data.glucoseMeasurement.xxxxx and also data.graphData.[x].xxxxx
 struct RequestGraphResponseGlucoseMeasurement: Codable {
-    
     // the glucose measurement "factory" timestamp which is in UTC timezone
     let FactoryTimestamp: Date
     
@@ -278,14 +250,11 @@ struct RequestGraphResponseGlucoseMeasurement: Codable {
 
 /// struct to define data.activeSensors.[x].sensor.xxxxx
 struct RequestGraphResponseActiveSensors: Codable {
-    
     let sensor: RequestGraphResponseSensor?
-    
 }
 
 /// struct to define data.activeSensors.[x].sensor.xxxxx (or also data.connection.sensor.xxxxx)
 struct RequestGraphResponseSensor: Codable {
-    
     // the sensor serial number
     let sn: String
     

--- a/xdrip/Texts/TextsHomeView.swift
+++ b/xdrip/Texts/TextsHomeView.swift
@@ -239,6 +239,10 @@ enum Texts_HomeView {
         return NSLocalizedString("libreLinkUpAccountCredentialsMissing", tableName: filename, bundle: Bundle.main, value: "Username/password missing", comment: "username and/or password is missing for librelinkup")
     }()
     
+    static let libreLinkUpAccountCredentialsInvalid: String = {
+        return NSLocalizedString("libreLinkUpAccountCredentialsInvalid", tableName: filename, bundle: Bundle.main, value: "Invalid User/Password", comment: "username and/or password is invalid for librelinkup")
+    }()
+    
     static let showHideItemsTitle: String = {
         return NSLocalizedString("showHideItemsTitle", tableName: filename, bundle: Bundle.main, value: "Quick Show/Hide", comment: "show or hide various interface items")
     }()

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -3277,7 +3277,6 @@ final class RootViewController: UIViewController, ObservableObject {
             
             switch UserDefaults.standard.followerDataSourceType {
             case .nightscout:
-                
                 if !UserDefaults.standard.nightscoutEnabled {
                     dataSourceSensorMaxAgeOutlet.textColor = .systemRed
                     dataSourceSensorMaxAgeOutlet.text = Texts_HomeView.nightscoutNotEnabled
@@ -3298,11 +3297,13 @@ final class RootViewController: UIViewController, ObservableObject {
                     dataSourceSensorMaxAgeOutlet.text = nightscoutUrlString
                 }
                 
-            case .libreLinkUp:
-                
+            case .libreLinkUp, .libreLinkUpRussia:
                 if UserDefaults.standard.libreLinkUpEmail == nil || UserDefaults.standard.libreLinkUpPassword == nil {
                     dataSourceSensorMaxAgeOutlet.textColor = .systemRed
                     dataSourceSensorMaxAgeOutlet.text = Texts_HomeView.libreLinkUpAccountCredentialsMissing
+                } else if UserDefaults.standard.libreLinkUpPreventLogin {
+                    dataSourceSensorMaxAgeOutlet.textColor = .systemRed
+                    dataSourceSensorMaxAgeOutlet.text = Texts_HomeView.libreLinkUpAccountCredentialsInvalid
                 }
             }
         }
@@ -4096,7 +4097,7 @@ extension RootViewController: FollowerDelegate {
                             _ = followManager.createBgReading(followGlucoseData: followGlucoseData)
                         }
                         
-                    case .libreLinkUp:
+                    case .libreLinkUp, .libreLinkUpRussia:
                         
                         if let followManager = libreLinkUpFollowManager {
                             _ = followManager.createBgReading(followGlucoseData: followGlucoseData)

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewDataSourceSettingsViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewDataSourceSettingsViewModel.swift
@@ -234,7 +234,7 @@ class SettingsViewDataSourceSettingsViewModel: NSObject, SettingsViewModelProtoc
             
         case .followerUserName:
             switch UserDefaults.standard.followerDataSourceType {
-            case .libreLinkUp:
+            case .libreLinkUp, .libreLinkUpRussia:
                 return SettingsSelectedRowAction.askText(title: UserDefaults.standard.followerDataSourceType.description, message: Texts_SettingsView.enterUsername, keyboardType: .default, text: UserDefaults.standard.libreLinkUpEmail, placeHolder: nil, actionTitle: nil, cancelTitle: nil, actionHandler: { (libreLinkUpEmail: String) in
                         
                     UserDefaults.standard.libreLinkUpEmail = libreLinkUpEmail.toNilIfLength0()
@@ -253,7 +253,7 @@ class SettingsViewDataSourceSettingsViewModel: NSObject, SettingsViewModelProtoc
             
         case .followerPassword:
             switch UserDefaults.standard.followerDataSourceType {
-            case .libreLinkUp:
+            case .libreLinkUp, .libreLinkUpRussia:
                 return SettingsSelectedRowAction.askText(title: UserDefaults.standard.followerDataSourceType.description, message: Texts_SettingsView.enterPassword, keyboardType: .default, text: UserDefaults.standard.libreLinkUpPassword, placeHolder: nil, actionTitle: nil, cancelTitle: nil, actionHandler: { (libreLinkUpPassword: String) in
     
                     UserDefaults.standard.libreLinkUpPassword = libreLinkUpPassword.toNilIfLength0()
@@ -301,7 +301,7 @@ class SettingsViewDataSourceSettingsViewModel: NSObject, SettingsViewModelProtoc
                 // no need to show any extra rows/settings (beyond patient name) as all Nightscout required parameters are set in the Nightscout section
                 return 5
             
-            case .libreLinkUp:
+            case .libreLinkUp, .libreLinkUpRussia:
                 // show all sections if needed. If there is no active sensor data then just hide some of the rows
                 return UserDefaults.standard.activeSensorSerialNumber != nil ? count : count - (UserDefaults.standard.libreLinkUpPassword == nil || UserDefaults.standard.libreLinkUpEmail == nil ? 4 : 3)
             }
@@ -393,7 +393,7 @@ class SettingsViewDataSourceSettingsViewModel: NSObject, SettingsViewModelProtoc
             
         case .followerUserName:
             switch UserDefaults.standard.followerDataSourceType {
-            case .libreLinkUp:
+            case .libreLinkUp, .libreLinkUpRussia:
                 return UserDefaults.standard.libreLinkUpEmail?.obscured() ?? Texts_SettingsView.valueIsRequired
             default:
                 return nil
@@ -401,7 +401,7 @@ class SettingsViewDataSourceSettingsViewModel: NSObject, SettingsViewModelProtoc
             
         case .followerPassword:
             switch UserDefaults.standard.followerDataSourceType {
-            case .libreLinkUp:
+            case .libreLinkUp, .libreLinkUpRussia:
                 return UserDefaults.standard.libreLinkUpPassword?.obscured() ?? Texts_SettingsView.valueIsRequired
             default:
                 return nil
@@ -409,7 +409,7 @@ class SettingsViewDataSourceSettingsViewModel: NSObject, SettingsViewModelProtoc
             
         case .followerSensorSerialNumber:
             switch UserDefaults.standard.followerDataSourceType {
-            case .libreLinkUp:
+            case .libreLinkUp, .libreLinkUpRussia:
                 // we will use this row to also show important information regarding any login errors
                 if UserDefaults.standard.libreLinkUpReAcceptNeeded {
                     return Texts_SettingsView.libreLinkUpReAcceptNeeded
@@ -418,7 +418,7 @@ class SettingsViewDataSourceSettingsViewModel: NSObject, SettingsViewModelProtoc
                         // nicely format the (incomplete) serial numbers from LibreLinkUp
                         return processLibreLinkUpSensorInfo(sn: UserDefaults.standard.activeSensorSerialNumber)
                     } else if UserDefaults.standard.libreLinkUpPreventLogin {
-                        return "Invalid User/Password"
+                        return "⚠️ " + Texts_HomeView.libreLinkUpAccountCredentialsInvalid
                     } else {
                         return "⚠️ " + Texts_SettingsView.libreLinkUpNoActiveSensor
                     }
@@ -430,7 +430,7 @@ class SettingsViewDataSourceSettingsViewModel: NSObject, SettingsViewModelProtoc
             
         case .followerSensorStartDate:
             switch UserDefaults.standard.followerDataSourceType {
-            case .libreLinkUp:
+            case .libreLinkUp, .libreLinkUpRussia:
                 if let startDate = UserDefaults.standard.activeSensorStartDate {
                     let sensorTimeInMinutes = Int(Date().timeIntervalSince1970 - startDate.timeIntervalSince1970) / 60
                     
@@ -465,6 +465,13 @@ class SettingsViewDataSourceSettingsViewModel: NSObject, SettingsViewModelProtoc
                     }
                     
                     return returnString
+                } else {
+                    return "-"
+                }
+                
+            case .libreLinkUpRussia:
+                if UserDefaults.standard.activeSensorSerialNumber != nil {
+                    return "Russia"
                 } else {
                     return "-"
                 }


### PR DESCRIPTION
![Simulator Screenshot - iPhone 16 Pro - 2025-03-10 at 20 56 26](https://github.com/user-attachments/assets/11d45985-9b0d-4f35-841b-7a3b61c8a37b)

Allows access to the libreview.ru domains.

Is kept as a separate data source as there is no way to detect that RU should be used - no redirects are sent for different regions when trying to access the global URLS, the credentials are just rejected. Adding it as a separate data source makes things much cleaner.

Tested and working.

![image](https://github.com/user-attachments/assets/e4824934-f763-45b6-ad69-a907cf59b430)
