### PR TITLE
Update GitHub Actions to Xcode 16.4

### DIFF
--- a/.github/workflows/build_xdrip.yml
+++ b/.github/workflows/build_xdrip.yml
@@ -169,7 +169,7 @@ jobs:
         )
     steps:
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode_16.2.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer"
       
       - name: Checkout Repo for syncing
         if: |


### PR DESCRIPTION
Xcode 16.2 is no longer available on GitHub Actions and causes build errors.
This PR updates the workflow to use Xcode 16.4 instead.

Link to successful build: https://github.com/bjorkert/xdripswift/actions/runs/17187187012