### PR TITLE
build_xdrip.yml: Disable keepalive action

### DIFF
--- a/.github/workflows/build_xdrip.yml
+++ b/.github/workflows/build_xdrip.yml
@@ -136,12 +136,14 @@ jobs:
     
     # Keep repository "alive": add empty commits to ALIVE_BRANCH after "time_elapsed" days of inactivity to avoid inactivation of scheduled workflows
     - name: Keep alive
-      if: |
-        needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-        (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')
-      uses: gautamkrishnar/keepalive-workflow@v1 # using the workflow with default settings
-      with:
-        time_elapsed: 20 # Time elapsed from the previous commit to trigger a new automated commit (in days)
+      run: |
+        echo "Keep Alive temporarily removed while gautamkrishnar/keepalive-workflow is not available"
+    #  if: |
+    #    needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
+    #    (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')
+    #  uses: gautamkrishnar/keepalive-workflow@v1 # using the workflow with default settings
+    #  with:
+    #    time_elapsed: 20 # Time elapsed from the previous commit to trigger a new automated commit (in days)
     
     - name: Show scheduled build configuration message
       if: needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION != 'true'


### PR DESCRIPTION
The gautamkrishnar/keepalive-workflow has been taken down by GitHub, and GitHub Actions builds are failing due to this. 

Disabling the keepalive-workflow because the repo is no longer available. A permanent fix will need to be implemented later, this is a bandaid to prevent all build workflows to fail.

Successful test of the workflow (the run was terminated manually after the critical steps had completed):
https://github.com/bjornoleh/xdripswift/actions/runs/14604108694

This is also the same change that was made for LoopWorkspace: LoopKit/LoopWorkspace#248, and a similar PR is being reviewed for Trio.

