### PR TITLE
corrections for type errors in newer m4 Macs

### DIFF
--- a/xdrip/BluetoothTransmitter/CGM/Libre/Atom/CGMAtomTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Atom/CGMAtomTransmitter.swift
@@ -205,7 +205,7 @@ class CGMAtomTransmitter:BluetoothTransmitter, CGMTransmitter {
                                 self.libreSensorType = libreSensorType
                                 
                                 // decrypt of libre2 or libreUS
-                                dataIsDecryptedToLibre1Format = libreSensorType.decryptIfPossibleAndNeeded(rxBuffer: &rxBuffer[0..<344], headerLength: 0, log: log, patchInfo: patchInfo, uid: sensorSerialNumberAsData.bytes)
+                                dataIsDecryptedToLibre1Format = libreSensorType.decryptIfPossibleAndNeeded(rxBuffer: &rxBuffer[0..<344], headerLength: 0, log: log, patchInfo: patchInfo, uid: Array(sensorSerialNumberAsData))
                                 
                                 // now except libreProH, all libres' 344 data is libre1 format
                                 // should crc check

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Bubble/CGMBubbleTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Bubble/CGMBubbleTransmitter.swift
@@ -257,7 +257,7 @@ class CGMBubbleTransmitter:BluetoothTransmitter, CGMTransmitter {
                                     
                                     if let firmware = firmware?.toDouble(), firmware < 2.6 {
                                         
-                                        dataIsDecryptedToLibre1Format = libreSensorType.decryptIfPossibleAndNeeded(rxBuffer: &rxBuffer, headerLength: bubbleHeaderLength, log: log, patchInfo: patchInfo, uid: rxBuffer[0..<bubbleHeaderLength].bytes)
+                                        dataIsDecryptedToLibre1Format = libreSensorType.decryptIfPossibleAndNeeded(rxBuffer: &rxBuffer, headerLength: bubbleHeaderLength, log: log, patchInfo: patchInfo, uid: Array(rxBuffer[0..<bubbleHeaderLength]))
                                         
                                     } else {
                                         

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Libre2/CGMLibre2Transmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Libre2/CGMLibre2Transmitter.swift
@@ -384,7 +384,7 @@ extension CGMLibre2Transmitter: LibreNFCDelegate {
             
             var framCopy = fram
             
-            if libreSensorType.decryptIfPossibleAndNeeded(rxBuffer: &framCopy, headerLength: 0, log: log, patchInfo: patchInfo.hexEncodedString().uppercased(), uid: sensorUID.bytes) {
+            if libreSensorType.decryptIfPossibleAndNeeded(rxBuffer: &framCopy, headerLength: 0, log: log, patchInfo: patchInfo.hexEncodedString().uppercased(), uid: Array(sensorUID)) {
                 
                 // we have all date to create libre1DerivedAlgorithmParameters
                 UserDefaults.standard.libre1DerivedAlgorithmParameters = Libre1DerivedAlgorithmParameters(bytes: framCopy, serialNumber: serialNumber, libreSensorType: libreSensorType)

--- a/xdrip/BluetoothTransmitter/CGM/Libre/MiaoMiao/CGMMiaoMiaoTransmitter.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/MiaoMiao/CGMMiaoMiaoTransmitter.swift
@@ -178,7 +178,7 @@ class CGMMiaoMiaoTransmitter:BluetoothTransmitter, CGMTransmitter {
                                 cGMMiaoMiaoTransmitterDelegate?.received(libreSensorType: libreSensorType, from: self)
 
                                 // decrypt of libre2 or libreUS
-                                dataIsDecryptedToLibre1Format = libreSensorType.decryptIfPossibleAndNeeded(rxBuffer: &rxBuffer, headerLength: miaoMiaoHeaderLength, log: log, patchInfo: patchInfo, uid: rxBuffer[5..<13].bytes)
+                                dataIsDecryptedToLibre1Format = libreSensorType.decryptIfPossibleAndNeeded(rxBuffer: &rxBuffer, headerLength: miaoMiaoHeaderLength, log: log, patchInfo: patchInfo, uid: Array(rxBuffer[5..<13]))
                                 
                                 // now except libreProH, all libres' 344 data is libre1 format
                                 // should crc check
@@ -481,7 +481,7 @@ class CGMMiaoMiaoTransmitter:BluetoothTransmitter, CGMTransmitter {
                             // note that we should always have a libreSensorType
                             
                             // decrypt of libre2 or libreUS
-                            dataIsDecryptedToLibre1Format = libreSensorType.decryptIfPossibleAndNeeded(rxBuffer: &rxBuffer, headerLength: miaoMiaoHeaderLength, log: nil, patchInfo: patchInfo, uid: rxBuffer[5..<13].bytes)
+                            dataIsDecryptedToLibre1Format = libreSensorType.decryptIfPossibleAndNeeded(rxBuffer: &rxBuffer, headerLength: miaoMiaoHeaderLength, log: nil, patchInfo: patchInfo, uid: Array(rxBuffer[5..<13]))
                             
                             // now except libreProH, all libres' 344 data is libre1 format
                             // should crc check

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFC.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreNFC.swift
@@ -562,7 +562,7 @@ class LibreNFC: NSObject, NFCTagReaderSessionDelegate {
 
     func writeRaw(_ address: UInt16, _ data: Data, tag: NFCISO15693Tag, handler: @escaping (UInt16, Data, Error?) -> Void) {
         
-        let backdoor = "deadbeef".bytes
+        let backdoor = [UInt8]([0xDE, 0xAD, 0xBE, 0xEF]) // "deadbeef".bytes
         
         // Unlock
         xdrip.trace("NFC: sending 0xa4 0x07 0x%{public}@ command (%{public}@ unlock)", log: log, category: ConstantsLog.categoryLibreNFC, type: .info, Data(backdoor).toHexString(), "libre 2")

--- a/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorType.swift
+++ b/xdrip/BluetoothTransmitter/CGM/Libre/Utilities/LibreSensorType.swift
@@ -81,7 +81,7 @@ public enum LibreSensorType: String {
                     trace("    decrypting libre data", log: log, category: ConstantsLog.categoryLibreSensorType, type: .info)
                 }
                 
-                libreData = Data(PreLibre2.decryptFRAM(uid, info.bytes, libreData.bytes))
+                libreData = Data(PreLibre2.decryptFRAM(uid, Array(info), Array(libreData)))
                 
             } else {
                 


### PR DESCRIPTION
This pull request updates several instances where .bytes was used on String, Data, or [UInt8] values. These were relying on non-standard extensions or legacy behaviors that are no longer supported in recent versions of Swift (as used in Xcode on M4 Macs and newer toolchains). This issue also seems to affect VM installations using Xcode 15.5.

Example screenshot with compiler errors:
<img width="2048" height="1240" alt="image" src="https://github.com/user-attachments/assets/cd16d5c7-3b3d-4b13-9440-6164514f7cec" />

