### PR TITLE
Add support for UI file sharing to allow for database access / backup

### DIFF
--- a/xdrip/Supporting Files/Info.plist
+++ b/xdrip/Supporting Files/Info.plist
@@ -74,6 +74,10 @@
 	<string>Store bloodglucose readings</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>


### PR DESCRIPTION
In this patch, I enable UI file sharing using MacOS to allow you to backup / restore your database file.

I ran into an issue with the expiring public Testflight where to install with a new app identifier, it didn't pull the data from the old version.  This was an issue as I didn't want to lose months of CGM data.

I figure it would also be useful if anyone wants to muck around with the sqlite database themselves.

FYI for anyone running into the specific (expiring build) issue I did: 
1. Use Finder to create a full local backup
2. Use (iMazing)[http://imazing.com/] to extract the sqlite file
  > (Backups -> click on your recent backup -> More -> File System -> Apps -> AppDomain.com.OLD_TESTFLIGHT_TEAM_ID.xdriftswift -> Documents), then download the sqlite file to your desktop.
3. Install your new build (using xCode in my case, but perhaps with someone else's Testflight).
4. FORCE QUIT xDrip on your iphone.
5. Connect your phone via USB
6. Locate it in Finder
7. Go to Files -> xDrip4iO5
8. Drag the backed up sqlite file to there, overwriting the one in that folder.
9. If they exist, delete xdrip.sqlite-shm and xdrip.sqlite-wal