### PR TITLE
iOS26 updates

### DIFF
--- a/xDrip Widget/Views/LiveActivityView.swift
+++ b/xDrip Widget/Views/LiveActivityView.swift
@@ -1,0 +1,50 @@
+//
+//  LiveActivityView.swift
+//  xdrip
+//
+//  Created by Paul Plant on 30/7/25.
+//  Copyright © 2025 Johan Degraeve. All rights reserved.
+//
+
+import SwiftUI
+import WidgetKit
+
+// conditionally show a view with the activity families added if available
+struct LiveActivityView: View {
+    @State var context: ActivityViewContext<XDripWidgetAttributes>
+    
+    var body: some View {
+        if #available(iOS 18.0, *) {
+            LiveActivityViewWithActivityFamily(context: context)
+        } else {
+            LiveActivityViewWithoutActivityFamily(context: context)
+        }
+    }
+}
+
+@available(iOS 18.0, *)
+struct LiveActivityViewWithActivityFamily: View {
+    @Environment(\.activityFamily) var activityFamily
+    @State var context: ActivityViewContext<XDripWidgetAttributes>
+    
+    var body: some View {
+        if #available(iOS 18.0, *) {
+            switch activityFamily {
+            case .small:
+                LiveActivityViewContentActivityFamilies(context: context)
+            case .medium:
+                LiveActivityViewContent(context: context)
+            @unknown default:
+                LiveActivityViewContent(context: context)
+            }
+        }
+    }
+}
+
+struct LiveActivityViewWithoutActivityFamily: View {
+    @State var context: ActivityViewContext<XDripWidgetAttributes>
+    
+    var body: some View {
+        LiveActivityViewContent(context: context)
+    }
+}

--- a/xDrip Widget/Views/LiveActivityViewContent.swift
+++ b/xDrip Widget/Views/LiveActivityViewContent.swift
@@ -1,0 +1,199 @@
+//
+//  LiveActivityViewContent.swift
+//  xdrip
+//
+//  Created by Paul Plant on 30/7/25.
+//  Copyright © 2025 Johan Degraeve. All rights reserved.
+//
+
+import SwiftUI
+import WidgetKit
+
+// this is the standard live activity view
+struct LiveActivityViewContent : View {
+    @State var context: ActivityViewContext<XDripWidgetAttributes>
+    
+    var body: some View {
+        if context.state.liveActivityType == .minimal {
+            // 1 = minimal widget with no chart
+            HStack(alignment: .center) {
+                Text("\(context.state.bgValueStringInUserChosenUnit()) \(context.state.trendArrow())")
+                    .font(.largeTitle).bold()
+                    .foregroundStyle(context.state.bgTextColor())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.2)
+                
+                Spacer()
+                
+                if context.state.warnUserToOpenApp {
+                    Text("Open app...")
+                        .font(.footnote).bold()
+                        .foregroundStyle(.black)
+                        .multilineTextAlignment(.center)
+                        .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
+                        .background(.cyan).opacity(0.9)
+                        .cornerRadius(10)
+                    
+                    Spacer()
+                }
+                
+                HStack(alignment: .center, spacing: 12) {
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Text(context.state.deltaChangeStringInUserChosenUnit())
+                            .font(.title).fontWeight(.semibold)
+                            .foregroundStyle(context.state.deltaChangeTextColor())
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.2)
+                        
+                        Text(context.state.bgUnitString)
+                            .font(.title)
+                            .foregroundStyle(.colorTertiary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.2)
+                    }
+                    
+                    if let deviceStatusIconImage = context.state.deviceStatusIconImage(), let deviceStatusColor = context.state.deviceStatusColor() {
+                        deviceStatusIconImage
+                            .font(.title2).bold()
+                            .foregroundStyle(deviceStatusColor)
+                    }
+                }
+            }
+            .activityBackgroundTint(.black)
+            .padding([.top, .bottom], 0)
+            .padding([.leading, .trailing], 20)
+            
+        } else if context.state.liveActivityType == .normal {
+            // 0 = normal size chart
+            HStack(spacing: 30) {
+                VStack(spacing: 0) {
+                    Text("\(context.state.bgValueStringInUserChosenUnit())\(context.state.trendArrow())")
+                        .font(.largeTitle).bold()
+                        .foregroundStyle(context.state.bgTextColor())
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.2)
+                    
+                    HStack(alignment: .center, spacing: 8) {
+                        HStack(alignment: .firstTextBaseline, spacing: 4) {
+                            Text(context.state.deltaChangeStringInUserChosenUnit())
+                                .font(.title2).fontWeight(.semibold)
+                                .foregroundStyle(context.state.deltaChangeTextColor())
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.2)
+                            
+                            if let deviceStatusIconImage = context.state.deviceStatusIconImage(), let deviceStatusColor = context.state.deviceStatusColor() {
+                                deviceStatusIconImage
+                                    .font(.body).bold()
+                                    .foregroundStyle(deviceStatusColor)
+                            } else {
+                                Text(context.state.bgUnitString)
+                                    .font(.title2)
+                                    .foregroundStyle(.colorTertiary)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.2)
+                            }
+                        }
+                    }
+                }
+                
+                ZStack {
+                    GlucoseChartView(glucoseChartType: .liveActivity, bgReadingValues: context.state.bgReadingValues, bgReadingDates: context.state.bgReadingDates, isMgDl: context.state.isMgDl, urgentLowLimitInMgDl: context.state.urgentLowLimitInMgDl, lowLimitInMgDl: context.state.lowLimitInMgDl, highLimitInMgDl: context.state.highLimitInMgDl, urgentHighLimitInMgDl: context.state.urgentHighLimitInMgDl, liveActivityType: .normal, hoursToShowScalingHours: nil, glucoseCircleDiameterScalingHours: nil, overrideChartHeight: nil, overrideChartWidth: nil, highContrast: nil)
+                    
+                    if context.state.warnUserToOpenApp {
+                        VStack(alignment: .center) {
+                            Spacer()
+                            Text("Open \(ConstantsHomeView.applicationName)")
+                                .font(.footnote).bold()
+                                .foregroundStyle(.black)
+                                .multilineTextAlignment(.center)
+                                .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
+                                .background(.cyan).opacity(0.9)
+                                .cornerRadius(10)
+                            Spacer()
+                        }
+                        .padding(8)
+                    }
+                }
+            }
+            .activityBackgroundTint(.black)
+            .padding(.top, 10)
+            .padding(.bottom, 10)
+            
+        } else {
+            // 3 = large chart is final default option
+            ZStack {
+                VStack(spacing: 0) {
+                    HStack(alignment: .center) {
+                        Text("\(context.state.bgValueStringInUserChosenUnit()) \(context.state.trendArrow())")
+                            .font(.largeTitle).fontWeight(.bold)
+                            .foregroundStyle(context.state.bgTextColor())
+                            .scaledToFill()
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.5)
+                        
+                        Spacer()
+                        
+                        HStack(alignment: .center, spacing: 10) {
+                            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                                Text(context.state.deltaChangeStringInUserChosenUnit())
+                                    .font(.title).fontWeight(.semibold)
+                                    .foregroundStyle(context.state.deltaChangeTextColor())
+                                    .lineLimit(1)
+                                
+                                Text(context.state.bgUnitString)
+                                    .font(.title)
+                                    .foregroundStyle(.colorTertiary)
+                                    .lineLimit(1)
+                            }
+                            
+                            if let deviceStatusIconImage = context.state.deviceStatusIconImage(), let deviceStatusColor = context.state.deviceStatusColor() {
+                                deviceStatusIconImage
+                                    .font(.title3).bold()
+                                    .foregroundStyle(deviceStatusColor)
+                            }
+                        }
+                    }
+                    .padding(.top, 8)
+                    .padding(.bottom, 2)
+                    .padding(.leading, 15)
+                    .padding(.trailing, 15)
+                    
+                    GlucoseChartView(glucoseChartType: .liveActivity, bgReadingValues: context.state.bgReadingValues, bgReadingDates: context.state.bgReadingDates, isMgDl: context.state.isMgDl, urgentLowLimitInMgDl: context.state.urgentLowLimitInMgDl, lowLimitInMgDl: context.state.lowLimitInMgDl, highLimitInMgDl: context.state.highLimitInMgDl, urgentHighLimitInMgDl: context.state.urgentHighLimitInMgDl, liveActivityType: .large, hoursToShowScalingHours: nil, glucoseCircleDiameterScalingHours: nil, overrideChartHeight: nil, overrideChartWidth: nil, highContrast: nil)
+                    
+                    HStack {
+                        Text(context.state.dataSourceDescription)
+                            .font(.caption).bold()
+                            .foregroundStyle(.colorSecondary)
+                        
+                        Spacer()
+                        
+                        Text("Last reading at \(context.state.bgReadingDate?.formatted(date: .omitted, time: .shortened) ?? "--:--")")
+                            .font(.caption)
+                            .foregroundStyle(.colorSecondary)
+                    }
+                    .padding(.top, 6)
+                    .padding(.bottom, 10)
+                    .padding(.leading, 15)
+                    .padding(.trailing, 15)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(0)
+                
+                if context.state.warnUserToOpenApp {
+                    VStack(alignment: .center) {
+                        Text("Please open \(ConstantsHomeView.applicationName)")
+                            .font(.footnote).bold()
+                            .foregroundStyle(.black)
+                            .multilineTextAlignment(.center)
+                            .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
+                            .background(.cyan).opacity(0.9)
+                            .cornerRadius(10)
+                    }
+                }
+            }
+            .activityBackgroundTint(.black)
+        }
+    }
+}
+
+

--- a/xDrip Widget/Views/LiveActivityViewContentActivityFamilies.swift
+++ b/xDrip Widget/Views/LiveActivityViewContentActivityFamilies.swift
@@ -1,0 +1,80 @@
+//
+//  LiveActivityContentActivityFamiliesView.swift
+//  xdrip
+//
+//  Created by Paul Plant on 29/7/25.
+//  Copyright © 2025 Johan Degraeve. All rights reserved.
+//
+
+import SwiftUI
+import WidgetKit
+
+// this is the newer live activity view which is used for >=iOS18 and uses the activity family to
+// correctly show the view in Smart Stack and CarPlay if possible (>=iOS26)
+@available(iOS 18.0, *)
+struct LiveActivityViewContentActivityFamilies: View {
+    @Environment(\.widgetFamily) var activityFamily
+    @State var context: ActivityViewContext<XDripWidgetAttributes>
+    
+    var body: some View {
+        ZStack {
+            GeometryReader { geo in
+                VStack(spacing: 3) {
+                    HStack(alignment: .center) {
+                        HStack(alignment: .center, spacing: 3) {
+                            Text("\(context.state.bgValueStringInUserChosenUnit())\(context.state.trendArrow()) ")
+                                .font(.headline)
+                                .foregroundStyle(context.state.bgTextColor())
+                            
+                            Text(context.state.deltaChangeStringInUserChosenUnit())
+                                .font(.subheadline)
+                                .foregroundStyle(context.state.deltaChangeTextColor())
+                                .lineLimit(1)
+                        }
+                        .padding(.leading, 10)
+                        
+                        Spacer()
+                        
+                        Text("\(context.state.bgReadingDate?.formatted(date: .omitted, time: .shortened) ?? "--:--")")
+                            .font(.subheadline)
+                            .foregroundStyle(.colorTertiary)
+                            .minimumScaleFactor(0.2)
+                            .padding(.trailing, 10)
+                    }
+                    .padding(.top, 4)
+                    
+                    GlucoseChartView(
+                        glucoseChartType: .watchAccessoryRectangular,
+                        bgReadingValues: context.state.bgReadingValues,
+                        bgReadingDates: context.state.bgReadingDates,
+                        isMgDl: context.state.isMgDl,
+                        urgentLowLimitInMgDl: context.state.urgentLowLimitInMgDl,
+                        lowLimitInMgDl: context.state.lowLimitInMgDl,
+                        highLimitInMgDl: context.state.highLimitInMgDl,
+                        urgentHighLimitInMgDl: context.state.urgentHighLimitInMgDl,
+                        liveActivityType: nil,
+                        hoursToShowScalingHours: 4,
+                        glucoseCircleDiameterScalingHours: 5,
+                        overrideChartHeight: min(activityFamily.toSidebarRowSize == .small ? ConstantsGlucoseChartSwiftUI.viewHeightWatchAccessoryRectangularSmall : ConstantsGlucoseChartSwiftUI.viewHeightWatchAccessoryRectangular, geo.size.height * 0.55),
+                        overrideChartWidth: geo.size.width - 20,
+                        highContrast: nil
+                    )
+                    .frame(maxWidth: .infinity, alignment: .center)
+                }
+            }
+        }
+        
+    }
+}
+
+// MARK: - extensions
+extension WidgetFamily {
+    var toSidebarRowSize: SidebarRowSize {
+        switch self {
+        case .systemSmall:  return .small
+        case .systemMedium: return .medium
+        case .systemLarge:  return .large
+        default:            return .medium
+        }
+    }
+}

--- a/xDrip Widget/XDripWidgetLiveActivity.swift
+++ b/xDrip Widget/XDripWidgetLiveActivity.swift
@@ -13,195 +13,16 @@ import WidgetKit
 struct XDripWidgetLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: XDripWidgetAttributes.self) { context in
-            
-            if context.state.liveActivityType == .minimal {
-                // 1 = minimal widget with no chart
-                HStack(alignment: .center) {
-                    Text("\(context.state.bgValueStringInUserChosenUnit()) \(context.state.trendArrow())")
-                        .font(.largeTitle).bold()
-                        .foregroundStyle(context.state.bgTextColor())
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.2)
-                    
-                    Spacer()
-                    
-                    if context.state.warnUserToOpenApp {
-                        Text("Open app...")
-                            .font(.footnote).bold()
-                            .foregroundStyle(.black)
-                            .multilineTextAlignment(.center)
-                            .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
-                            .background(.cyan).opacity(0.9)
-                            .cornerRadius(10)
-                        
-                        Spacer()
-                    }
-                    
-                    HStack(alignment: .center, spacing: 12) {
-                        HStack(alignment: .firstTextBaseline, spacing: 4) {
-                            Text(context.state.deltaChangeStringInUserChosenUnit())
-                                .font(.title).fontWeight(.semibold)
-                                .foregroundStyle(context.state.deltaChangeTextColor())
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.2)
-                            
-                            Text(context.state.bgUnitString)
-                                .font(.title)
-                                .foregroundStyle(.colorTertiary)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.2)
-                        }
-                        
-                        if let deviceStatusIconImage = context.state.deviceStatusIconImage(), let deviceStatusColor = context.state.deviceStatusColor() {
-                            deviceStatusIconImage
-                                .font(.title2).bold()
-                                .foregroundStyle(deviceStatusColor)
-                        }
-                    }
-                }
-                .activityBackgroundTint(.black)
-                .padding([.top, .bottom], 0)
-                .padding([.leading, .trailing], 20)
-                
-            } else if context.state.liveActivityType == .normal {
-                // 0 = normal size chart
-                HStack(spacing: 30) {
-                    VStack(spacing: 0) {
-                        Text("\(context.state.bgValueStringInUserChosenUnit())\(context.state.trendArrow())")
-                            .font(.largeTitle).bold()
-                            .foregroundStyle(context.state.bgTextColor())
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.2)
-                        
-                        HStack(alignment: .center, spacing: 8) {
-                            HStack(alignment: .firstTextBaseline, spacing: 4) {
-                                Text(context.state.deltaChangeStringInUserChosenUnit())
-                                    .font(.title2).fontWeight(.semibold)
-                                    .foregroundStyle(context.state.deltaChangeTextColor())
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.2)
-                                
-                                if let deviceStatusIconImage = context.state.deviceStatusIconImage(), let deviceStatusColor = context.state.deviceStatusColor() {
-                                    deviceStatusIconImage
-                                        .font(.body).bold()
-                                        .foregroundStyle(deviceStatusColor)
-                                } else {
-                                    Text(context.state.bgUnitString)
-                                        .font(.title2)
-                                        .foregroundStyle(.colorTertiary)
-                                        .lineLimit(1)
-                                        .minimumScaleFactor(0.2)
-                                }
-                            }
-                        }
-                    }
-                    
-                    ZStack {
-                        GlucoseChartView(glucoseChartType: .liveActivity, bgReadingValues: context.state.bgReadingValues, bgReadingDates: context.state.bgReadingDates, isMgDl: context.state.isMgDl, urgentLowLimitInMgDl: context.state.urgentLowLimitInMgDl, lowLimitInMgDl: context.state.lowLimitInMgDl, highLimitInMgDl: context.state.highLimitInMgDl, urgentHighLimitInMgDl: context.state.urgentHighLimitInMgDl, liveActivityType: .normal, hoursToShowScalingHours: nil, glucoseCircleDiameterScalingHours: nil, overrideChartHeight: nil, overrideChartWidth: nil, highContrast: nil)
-                        
-                        if context.state.warnUserToOpenApp {
-                            VStack(alignment: .center) {
-                                Spacer()
-                                Text("Open \(ConstantsHomeView.applicationName)")
-                                    .font(.footnote).bold()
-                                    .foregroundStyle(.black)
-                                    .multilineTextAlignment(.center)
-                                    .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
-                                    .background(.cyan).opacity(0.9)
-                                    .cornerRadius(10)
-                                Spacer()
-                            }
-                            .padding(8)
-                        }
-                    }
-                }
-                .activityBackgroundTint(.black)
-                .padding(.top, 10)
-                .padding(.bottom, 10)
-                
-            } else {
-                // 3 = large chart is final default option
-                ZStack {
-                    VStack(spacing: 0) {
-                        HStack(alignment: .center) {
-                            Text("\(context.state.bgValueStringInUserChosenUnit()) \(context.state.trendArrow())")
-                                .font(.largeTitle).fontWeight(.bold)
-                                .foregroundStyle(context.state.bgTextColor())
-                                .scaledToFill()
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.5)
-                            
-                            Spacer()
-                            
-                            HStack(alignment: .center, spacing: 10) {
-                                HStack(alignment: .firstTextBaseline, spacing: 4) {
-                                    Text(context.state.deltaChangeStringInUserChosenUnit())
-                                        .font(.title).fontWeight(.semibold)
-                                        .foregroundStyle(context.state.deltaChangeTextColor())
-                                        .lineLimit(1)
-                                    
-                                    Text(context.state.bgUnitString)
-                                        .font(.title)
-                                        .foregroundStyle(.colorTertiary)
-                                        .lineLimit(1)
-                                }
-                                
-                                if let deviceStatusIconImage = context.state.deviceStatusIconImage(), let deviceStatusColor = context.state.deviceStatusColor() {
-                                    deviceStatusIconImage
-                                        .font(.title3).bold()
-                                        .foregroundStyle(deviceStatusColor)
-                                }
-                            }
-                        }
-                        .padding(.top, 8)
-                        .padding(.bottom, 2)
-                        .padding(.leading, 15)
-                        .padding(.trailing, 15)
-                        
-                        GlucoseChartView(glucoseChartType: .liveActivity, bgReadingValues: context.state.bgReadingValues, bgReadingDates: context.state.bgReadingDates, isMgDl: context.state.isMgDl, urgentLowLimitInMgDl: context.state.urgentLowLimitInMgDl, lowLimitInMgDl: context.state.lowLimitInMgDl, highLimitInMgDl: context.state.highLimitInMgDl, urgentHighLimitInMgDl: context.state.urgentHighLimitInMgDl, liveActivityType: .large, hoursToShowScalingHours: nil, glucoseCircleDiameterScalingHours: nil, overrideChartHeight: nil, overrideChartWidth: nil, highContrast: nil)
-                        
-                        HStack {
-                            Text(context.state.dataSourceDescription)
-                                .font(.caption).bold()
-                                .foregroundStyle(.colorSecondary)
-                            
-                            Spacer()
-                            
-                            Text("Last reading at \(context.state.bgReadingDate?.formatted(date: .omitted, time: .shortened) ?? "--:--")")
-                                .font(.caption)
-                                .foregroundStyle(.colorSecondary)
-                        }
-                        .padding(.top, 6)
-                        .padding(.bottom, 10)
-                        .padding(.leading, 15)
-                        .padding(.trailing, 15)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(0)
-                    
-                    if context.state.warnUserToOpenApp {
-                        VStack(alignment: .center) {
-                            Text("Please open \(ConstantsHomeView.applicationName)")
-                                .font(.footnote).bold()
-                                .foregroundStyle(.black)
-                                .multilineTextAlignment(.center)
-                                .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
-                                .background(.cyan).opacity(0.9)
-                                .cornerRadius(10)
-                        }
-                    }
-                }
-                .activityBackgroundTint(.black)
-            }
-            
+            // call a view here so that we can conditionally show one or another
+            LiveActivityView(context: context)
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) { Text("\(context.state.bgValueStringInUserChosenUnit())\(context.state.trendArrow())")
-                    .font(.largeTitle).bold()
-                    .foregroundStyle(context.state.bgTextColor())
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.2)
+                        .font(.largeTitle).bold()
+                        .foregroundStyle(context.state.bgTextColor())
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.2)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
@@ -258,6 +79,7 @@ struct XDripWidgetLiveActivity: Widget {
             .widgetURL(URL(string: "xdripswift"))
             .keylineTint(context.state.bgTextColor())
         }
+        .addSupplementalActivityFamilies()
     }
 }
 
@@ -317,5 +139,18 @@ struct XDripWidgetLiveActivity_Previews: PreviewProvider {
         attributes
             .previewContext(contentState, viewKind: .dynamicIsland(.minimal))
             .previewDisplayName("Minimal")
+    }
+}
+
+// MARK: - extensions
+extension WidgetConfiguration {
+    // this function will (if available) add the .small activity family is using >=iOS18 so that the specific live activity view
+    // can also be displayed in the Smart Stack of the Apple Watch and also CarPlay (if using >=iOS26)
+    func addSupplementalActivityFamilies() -> some WidgetConfiguration {
+        if #available(iOSApplicationExtension 18.0, *) {
+            return self.supplementalActivityFamilies([.small])
+        } else {
+            return self
+        }
     }
 }

--- a/xdrip.xcodeproj/project.pbxproj
+++ b/xdrip.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		47A6AC452B7D43100047A4BA /* Common.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8BDD444221C9D0D006EAB84 /* Common.strings */; };
 		47A6AC462B7D43110047A4BA /* Common.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8BDD444221C9D0D006EAB84 /* Common.strings */; };
 		47A7DFB62BE4BE4900F1DA5F /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A7DFB52BE4BE4900F1DA5F /* UIView.swift */; };
+		47A8B8872E392BFE00081CBD /* LiveActivityViewContentActivityFamilies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A8B8862E392BF700081CBD /* LiveActivityViewContentActivityFamilies.swift */; };
 		47AB72F327105EF4005E7CAB /* SettingsViewHelpSettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AB72F227105EF4005E7CAB /* SettingsViewHelpSettingModel.swift */; };
 		47ACB9292D835841001EC891 /* DatePickerViewControllerModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ACB9282D835838001EC891 /* DatePickerViewControllerModal.swift */; };
 		47ADD2DF27FAF8630025E2F4 /* ChartPointsScatterDownTrianglesLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ADD2DE27FAF8630025E2F4 /* ChartPointsScatterDownTrianglesLayer.swift */; };
@@ -171,6 +172,8 @@
 		47B136DB2BC9BB55001E7ED3 /* ContactImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B136DA2BC9BB55001E7ED3 /* ContactImageView.swift */; };
 		47B136DD2BCA9151001E7ED3 /* ConstantsContactImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B136DC2BCA9151001E7ED3 /* ConstantsContactImage.swift */; };
 		47B60F3726F389E2003198D3 /* LandscapeChartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B60F3626F389E2003198D3 /* LandscapeChartViewController.swift */; };
+		47B65D412E3A31B100C3140B /* LiveActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B65D402E3A319D00C3140B /* LiveActivityView.swift */; };
+		47B65D452E3A756300C3140B /* LiveActivityViewContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B65D442E3A755900C3140B /* LiveActivityViewContent.swift */; };
 		47B731412B83DD3C00B0A450 /* ConstantsLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B7313F2B83DC0200B0A450 /* ConstantsLiveActivity.swift */; };
 		47B7FC722B00CF4B004C872B /* FollowerBackgroundKeepAliveType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B7FC712B00CF4B004C872B /* FollowerBackgroundKeepAliveType.swift */; };
 		47CA61E42B965E7100C2A597 /* AccessoryCircularView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA61E32B965E7100C2A597 /* AccessoryCircularView.swift */; };
@@ -999,6 +1002,7 @@
 		47A6ABE82B790CC70047A4BA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		47A6ABEE2B7949B80047A4BA /* WatchStateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchStateModel.swift; sourceTree = "<group>"; };
 		47A7DFB52BE4BE4900F1DA5F /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
+		47A8B8862E392BF700081CBD /* LiveActivityViewContentActivityFamilies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityViewContentActivityFamilies.swift; sourceTree = "<group>"; };
 		47AB72F227105EF4005E7CAB /* SettingsViewHelpSettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewHelpSettingModel.swift; sourceTree = "<group>"; };
 		47ACB9282D835838001EC891 /* DatePickerViewControllerModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerViewControllerModal.swift; sourceTree = "<group>"; };
 		47ADD2DE27FAF8630025E2F4 /* ChartPointsScatterDownTrianglesLayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartPointsScatterDownTrianglesLayer.swift; sourceTree = "<group>"; };
@@ -1006,6 +1010,8 @@
 		47B136DA2BC9BB55001E7ED3 /* ContactImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactImageView.swift; sourceTree = "<group>"; };
 		47B136DC2BCA9151001E7ED3 /* ConstantsContactImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsContactImage.swift; sourceTree = "<group>"; };
 		47B60F3626F389E2003198D3 /* LandscapeChartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandscapeChartViewController.swift; sourceTree = "<group>"; };
+		47B65D402E3A319D00C3140B /* LiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityView.swift; sourceTree = "<group>"; };
+		47B65D442E3A755900C3140B /* LiveActivityViewContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityViewContent.swift; sourceTree = "<group>"; };
 		47B7313F2B83DC0200B0A450 /* ConstantsLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsLiveActivity.swift; sourceTree = "<group>"; };
 		47B7FC712B00CF4B004C872B /* FollowerBackgroundKeepAliveType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowerBackgroundKeepAliveType.swift; sourceTree = "<group>"; };
 		47C210ED2B5298EB00005711 /* GlucoseChartType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseChartType.swift; sourceTree = "<group>"; };
@@ -2012,6 +2018,9 @@
 			children = (
 				47CA61E32B965E7100C2A597 /* AccessoryCircularView.swift */,
 				47CA61E52B966A9700C2A597 /* AccessoryRectangularView.swift */,
+				47B65D402E3A319D00C3140B /* LiveActivityView.swift */,
+				47B65D442E3A755900C3140B /* LiveActivityViewContent.swift */,
+				47A8B8862E392BF700081CBD /* LiveActivityViewContentActivityFamilies.swift */,
 				4746067D2B962FBD00AC9214 /* SystemLargeView.swift */,
 				4746067B2B962F8500AC9214 /* SystemMediumView.swift */,
 				474606792B962F4C00AC9214 /* SystemSmallView.swift */,
@@ -4246,9 +4255,11 @@
 				474606772B962CCD00AC9214 /* XDripWidget+Provider.swift in Sources */,
 				4746067C2B962F8500AC9214 /* SystemMediumView.swift in Sources */,
 				4716A4F62B406C3D00419052 /* XDripWidgetLiveActivity.swift in Sources */,
+				47B65D452E3A756300C3140B /* LiveActivityViewContent.swift in Sources */,
 				4716A4F42B406C3D00419052 /* XDripWidgetBundle.swift in Sources */,
 				474606752B962C4D00AC9214 /* XDripWidget+EntryView.swift in Sources */,
 				4716A4F82B406C3D00419052 /* XDripWidget.swift in Sources */,
+				47A8B8872E392BFE00081CBD /* LiveActivityViewContentActivityFamilies.swift in Sources */,
 				4715C32E2C9ED5E10052215F /* LiveActivityType.swift in Sources */,
 				4716A50D2B416EE100419052 /* ConstantsGlucoseChartSwiftUI.swift in Sources */,
 				47A6AC312B7D3E250047A4BA /* ConstantsBloodGlucose.swift in Sources */,
@@ -4260,6 +4271,7 @@
 				47A6AC412B7D42EC0047A4BA /* TextsCommon.swift in Sources */,
 				478A92572B8FA1E30084C394 /* ConstantsBGGraphBuilder.swift in Sources */,
 				4746068F2B963EA100AC9214 /* View.swift in Sources */,
+				47B65D412E3A31B100C3140B /* LiveActivityView.swift in Sources */,
 				47A6AC322B7D3E250047A4BA /* ConstantsUI.swift in Sources */,
 				474606802B96308A00AC9214 /* WidgetSharedUserDefaultsModel.swift in Sources */,
 				47A6AC362B7D3E640047A4BA /* GlucoseChartType.swift in Sources */,

--- a/xdrip/SwiftUIViews/GlucoseChartView.swift
+++ b/xdrip/SwiftUIViews/GlucoseChartView.swift
@@ -217,7 +217,21 @@ struct GlucoseChartView: View {
         }
         .chartYAxis(chartType.yAxisShowLabels())
         .chartYScale(domain: domain)
-        .background(chartType.backgroundColor())
+        .modifier(ChartBackgroundModifier(chartType: chartType))
         .clipShape(RoundedRectangle(cornerRadius: chartType.cornerRadius()))
+    }
+}
+
+// apply a view modifier so that we can correctly show the chart views when displayed as a widget
+// this ensures that the widgets can be displayed in tinted or clear styles (in iOS26)
+private struct ChartBackgroundModifier: ViewModifier {
+    let chartType: GlucoseChartType
+    
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            content.containerBackground(.clear, for: .widget)
+        } else {
+            content.background(chartType.backgroundColor())
+        }
     }
 }


### PR DESCRIPTION
PR to correct widget backgrounds for when used with clear/tinted widget views. It also allows the live activity to show correct transparency with iOS26 liquid metal (also works nicely now for the widgets in iOS26 CarPlay).

Adds Smart Stack support to show the iOS Live Activity on the Apple Watch, together with CarPlay (iOS26).