### PR TITLE
Handle new Libre 2 Plus EU (May 2025) sensors

### DIFF
--- a/xdrip/BluetoothTransmitter/CGM/Libre/Bubble/CGMBubbleTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Bubble/CGMBubbleTransmitter.swift
@@ -253,7 +253,7 @@ class CGMBubbleTransmitter:BluetoothTransmitter, CGMTransmitter {
                                 // if firmware < 2.6, libre2 and libreUS will decrypt fram local
                                 // after decryptFRAM, the libre2 and libreUS 344 will be libre1 344 data format
                                 // firmware >= 2.6, then bubble already decrypted the data, no need for decryption we already have the 344 bytes
-                                if libreSensorType == .libre2 || libreSensorType == .libre2C5 || libreSensorType == .libre2C6 || libreSensorType == .libreUS || libreSensorType == .libreUSE6 {
+                                if libreSensorType == .libre2 || libreSensorType == .libre2C5 || libreSensorType == .libre2C6 || libreSensorType == .libre27F || libreSensorType == .libreUS || libreSensorType == .libreUSE6 {
                                     
                                     if let firmware = firmware?.toDouble(), firmware < 2.6 {
                                         

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Libre2/CGMLibre2Transmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Libre2/CGMLibre2Transmitter.swift
@@ -488,9 +488,13 @@ extension CGMLibre2Transmitter: LibreNFCDelegate {
         
     }
     
-    func nfcScanSerialNumber(sensorSerialNumber: String) {
+    func nfcScanExpectedDevice(serialNumber: String, macAddress: String) {
         
-        self.updateExpectedDeviceName(sensorSerialNumber: sensorSerialNumber)
+        if (self.libreSensorType == .libre27F) {
+            self.updateExpectedDeviceName(name: macAddress)
+        } else {
+            self.updateExpectedDeviceName(name: "ABBOTT" + serialNumber)
+        }
         
     }
     

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreDataParser.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreDataParser.swift
@@ -231,7 +231,7 @@ class LibreDataParser {
                 // should never come here ?
                 trace("in libreDataProcessor, is libreUS but data is not decrypted - no further processing", log: log, category: ConstantsLog.categoryLibreDataParser, type: .info)
                 
-            case .libre2, .libre2C5, .libre2C6:
+            case .libre2, .libre2C5, .libre2C6, .libre27F:
                 
                 // should never come here ?
                 trace("in libreDataProcessor, is libre2 but data is not decrypted - no further processing", log: log, category: ConstantsLog.categoryLibreDataParser, type: .info)

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFC.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFC.swift
@@ -49,7 +49,7 @@ class LibreNFC: NSObject, NFCTagReaderSessionDelegate {
     /// use to keep track of the sensor serial number so that we can pass it back to the delegate
     private var serialNumber: String = ""
     
-    /// use to jeeo track of the sensor mac address so that we can pass it back to the delegate (for new Libre 2 Plus)
+    /// use to keep track of the sensor mac address so that we can pass it back to the delegate (for new Libre 2 Plus)
     private var macAddress: String = ""
     
     // MARK: - initalizer

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFC.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFC.swift
@@ -49,6 +49,9 @@ class LibreNFC: NSObject, NFCTagReaderSessionDelegate {
     /// use to keep track of the sensor serial number so that we can pass it back to the delegate
     private var serialNumber: String = ""
     
+    /// use to jeeo track of the sensor mac address so that we can pass it back to the delegate (for new Libre 2 Plus)
+    private var macAddress: String = ""
+    
     // MARK: - initalizer
     
     init(libreNFCDelegate: LibreNFCDelegate) {
@@ -121,7 +124,7 @@ class LibreNFC: NSObject, NFCTagReaderSessionDelegate {
                 
                 libreNFCDelegate?.nfcScanResult(successful: true)
                 
-                libreNFCDelegate?.nfcScanSerialNumber(sensorSerialNumber: serialNumber)
+                libreNFCDelegate?.nfcScanExpectedDevice(serialNumber: serialNumber, macAddress: macAddress)
                 
                 libreNFCDelegate?.startBLEScanning()
                 
@@ -467,7 +470,9 @@ class LibreNFC: NSObject, NFCTagReaderSessionDelegate {
                                             
                                             self.serialNumber = LibreSensorSerialNumber(withUID: sensorUID, with: LibreSensorType.type(patchInfo: patchInfo.toHexString()))?.serialNumber ?? "unknown"
                                             
-                                            let debugInfo = "NFC: successfully enabled BLE streaming on Libre 2 " + self.serialNumber + " unlock code: " + self.unlockCode.description + " MAC address: " + Data(response.reversed()).hexAddress
+                                            self.macAddress = Data(response.reversed()).hexEncodedString().uppercased()
+                                            
+                                            let debugInfo = "NFC: successfully enabled BLE streaming on Libre 2 " + self.serialNumber + " unlock code: " + self.unlockCode.description + " MAC address: " + self.macAddress
                                             
                                             xdrip.trace("%{public}@", log: self.log, category: ConstantsLog.categoryLibreNFC, type: .info, debugInfo)
                                             
@@ -719,6 +724,8 @@ class LibreNFC: NSObject, NFCTagReaderSessionDelegate {
         var manufacturer = String(tag.icManufacturerCode)
         if manufacturer == "7" {
             manufacturer.append(" (Texas Instruments)")
+        } else if manufacturer == "122" {
+            manufacturer.append(" (Abbott Diabetes Care)")
         }
 
         xdrip.trace("NFC: IC manufacturer code: %{public}@", log: self.log, category: ConstantsLog.categoryLibreNFC, type: .info, manufacturer)
@@ -737,7 +744,7 @@ class LibreNFC: NSObject, NFCTagReaderSessionDelegate {
         switch tag.identifier[2] {
         case 0xA0: rom += "TAL152H Libre 1 A0"
         case 0xA4: rom += "TAL160H Libre 2 A4"
-        default:   rom += " unknown"
+        default:   rom = String(tag.identifier[2])
         }
 
         xdrip.trace("NFC: %{public}@ ROM", log: self.log, category: ConstantsLog.categoryLibreNFC, type: .info, rom)

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFCDelegate.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFCDelegate.swift
@@ -16,6 +16,6 @@ protocol LibreNFCDelegate: AnyObject {
     func startBLEScanning()
     
     /// used to pass the recently scanned serial number back
-    func nfcScanSerialNumber(sensorSerialNumber: String)
+    func nfcScanExpectedDevice(serialNumber: String, macAddress: String)
     
 }

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorSerialNumber.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorSerialNumber.swift
@@ -104,7 +104,7 @@ public struct LibreSensorSerialNumber: CustomStringConvertible {
                 
                 first = "1"
                 
-            case .libre2, .libre2C5, .libre2C6:
+            case .libre2, .libre2C5, .libre2C6, .libre27F:
             
                 first = "3"
                 

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorType.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorType.swift
@@ -16,6 +16,8 @@ public enum LibreSensorType: String {
     
     case libre2C6 = "C6" // EU Libre 2 Plus
     
+    case libre27F = "7F" // new EU Libre 2 Plus (May 2025)
+    
     case libreUS = "E5"
     
     case libreUSE6 = "E6"
@@ -40,6 +42,9 @@ public enum LibreSensorType: String {
             
         case .libre2C6:
             return "Libre 2 Plus EU"
+            
+        case .libre27F:
+            return "Libre 2 Plus EU (New)"
             
         case .libreUS:
             return "Libre US"
@@ -66,7 +71,7 @@ public enum LibreSensorType: String {
         }
         
         // decrypt if libre2 or libreUS
-        if self == .libre2 || self == .libre2C5 || self == .libre2C6 || self == .libreUS || self == .libreUSE6 {
+        if self == .libre2 || self == .libre2C5 || self == .libre2C6 || self == .libre27F || self == .libreUS || self == .libreUSE6 {
             
             var libreData = rxBuffer.subdata(in: headerLength..<(rxBufferEnd + 1))
 
@@ -148,6 +153,9 @@ public enum LibreSensorType: String {
         case "70":
             return .libreProH
             
+        case "7F":
+            return .libre27F // newer non-Gen2 European Libre 2+ May 2025
+            
         default:
             return nil
             
@@ -169,7 +177,7 @@ public enum LibreSensorType: String {
         case .libre2, .libre2C5:
             return 14.5
             
-        case .libre2C6:
+        case .libre2C6, .libre27F:
             return 15.5
 
         case .libreUS, .libreUSE6:

--- a/xdrip/BluetoothTransmitter/Generic/BluetoothTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/Generic/BluetoothTransmitter.swift
@@ -291,9 +291,9 @@ class BluetoothTransmitter: NSObject, CBCentralManagerDelegate, CBPeripheralDele
     }
     
     /// called by the delegate in the case of a transmitter that needs an NFC scan and used to update the expected name to include the recently scanned sensor serial number. This ensures that we only allow this sensor to connect.
-    func updateExpectedDeviceName(sensorSerialNumber: String) {
+    func updateExpectedDeviceName(name: String) {
         
-        self.expectedName = "ABBOTT" + sensorSerialNumber
+        self.expectedName = name
         
     }
     
@@ -408,7 +408,7 @@ class BluetoothTransmitter: NSObject, CBCentralManagerDelegate, CBPeripheralDele
                     stopScanAndconnect(to: peripheral)
                 } else {
                     // peripheral.name is nil or does not contain expectedName
-                    trace("    new peripheral doesn't have device name as expected, ignoring this device", log: log, category: ConstantsLog.categoryBlueToothTransmitter, type: .info)
+                    trace("    new peripheral doesn't have device name as expected (%{public}@), ignoring this device", log: log, category: ConstantsLog.categoryBlueToothTransmitter, type: .info, expectedName)
                 }
             } else {
                 // we don't expect any specific device name, so let's connect


### PR DESCRIPTION
## Support for Libre 2 Plus EU Sensors (identified by serial numbers starting with 301)

###  Changes made:

    - Included detection for the new sensor type via patchInfo starting with "7F".

    - Updated expected Bluetooth device name logic: now matches using the MAC address instead of "ABBOTT" + serial number.

###  Testing:

    - Successfully tested on a Libre 2 Plus EU sensor.

    - Verified Bluetooth connection and continuous data reception.