### PR TITLE
Low battery alert for phone

### DIFF
--- a/xdrip/Constants/ConstantsDefaultAlertLevels.swift
+++ b/xdrip/Constants/ConstantsDefaultAlertLevels.swift
@@ -12,7 +12,7 @@ enum ConstantsDefaultAlertLevels {
     static let defaultBatteryAlertLevelWatlaa = 20
     static let defaultBatteryAlertLevelLibre2 = 20
     static let defaultBatteryAlertLevelAtom = 20
-    static let defaultBatteryAlertLevelPhone = 2
+    static let defaultBatteryAlertLevelPhone = 10
     // blood glucose level alert values in mgdl
     static let veryHigh = 250
     static let veryLow = 50

--- a/xdrip/Constants/ConstantsDefaultAlertLevels.swift
+++ b/xdrip/Constants/ConstantsDefaultAlertLevels.swift
@@ -12,7 +12,7 @@ enum ConstantsDefaultAlertLevels {
     static let defaultBatteryAlertLevelWatlaa = 20
     static let defaultBatteryAlertLevelLibre2 = 20
     static let defaultBatteryAlertLevelAtom = 20
-    
+    static let defaultBatteryAlertLevelPhone = 2
     // blood glucose level alert values in mgdl
     static let veryHigh = 250
     static let veryLow = 50

--- a/xdrip/Constants/ConstantsNotifications.swift
+++ b/xdrip/Constants/ConstantsNotifications.swift
@@ -18,6 +18,8 @@ enum ConstantsNotifications {
         static let fastDropAlert = "fastDropAlert"
         /// fast rise
         static let fastRiseAlert = "fastRiseAlert"
+        /// phone battery low
+        static let phoneBatteryLow = "phoneBatteryLow"
     }
     
     /// identifiers for calibration requests

--- a/xdrip/Managers/Alerts/AlertKind.swift
+++ b/xdrip/Managers/Alerts/AlertKind.swift
@@ -184,7 +184,7 @@ public enum AlertKind:Int, CaseIterable {
     ///     - alertbody : AlertBody, AlertTitle and delay are used if an alert needs to be raised for the notification.
     ///     - alerttitle : AlertBody, AlertTitle and delay are used if an alert needs to be raised for the notification.
     ///     - delayInSeconds : If delayInSeconds not nil and > 0 or if delayInSeconds is nil, then the alert will be a future planned Alert. This will only be applicable to missed reading alerts.
-    func  (currentAlertEntry:AlertEntry, nextAlertEntry:AlertEntry?, lastBgReading:BgReading?, _ lastButOneBgReading:BgReading?, lastCalibration:Calibration?, transmitterBatteryInfo:TransmitterBatteryInfo?) -> (alertNeeded:Bool, alertBody:String?, alertTitle:String?, delayInSeconds:Int?) {
+    func alertNeeded(currentAlertEntry:AlertEntry, nextAlertEntry:AlertEntry?, lastBgReading:BgReading?, _ lastButOneBgReading:BgReading?, lastCalibration:Calibration?, transmitterBatteryInfo:TransmitterBatteryInfo?) -> (alertNeeded:Bool, alertBody:String?, alertTitle:String?, delayInSeconds:Int?) {
         //Not all input parameters in the closure are needed for every type of alert. - this is to make it generic
         
         let isMgDl = UserDefaults.standard.bloodGlucoseUnitIsMgDl

--- a/xdrip/Managers/Alerts/AlertKind.swift
+++ b/xdrip/Managers/Alerts/AlertKind.swift
@@ -16,6 +16,7 @@ public enum AlertKind:Int, CaseIterable {
     case batterylow = 6
     case fastdrop = 7
     case fastrise = 8
+    case phonebatterylow = 9
 
     /// this is used for presentation in UI table view. It allows to order the alert kinds in the view, different than they case ordering, and so allows to add new cases
     init?(forSection section: Int) {
@@ -40,7 +41,8 @@ public enum AlertKind:Int, CaseIterable {
             self = .calibration
         case 8:
             self = .batterylow
-            
+        case 9:
+            self = .phonebatterylow
         default:
             fatalError("in AlertKind initializer init(forRowAt row: Int), there's no case for the rownumber")
         }
@@ -69,6 +71,8 @@ public enum AlertKind:Int, CaseIterable {
             return 5
         case 8://battery low
             return 6
+        case 9://phone battery low
+            return 9
         default:
             fatalError("in alertKindRawValue, unknown case")
         }
@@ -79,7 +83,7 @@ public enum AlertKind:Int, CaseIterable {
         switch self {
         case .low, .high, .verylow, .veryhigh, .fastdrop, .fastrise:
             return true
-        case .missedreading, .batterylow, .calibration:
+        case .missedreading, .batterylow, .calibration, .phonebatterylow:
             return false
         }
     }
@@ -89,7 +93,7 @@ public enum AlertKind:Int, CaseIterable {
     /// probably only useful in UI - named AlertKind and not AlertType because there's already an AlertType which has a different goal
     func needsAlertValue() -> Bool {
         switch self {
-        case .low, .high, .verylow, .veryhigh, .missedreading, .calibration, .batterylow, .fastdrop, .fastrise:
+        case .low, .high, .verylow, .veryhigh, .missedreading, .calibration, .batterylow, .fastdrop, .fastrise, .phonebatterylow:
             return true
         }
     }
@@ -101,7 +105,7 @@ public enum AlertKind:Int, CaseIterable {
         switch self {
         case .low, .high, .verylow, .veryhigh, .fastdrop, .fastrise:
             return true
-        case .missedreading, .calibration, .batterylow:
+        case .missedreading, .calibration, .batterylow, .phonebatterylow:
             return false
         }
     }
@@ -131,6 +135,8 @@ public enum AlertKind:Int, CaseIterable {
             return ConstantsDefaultAlertLevels.fastdrop;
         case .fastrise:
             return ConstantsDefaultAlertLevels.fastrise;
+        case .phonebatterylow:
+            return ConstantsDefaultAlertLevels.defaultBatteryAlertLevelPhone
         }
     }
     
@@ -155,6 +161,8 @@ public enum AlertKind:Int, CaseIterable {
             return "fastdrop"
         case .fastrise:
             return "fastrise"
+        case .phonebatterylow:
+            return "phonebatterylow"
         }
     }
     
@@ -176,7 +184,7 @@ public enum AlertKind:Int, CaseIterable {
     ///     - alertbody : AlertBody, AlertTitle and delay are used if an alert needs to be raised for the notification.
     ///     - alerttitle : AlertBody, AlertTitle and delay are used if an alert needs to be raised for the notification.
     ///     - delayInSeconds : If delayInSeconds not nil and > 0 or if delayInSeconds is nil, then the alert will be a future planned Alert. This will only be applicable to missed reading alerts.
-    func alertNeeded(currentAlertEntry:AlertEntry, nextAlertEntry:AlertEntry?, lastBgReading:BgReading?, _ lastButOneBgReading:BgReading?, lastCalibration:Calibration?, transmitterBatteryInfo:TransmitterBatteryInfo?) -> (alertNeeded:Bool, alertBody:String?, alertTitle:String?, delayInSeconds:Int?) {
+    func  (currentAlertEntry:AlertEntry, nextAlertEntry:AlertEntry?, lastBgReading:BgReading?, _ lastButOneBgReading:BgReading?, lastCalibration:Calibration?, transmitterBatteryInfo:TransmitterBatteryInfo?) -> (alertNeeded:Bool, alertBody:String?, alertTitle:String?, delayInSeconds:Int?) {
         //Not all input parameters in the closure are needed for every type of alert. - this is to make it generic
         
         let isMgDl = UserDefaults.standard.bloodGlucoseUnitIsMgDl
@@ -365,7 +373,22 @@ public enum AlertKind:Int, CaseIterable {
                 }
                 
                 return (false, nil, nil, nil)
+
+        case .phonebatterylow:
+            // if alertEntry not enabled, return false
+            if !currentAlertEntry.alertType.enabled {return (false, nil, nil, nil)}
+            
+            // Create battery info similar to transmitter battery info
+            UIDevice.current.isBatteryMonitoringEnabled = true
+            let phoneBatteryLevel = Int(UIDevice.current.batteryLevel * 100)
+            
+            // Check if battery level is below threshold, similar to transmitter check
+            if currentAlertEntry.value > phoneBatteryLevel {
+                return (true, "", Texts_Alerts.phoneBatteryLowAlertTitle, nil)
             }
+            
+            return (false, nil, nil, nil)
+        }
     }
     
     /// returns notification identifier for local notifications, for specific alertKind.
@@ -390,6 +413,8 @@ public enum AlertKind:Int, CaseIterable {
             return ConstantsNotifications.NotificationIdentifiersForAlerts.fastDropAlert
         case .fastrise:
             return ConstantsNotifications.NotificationIdentifiersForAlerts.fastRiseAlert
+        case .phonebatterylow:
+            return ConstantsNotifications.NotificationIdentifiersForAlerts.phoneBatteryLow
         }
     }
     
@@ -415,6 +440,8 @@ public enum AlertKind:Int, CaseIterable {
             return Texts_Alerts.fastDropTitle
         case .fastrise:
             return Texts_Alerts.fastRiseTitle
+        case .phonebatterylow:
+            return Texts_Alerts.phoneBatteryLowAlertTitle
         }
     }
     
@@ -435,6 +462,8 @@ public enum AlertKind:Int, CaseIterable {
             } else {
                 return ""// even though 20 is used as default alert level (assuming 20%) give as default value empty string
             }
+        case .phonebatterylow:
+            return "%"
         }
     }
     
@@ -469,7 +498,7 @@ fileprivate func createAlertTitleForBgReadingAlerts(alertKind: AlertKind) -> Str
         return Texts_Alerts.fastDropTitle
     case .fastrise:
         return Texts_Alerts.fastRiseTitle
-    case .missedreading, .calibration, .batterylow:
+    case .missedreading, .calibration, .batterylow, .phonebatterylow:
         return ""
     }
 }

--- a/xdrip/Managers/Alerts/AlertManager.swift
+++ b/xdrip/Managers/Alerts/AlertManager.swift
@@ -159,7 +159,7 @@ public class AlertManager:NSObject {
                 let checkAlertAndFireHelper = { (_ alertKind : AlertKind) -> Bool in self.checkAlertAndFire(alertKind: alertKind, lastBgReading: lastBgReading, lastButOneBgReading: lastButOneBgReading, lastCalibration: lastCalibration, transmitterBatteryInfo: transmitterBatteryInfo) }
                 
                 // specify the order in which alerts should be checked and group those with related snoozes
-                let alertGroupsByPreference: [[AlertKind]] = [[.fastdrop], [.verylow, .low], [.fastrise], [.veryhigh, .high], [.calibration], [.batterylow, .phonebatterylow]]
+                let alertGroupsByPreference: [[AlertKind]] = [[.fastdrop], [.verylow, .low], [.fastrise], [.veryhigh, .high], [.calibration], [.batterylow], [.phonebatterylow]]
                 
                 // only raise first alert group that's been tripped
                 // check the result to see if it's an alert kind that creates an immediate notification that contains the reading value

--- a/xdrip/Managers/Alerts/AlertManager.swift
+++ b/xdrip/Managers/Alerts/AlertManager.swift
@@ -159,7 +159,7 @@ public class AlertManager:NSObject {
                 let checkAlertAndFireHelper = { (_ alertKind : AlertKind) -> Bool in self.checkAlertAndFire(alertKind: alertKind, lastBgReading: lastBgReading, lastButOneBgReading: lastButOneBgReading, lastCalibration: lastCalibration, transmitterBatteryInfo: transmitterBatteryInfo) }
                 
                 // specify the order in which alerts should be checked and group those with related snoozes
-                let alertGroupsByPreference: [[AlertKind]] = [[.fastdrop], [.verylow, .low], [.fastrise], [.veryhigh, .high], [.calibration], [.batterylow]]
+                let alertGroupsByPreference: [[AlertKind]] = [[.fastdrop], [.verylow, .low], [.fastrise], [.veryhigh, .high], [.calibration], [.batterylow, .phonebatterylow]]
                 
                 // only raise first alert group that's been tripped
                 // check the result to see if it's an alert kind that creates an immediate notification that contains the reading value
@@ -178,8 +178,8 @@ public class AlertManager:NSObject {
                     
                 }
                     
-                    // the missed reading alert will be a future planned alert
-                    _ = checkAlertAndFireHelper(.missedreading)
+                // the missed reading alert will be a future planned alert
+                _ = checkAlertAndFireHelper(.missedreading)
                 
             } else {
                 trace("in checkAlerts, latestBgReadings is older than %{public}@ minutes", log: self.log, category: ConstantsLog.categoryAlertManager, type: .info, maxAgeOfLastBgReadingInSeconds.description)
@@ -566,7 +566,7 @@ public class AlertManager:NSObject {
 
                 } // if snoozePeriodInMinutes or snoozeTimeStamp is nil (which shouldn't be the case) continue without taking into account the snooze status
                 
-            case .calibration, .batterylow, .low, .high, .verylow, .veryhigh, .fastdrop, .fastrise:
+            case .calibration, .batterylow, .phonebatterylow, .low, .high, .verylow, .veryhigh, .fastdrop, .fastrise:
                 trace("in checkAlertAndFire, alert %{public}@ is currently snoozed", log: self.log, category: ConstantsLog.categoryAlertManager, type: .info, alertKind.descriptionForLogging())
                 return false
             }

--- a/xdrip/Texts/TextsAlerts.swift
+++ b/xdrip/Texts/TextsAlerts.swift
@@ -33,6 +33,10 @@ class Texts_Alerts {
         return NSLocalizedString("alerts_batterylow", tableName: filename, bundle: Bundle.main, value: "Transmitter Battery Low", comment: "transmitter battery low, this is the title of the alert notification, also in alert settings list, for the name of the alert")
     }()
     
+    static let phoneBatteryLowAlertTitle: String = {
+        return NSLocalizedString("alerts_phonebatterylow", tableName: filename, bundle: Bundle.main, value: "Phone Battery Low", comment: "phone battery low, this is the title of the alert notification, also in alert settings list, for the name of the alert")
+    }()
+    
     static let fastDropTitle: String = {
         return NSLocalizedString("alerts_fastdrop", tableName: filename, bundle: Bundle.main, value: "Fast Drop Alarm", comment: "When fast drop alert rises, this is the start of the text shown in the title of the alert notification, also in alert settings list, for the name of the alert")
     }()


### PR DESCRIPTION
I recently had a situation where I fell asleep at night and forgot to charge my phone. As a result, it ran out of battery, and I had no glucose readings for several hours, so Trio couldn’t loop. Luckily, nothing happened, but it made me realize that a low battery alert for the phone — not just the Dexcom transmitter — would make sense. That’s the background for this PR. I’ve been testing it live on my phone for a week now, and it’s been working well for me. If there’s interest in adding this to xDrip in general, here’s the PR 😄 

<img src="https://github.com/user-attachments/assets/51d5aace-3b8d-4e27-ac92-e7310feaf161" alt="Alert view" width="300"/>

<img src="https://github.com/user-attachments/assets/2a4ea4d3-8fd2-4edf-9c8c-ab00291d045c" alt="Alert in action" width="300"/>

*for the second picture I set the alert treshold to 90 just to demonstrate the alert