### PR TITLE
Live Activity widget URL change + App Delegate handler + NS token auth

### DIFF
--- a/xDrip Widget/XDripWidgetLiveActivity.swift
+++ b/xDrip Widget/XDripWidgetLiveActivity.swift
@@ -76,7 +76,7 @@ struct XDripWidgetLiveActivity: Widget {
                     .foregroundStyle(context.state.bgTextColor())
                     .minimumScaleFactor(0.2)
             }
-            .widgetURL(URL(string: "xdripswift"))
+            .widgetURL(URL(string: "xdripswift://open"))
             .keylineTint(context.state.bgTextColor())
         }
         .addSupplementalActivityFamilies()

--- a/xdrip/Application Delegate/AppDelegate.swift
+++ b/xdrip/Application Delegate/AppDelegate.swift
@@ -64,5 +64,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         completionHandler(true)
     }
+    
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        // Just acknowledge the URL so the system doesn't crash
+        return true
+    }
 }
 

--- a/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewNightscoutSettingsViewModel.swift
+++ b/xdrip/View Controllers/SettingsNavigationController/SettingsViewController/SettingsViewModels/SettingsViewNightscoutSettingsViewModel.swift
@@ -371,8 +371,19 @@ extension SettingsViewNightscoutSettingsViewModel: SettingsViewModelProtocol {
                 return .nothing
             
         case .openNightscout:
-            if let url = URL(string: UserDefaults.standard.nightscoutUrl ?? "") {
-                openWeb(url)
+            if let nightscoutURL = UserDefaults.standard.nightscoutUrl, let url = URL(string: nightscoutURL), var URLComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+                if UserDefaults.standard.nightscoutPort != 0 {
+                    URLComponents.port = UserDefaults.standard.nightscoutPort
+                }
+                
+                // if token not nil, then add also the token
+                if let token = UserDefaults.standard.nightscoutToken {
+                    URLComponents.queryItems = [URLQueryItem(name: "token", value: token)]
+                }
+                
+                if let url = URLComponents.url {
+                    openWeb(url)
+                }
             }
             
             return .nothing


### PR DESCRIPTION
Crash/Exception for one user with iOS26 Beta:

<img width="2048" height="1208" alt="image" src="https://github.com/user-attachments/assets/aac2802d-f607-4234-833b-303c47edf875" />

The fix is confirmed as working.