### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "fastlane"
+gem 'fastlane', '>= 2.227.2'


### PR DESCRIPTION
Make sure at least Fastlane uses version 2.227.2 as lower versions seems to be incompatible with recent Apple API changes. Might even want to use 2.228.0, did not change the gemfile.lock as that should be dynamically updated by bundle install.