### PR TITLE
feat: add medtrum nano transmitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Current Status :
     - Droplet 1
     - Atom
     - Libre 2
+    - Medtrum TouchCare Nano CGM (passive BLE co-listener; requires the official Medtrum EasyPatch app to be installed and running on the same iPhone — EasyPatch performs the sensor authentication, and xDrip listens to the same notifications via iOS's GATT multiplexing. No internet connection needed; calibrations performed in EasyPatch are automatically picked up.)
 - 6 hour graph with readings
 - Alerting
 - Upload to Nightscout

--- a/xDrip/Application Delegate/AppDelegate.swift
+++ b/xDrip/Application Delegate/AppDelegate.swift
@@ -16,9 +16,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var restrictRotation:UIInterfaceOrientationMask = .all
     
     private var log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryAppDelegate)
-    
+
     // MARK: - Application Life Cycle
-    
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         trace("****************************************", log: log, category: ConstantsLog.categoryAppDelegate, type: .info)
         trace("*** in didFinishLaunchingWithOptions ***", log: log, category: ConstantsLog.categoryAppDelegate, type: .info)

--- a/xDrip/BluetoothPeripheral/CGM/Medtrum/TouchCareNano/MedtrumTouchCareNano+BluetoothPeripheral.swift
+++ b/xDrip/BluetoothPeripheral/CGM/Medtrum/TouchCareNano/MedtrumTouchCareNano+BluetoothPeripheral.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension MedtrumTouchCareNano: BluetoothPeripheral {
+
+    func bluetoothPeripheralType() -> BluetoothPeripheralType {
+        return .MedtrumTouchCareNanoType
+    }
+
+}

--- a/xDrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
+++ b/xDrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
@@ -37,6 +37,9 @@ enum BluetoothPeripheralType: String, CaseIterable {
     /// omnipod heartbeat
     case OmniPodHeartBeatType = "OmniPod HeartBeat"
 
+    /// Medtrum TouchCare Nano CGM (data relayed by the paired Medtrum patch pump)
+    case MedtrumTouchCareNanoType = "Medtrum TouchCare Nano"
+
     /// - returns: the BluetoothPeripheralViewModel. If nil then there's no specific settings for the tpe of bluetoothPeripheral
     func viewModel() -> BluetoothPeripheralViewModel? {
         
@@ -71,6 +74,9 @@ enum BluetoothPeripheralType: String, CaseIterable {
 
         case .DexcomG7Type:
             return DexcomG7BluetoothPeripheralViewModel()
+
+        case .MedtrumTouchCareNanoType:
+            return MedtrumTouchCareNanoBluetoothPeripheralViewModel()
         }
 
     }
@@ -114,26 +120,29 @@ enum BluetoothPeripheralType: String, CaseIterable {
         case .DexcomG7Type:
             return DexcomG7(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
 
+        case .MedtrumTouchCareNanoType:
+            return MedtrumTouchCareNano(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
+
         }
 
     }
-    
+
     /// to which category of bluetoothperipherals does this type belong (M5Stack, CGM, ...)
     func category() -> BluetoothPeripheralCategory {
-        
+
         switch self {
-            
+
         case .M5StackType, .M5StickCType:
             return .M5Stack
-            
-        case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .DexcomG7Type:
+
+        case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .DexcomG7Type, .MedtrumTouchCareNanoType:
             return .CGM
 
         case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
             return .HeartBeat
-            
+
         }
-        
+
     }
     
     /// does the device need a transmitterID (currently only Dexcom)

--- a/xDrip/BluetoothTransmitter/CGM/Generic/CGMSensorType.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Generic/CGMSensorType.swift
@@ -5,5 +5,7 @@ enum CGMSensorType:String, CaseIterable {
     case Libre = "Libre"
     
     case Dexcom = "Dexcom"
-    
+
+    case Medtrum = "Medtrum"
+
 }

--- a/xDrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
@@ -96,20 +96,26 @@ enum CGMTransmitterType:String, CaseIterable {
     
     /// Libre2
     case Libre2 = "Libre2"
-    
+
+    /// Medtrum TouchCare Nano CGM (data relayed via the paired Medtrum patch pump's BLE)
+    case medtrumTouchCareNano = "Medtrum TouchCare Nano"
+
     /// what sensorType does this CGMTransmitter type support
     func sensorType() -> CGMSensorType {
-        
+
         switch self {
-            
+
         case .dexcom, .dexcomG7:
             return .Dexcom
-            
+
         case .miaomiao, .Bubble, .Libre2:
             return .Libre
-            
+
+        case .medtrumTouchCareNano:
+            return .Medtrum
+
         }
-        
+
     }
     
     /// if true, then a class conforming to the protocol CGMTransmitterDelegate will call newSensorDetected if it detects a new sensor is placed. Means there's no need to let the user start and stop a sensor
@@ -134,10 +140,16 @@ enum CGMTransmitterType:String, CaseIterable {
             
         case .dexcomG7:
             return true
-            
+
+        case .medtrumTouchCareNano:
+            // EasyPatch runs the actual sensor lifecycle, but we *can* infer sensor start by combining
+            // packet timestamp with the reading-counter we decode. Returning true lets xDrip auto-start
+            // its internal sensor record from the sensorAge we pass with each reading.
+            return true
+
         }
     }
-    
+
     /// this function says if the user should be able to manually start the sensor.
     ///
     /// Would normally not be required, because if canDetectNewSensor returns true, then manual start shouldn't e necessary.
@@ -153,10 +165,14 @@ enum CGMTransmitterType:String, CaseIterable {
             
         case .dexcomG7:
             return false
-        
+
+        case .medtrumTouchCareNano:
+            // EasyPatch owns sensor lifecycle; xDrip should not offer a manual start UI.
+            return false
+
         }
     }
-        
+
     /// returns default battery alert level, below this level an alert should be generated - this default value will be used when changing transmittertype
     func defaultBatteryAlertLevel() -> Int {
         switch self {
@@ -176,10 +192,14 @@ enum CGMTransmitterType:String, CaseIterable {
         case .dexcomG7:
             // we don't use this
             return ConstantsDefaultAlertLevels.defaultBatteryAlertLevelDexcomG5
-            
+
+        case .medtrumTouchCareNano:
+            // No pump-battery surface in xDrip; reuse the generic threshold so the UI has a sane default.
+            return ConstantsDefaultAlertLevels.defaultBatteryAlertLevelLibre2
+
         }
     }
-    
+
     /// what unit to use for battery level, like '%', Volt, or nothing at all
     ///
     /// to be used for UI stuff
@@ -199,7 +219,10 @@ enum CGMTransmitterType:String, CaseIterable {
         case .dexcomG7:
             // we don't use this
             return ""
-            
+
+        case .medtrumTouchCareNano:
+            return ""
+
         }
     }
     

--- a/xDrip/BluetoothTransmitter/CGM/Medtrum/TouchCareNano/CGMMedtrumTouchCareNanoTransmitter.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Medtrum/TouchCareNano/CGMMedtrumTouchCareNanoTransmitter.swift
@@ -1,0 +1,180 @@
+import Foundation
+import CoreBluetooth
+import os
+
+/// Passive co-listener for the Medtrum TouchCare Nano CGM.
+///
+/// Architecture: the CGM patch sensor talks to the Medtrum patch *pump* over a proprietary RF
+/// link; the pump then broadcasts pump status and CGM readings over BLE on service
+/// `669A9001-…`. The official Medtrum EasyPatch app pairs/authenticates with the pump and
+/// holds the BLE link. iOS's CoreBluetooth multiplexes a single ACL link across multiple
+/// apps once a bond exists: we subscribe to the same notification characteristics, and the
+/// raw glucose packets are delivered to us alongside EasyPatch — no auth required on our side.
+///
+/// Glucose source: notifications on characteristic `669A9141`. The packet layout (decoded
+/// empirically against EasyPatch ground-truth readings):
+/// ```
+/// offset 0:  packet type (0xb3 0x02)
+/// offset 2:  status/flag byte + constant (0x?? 0x5b)
+/// offset 4:  uint16 LE — reading counter (+1 per 2-min CGM cycle since sensor start)
+/// offset 6:  constant (0x07 0x14 0x00)
+/// offset 8:  uint16 LE — current glucose (raw)
+/// offset 10: uint16 LE — glucose 2 min ago
+/// offset 12: uint16 LE — glucose 4 min ago
+/// offset 14: uint16 LE — glucose 6 min ago
+/// offset 16: uint16 LE — small varying counter (observed 0x0000 ... 0x0400); unused
+/// offset 18: uint16 LE — per-sensor calibration factor (updates on each EasyPatch calibration)
+/// ```
+/// Conversion: `mg/dL = raw × 1000 / calibrationFactor`.
+/// Confirmed across two distinct calibrations (factor 8932 and 10333) against EasyPatch ground truth.
+@objcMembers
+class CGMMedtrumTouchCareNanoTransmitter: BluetoothTransmitter, CGMTransmitter {
+
+    // MARK: - properties
+
+    /// Medtrum custom service exposed by the patch pump
+    private let CBUUID_Service_MedtrumNano = "669A9001-0008-968F-E311-6050405558B3"
+
+    /// notification characteristic that carries CGM glucose packets
+    private let CBUUID_ReceiveCharacteristic_MedtrumNano = "669A9141-0008-968F-E311-6050405558B3"
+
+    /// we never write — base class requires a write UUID, supply the same UUID as receive (it's harmless because we never call writeDataToPeripheral)
+    private let CBUUID_WriteCharacteristic_MedtrumNano = "669A9141-0008-968F-E311-6050405558B3"
+
+    /// expected name pattern; Medtrum pumps advertise as "MT"
+    private let expectedDeviceNameMedtrum = "MT"
+
+    /// pump (= MD0201 etc) sensor system lifetime is 14 days
+    private let sensorLifeDays: Double = 14
+
+    /// CGM delegate (xDrip pipeline)
+    private(set) weak var cgmTransmitterDelegate: CGMTransmitterDelegate?
+
+    /// transmitter-specific delegate (settings UI)
+    public weak var cGMMedtrumTouchCareNanoTransmitterDelegate: CGMMedtrumTouchCareNanoTransmitterDelegate?
+
+    /// last reading counter we have already emitted — used to skip duplicates within one app run
+    private var lastEmittedCounter: Int = -1
+
+    private let log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryCGMMedtrumTouchCareNano)
+
+    // MARK: - Initialization
+
+    init(address: String?, name: String?, bluetoothTransmitterDelegate: BluetoothTransmitterDelegate, cGMMedtrumTouchCareNanoTransmitterDelegate: CGMMedtrumTouchCareNanoTransmitterDelegate, cGMTransmitterDelegate: CGMTransmitterDelegate) {
+
+        var newAddressAndName: BluetoothTransmitter.DeviceAddressAndName = .notYetConnected(expectedName: expectedDeviceNameMedtrum)
+        if let address = address {
+            newAddressAndName = .alreadyConnectedBefore(address: address, name: name)
+        }
+
+        self.cgmTransmitterDelegate = cGMTransmitterDelegate
+        self.cGMMedtrumTouchCareNanoTransmitterDelegate = cGMMedtrumTouchCareNanoTransmitterDelegate
+
+        super.init(addressAndName: newAddressAndName, CBUUID_Advertisement: nil, servicesCBUUIDs: [CBUUID(string: CBUUID_Service_MedtrumNano)], CBUUID_ReceiveCharacteristic: CBUUID_ReceiveCharacteristic_MedtrumNano, CBUUID_WriteCharacteristic: CBUUID_WriteCharacteristic_MedtrumNano, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
+    }
+
+    // MARK: - overrides
+
+    override func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        super.centralManagerDidUpdateState(central)
+
+        // Patch pump never advertises while EasyPatch holds the connection. Hunt for it in the
+        // system-connected list (works through bonded service multiplexing).
+        if central.state == .poweredOn, getConnectionStatus() != .connected {
+            _ = retrieveConnectedPeripheral(withServiceUUIDs: [CBUUID(string: CBUUID_Service_MedtrumNano)])
+        }
+    }
+
+    override func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        super.peripheral(peripheral, didUpdateValueFor: characteristic, error: error)
+
+        guard let value = characteristic.value else { return }
+        guard characteristic.uuid == CBUUID(string: CBUUID_ReceiveCharacteristic_MedtrumNano) else { return }
+
+        processGlucosePacket(value)
+    }
+
+    // MARK: - packet decoding
+
+    private func processGlucosePacket(_ data: Data) {
+        // CGM notifications are 20 bytes. Ignore other shapes that may appear on this characteristic.
+        guard data.count >= 20 else {
+            trace("packet too short (len=%{public}d), ignoring", log: log, category: ConstantsLog.categoryCGMMedtrumTouchCareNano, type: .debug, data.count)
+            return
+        }
+        // Single fingerprint byte: byte 1 (0x02) is the packet-type marker that distinguishes CGM
+        // glucose packets from any other 20-byte message on this characteristic. All other bytes
+        // are either status flags whose bit layout we have not fully mapped, or session/calibration
+        // values that may legitimately change (e.g. between sensors). The 40–400 mg/dL plausibility
+        // gate below provides defence-in-depth against any false-positive that slips through.
+        guard data[1] == 0x02 else {
+            trace("packet header does not match expected CGM marker, ignoring (hex=%{public}@)", log: log, category: ConstantsLog.categoryCGMMedtrumTouchCareNano, type: .debug, data.hexEncodedString())
+            return
+        }
+
+        let counter = Int(uint16LE(data, offset: 4))
+        let rawCurrent = uint16LE(data, offset: 8)
+        let calibrationFactor = uint16LE(data, offset: 18)
+
+        // Calibration factor is required to interpret the raw value; rare safety guard against div-by-zero / corruption.
+        guard calibrationFactor > 0 else {
+            trace("invalid calibration factor (0) in packet, ignoring (hex=%{public}@)", log: log, category: ConstantsLog.categoryCGMMedtrumTouchCareNano, type: .error, data.hexEncodedString())
+            return
+        }
+
+        let mgDl = Double(rawCurrent) * 1000.0 / Double(calibrationFactor)
+
+        // Plausibility guard — values outside a CGM-meaningful range get dropped (alarms must never fire on garbage).
+        guard mgDl >= 40, mgDl <= 400 else {
+            trace("rejected implausible glucose=%{public}.1f mg/dL (raw=%{public}d, calFactor=%{public}d, counter=%{public}d)", log: log, category: ConstantsLog.categoryCGMMedtrumTouchCareNano, type: .error, mgDl, Int(rawCurrent), Int(calibrationFactor), counter)
+            return
+        }
+
+        // Skip duplicate emissions of the same CGM cycle.
+        if counter == lastEmittedCounter {
+            return
+        }
+        lastEmittedCounter = counter
+
+        let sensorAge = TimeInterval(counter * 2 * 60) // counter ticks every 2 min since sensor start
+        trace("decoded glucose: %{public}.1f mg/dL (raw=%{public}d, calFactor=%{public}d, counter=%{public}d, sensorAge=%{public}.0fs)", log: log, category: ConstantsLog.categoryCGMMedtrumTouchCareNano, type: .info, mgDl, Int(rawCurrent), Int(calibrationFactor), counter, sensorAge)
+
+        var readings = [GlucoseData(timeStamp: Date(), glucoseLevelRaw: mgDl)]
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.cgmTransmitterDelegate?.cgmTransmitterInfoReceived(glucoseData: &readings, transmitterBatteryInfo: nil, sensorAge: sensorAge)
+        }
+    }
+
+    private func uint16LE(_ data: Data, offset: Int) -> UInt16 {
+        let lo = UInt16(data[offset])
+        let hi = UInt16(data[offset + 1])
+        return (hi << 8) | lo
+    }
+
+    // MARK: - CGMTransmitter
+
+    func cgmTransmitterType() -> CGMTransmitterType {
+        return .medtrumTouchCareNano
+    }
+
+    func maxSensorAgeInDays() -> Double? {
+        return sensorLifeDays
+    }
+
+    func getCBUUID_Service() -> String { return CBUUID_Service_MedtrumNano }
+
+    func getCBUUID_Receive() -> String { return CBUUID_ReceiveCharacteristic_MedtrumNano }
+
+    // EasyPatch handles sensor lifecycle — we deliberately implement these as no-ops.
+    func needsSensorStartTime() -> Bool { return false }
+
+    // Glucose values delivered to xDrip are already in mg/dL after applying the Medtrum per-sensor
+    // calibration factor decoded from the packet. Returning true here tells xDrip "treat these as
+    // calibrated readings"; it skips the user-calibration prompt and uses NoCalibrator (matches the
+    // RootViewController.getCalibrator switch).
+    func isWebOOPEnabled() -> Bool { return true }
+
+    func nonWebOOPAllowed() -> Bool { return false }
+}

--- a/xDrip/BluetoothTransmitter/CGM/Medtrum/TouchCareNano/CGMMedtrumTouchCareNanoTransmitterDelegate.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Medtrum/TouchCareNano/CGMMedtrumTouchCareNanoTransmitterDelegate.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Callbacks specific to the Medtrum TouchCare Nano transmitter, used by the settings UI
+/// (and BluetoothPeripheralManager) to surface device metadata as it's discovered.
+protocol CGMMedtrumTouchCareNanoTransmitterDelegate: AnyObject {
+
+    /// firmware string, if it becomes available
+    func received(firmware: String, from cGMMedtrumTouchCareNanoTransmitter: CGMMedtrumTouchCareNanoTransmitter)
+
+}

--- a/xDrip/BluetoothTransmitter/Generic/BluetoothTransmitter.swift
+++ b/xDrip/BluetoothTransmitter/Generic/BluetoothTransmitter.swift
@@ -468,6 +468,32 @@ class BluetoothTransmitter: NSObject, CBCentralManagerDelegate, CBPeripheralDele
         
     }
     
+    /// Find a peripheral already connected to the iOS Bluetooth stack (possibly by another app),
+    /// matching at least one of the given service UUIDs, and connect to it without scanning.
+    ///
+    /// Used to piggy-back on a third-party app's authenticated BLE session (e.g. Medtrum EasyPatch).
+    /// iOS multiplexes a single ACL link between apps, so notifications fan out to us once subscribed.
+    ///
+    /// - returns: true if a matching peripheral was found and connection was initiated.
+    func retrieveConnectedPeripheral(withServiceUUIDs serviceUUIDs: [CBUUID]) -> Bool {
+        return runOnCentralQueueSync {
+            guard let central = centralManager else { return false }
+            let peripherals = central.retrieveConnectedPeripherals(withServices: serviceUUIDs)
+            guard !peripherals.isEmpty else {
+                trace("in retrieveConnectedPeripheral, no system-connected peripherals match given services", log: log, category: ConstantsLog.categoryBlueToothTransmitter, type: .info)
+                return false
+            }
+            // Prefer one matching expectedName if set; otherwise take the first.
+            let candidate: CBPeripheral = peripherals.first(where: { p in
+                guard let expected = expectedName, let n = p.name else { return false }
+                return n.range(of: expected, options: .caseInsensitive) != nil
+            }) ?? peripherals[0]
+            trace("in retrieveConnectedPeripheral, connecting to system-connected peripheral name=%{public}@ id=%{public}@", log: log, category: ConstantsLog.categoryBlueToothTransmitter, type: .info, candidate.name ?? "<unnamed>", candidate.identifier.uuidString)
+            stopScanAndconnect(to: candidate)
+            return true
+        }
+    }
+
     /// try to connect to peripheral to which connection was successfully done previously, and that has a uuid that matches the stored deviceAddress. If such peripheral exists, then try to connect, it's not necessary to start scanning. iOS will connect as soon as the peripheral comes in range, or bluetooth status is switched on, whatever is necessary
     ///
     /// the result of the attempt to try to find such device, is returned

--- a/xDrip/Constants/ConstantsLog.swift
+++ b/xDrip/Constants/ConstantsLog.swift
@@ -94,6 +94,9 @@ enum ConstantsLog {
     /// medtrum easyview follow
     static let categoryMedtrumEasyViewFollowManager =       "MedtrumEasyViewFollowManager  "
 
+    /// medtrum touchcare nano cgm (BLE co-listener)
+    static let categoryCGMMedtrumTouchCareNano =            "CGMMedtrumTouchCareNano       "
+
     /// alertmanager
     static let categoryAlertManager =                       "AlertManager                  "
     

--- a/xDrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
+++ b/xDrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
@@ -58,6 +58,9 @@ extension BLEPeripheral {
     
     // a BLEPeripheral should only have one of dexcomG5, m5Stack, ...
     @NSManaged public var dexcomG7: DexcomG7?
+
+    // a BLEPeripheral should only have one of dexcomG5, m5Stack, ...
+    @NSManaged public var medtrumTouchCareNano: MedtrumTouchCareNano?
     
     /// sensorSerialNumber of last sensor that was read
     @NSManaged public var sensorSerialNumber: String?

--- a/xDrip/Core Data/classes/MedtrumTouchCareNano+CoreDataClass.swift
+++ b/xDrip/Core Data/classes/MedtrumTouchCareNano+CoreDataClass.swift
@@ -1,0 +1,23 @@
+import Foundation
+import CoreData
+
+public class MedtrumTouchCareNano: NSManagedObject {
+
+    /// last decoded reading counter from the pump's 669A9141 packet — used to drop duplicates across reconnects
+    public var lastReadingCounter: Int = -1
+
+    init(address: String, name: String, alias: String?, nsManagedObjectContext: NSManagedObjectContext) {
+
+        let entity = NSEntityDescription.entity(forEntityName: "MedtrumTouchCareNano", in: nsManagedObjectContext)!
+
+        super.init(entity: entity, insertInto: nsManagedObjectContext)
+
+        blePeripheral = BLEPeripheral(address: address, name: name, alias: alias, bluetoothPeripheralType: .MedtrumTouchCareNanoType, nsManagedObjectContext: nsManagedObjectContext)
+
+    }
+
+    private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
+
+}

--- a/xDrip/Core Data/classes/MedtrumTouchCareNano+CoreDataProperties.swift
+++ b/xDrip/Core Data/classes/MedtrumTouchCareNano+CoreDataProperties.swift
@@ -1,0 +1,16 @@
+import Foundation
+import CoreData
+
+extension MedtrumTouchCareNano {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<MedtrumTouchCareNano> {
+        return NSFetchRequest<MedtrumTouchCareNano>(entityName: "MedtrumTouchCareNano")
+    }
+
+    /// blePeripheral is required to conform to protocol BluetoothPeripheral
+    @NSManaged public var blePeripheral: BLEPeripheral
+
+    /// firmware version, if discovered
+    @NSManaged public var firmware: String?
+
+}

--- a/xDrip/Core Data/xdrip.xcdatamodeld/xdrip v16.xcdatamodel/contents
+++ b/xDrip/Core Data/xdrip.xcdatamodeld/xdrip v16.xcdatamodel/contents
@@ -55,6 +55,7 @@
         <relationship name="libre2" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Libre2" inverseName="blePeripheral" inverseEntity="Libre2"/>
         <relationship name="libre2heartbeat" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Libre2HeartBeat" inverseName="blePeripheral" inverseEntity="Libre2HeartBeat"/>
         <relationship name="m5Stack" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="M5Stack" inverseName="blePeripheral" inverseEntity="M5Stack"/>
+        <relationship name="medtrumTouchCareNano" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="MedtrumTouchCareNano" inverseName="blePeripheral" inverseEntity="MedtrumTouchCareNano"/>
         <relationship name="miaoMiao" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="MiaoMiao" inverseName="blePeripheral" inverseEntity="MiaoMiao"/>
         <relationship name="omniPodHeartBeat" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OmniPodHeartBeat" inverseName="blePeripheral" inverseEntity="OmniPodHeartBeat"/>
     </entity>
@@ -122,6 +123,10 @@
         <attribute name="rotation" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="textcolor" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="blePeripheral" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="m5Stack" inverseEntity="BLEPeripheral"/>
+    </entity>
+    <entity name="MedtrumTouchCareNano" representedClassName=".MedtrumTouchCareNano" syncable="YES">
+        <attribute name="firmware" optional="YES" attributeType="String"/>
+        <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="medtrumTouchCareNano" inverseEntity="BLEPeripheral"/>
     </entity>
     <entity name="MiaoMiao" representedClassName=".MiaoMiao" syncable="YES">
         <attribute name="firmware" optional="YES" attributeType="String"/>

--- a/xDrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager+CGMMedtrumTouchCareNanoTransmitterDelegate.swift
+++ b/xDrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager+CGMMedtrumTouchCareNanoTransmitterDelegate.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension BluetoothPeripheralManager: CGMMedtrumTouchCareNanoTransmitterDelegate {
+
+    func received(firmware: String, from cGMMedtrumTouchCareNanoTransmitter: CGMMedtrumTouchCareNanoTransmitter) {
+        guard let medtrumNano = findTransmitter(cGMMedtrumTouchCareNanoTransmitter: cGMMedtrumTouchCareNanoTransmitter) else { return }
+        medtrumNano.firmware = firmware
+        coreDataManager.saveChanges()
+    }
+
+    private func findTransmitter(cGMMedtrumTouchCareNanoTransmitter: CGMMedtrumTouchCareNanoTransmitter) -> MedtrumTouchCareNano? {
+        guard let index = bluetoothTransmitters.firstIndex(of: cGMMedtrumTouchCareNanoTransmitter),
+              let medtrumNano = bluetoothPeripherals[index] as? MedtrumTouchCareNano else { return nil }
+        return medtrumNano
+    }
+}

--- a/xDrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
+++ b/xDrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
@@ -163,10 +163,10 @@ class BluetoothPeripheralManager: NSObject {
                         _ = m5StackBluetoothTransmitter.writeBgReadingInfo(bgReading: bgReadingToSend[0])
                     }
                     
-                case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .DexcomG7Type:
+                case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .DexcomG7Type, .MedtrumTouchCareNanoType:
                     // cgm's don't receive reading, they send it
                     break
-                    
+
                 case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
                     // heartbeat transmitters are just there to wake up the app
                     break
@@ -340,11 +340,26 @@ class BluetoothPeripheralManager: NSObject {
 
                     }
 
+                case .MedtrumTouchCareNanoType:
+
+                    if let medtrumNano = bluetoothPeripheral as? MedtrumTouchCareNano {
+
+                        if let cgmTransmitterDelegate = cgmTransmitterDelegate {
+
+                            newTransmitter = CGMMedtrumTouchCareNanoTransmitter(address: medtrumNano.blePeripheral.address, name: medtrumNano.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMMedtrumTouchCareNanoTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate)
+
+                        } else {
+
+                            trace("in getBluetoothTransmitter, case MedtrumTouchCareNanoType but cgmTransmitterDelegate is nil, looks like a coding error ", log: log, category: ConstantsLog.categoryBluetoothPeripheralManager, type: .error)
+
+                        }
+                    }
+
                 }
-                
-                
+
+
                 bluetoothTransmitters[index] = newTransmitter
-                
+
                 return newTransmitter
                 
             }
@@ -407,9 +422,14 @@ class BluetoothPeripheralManager: NSObject {
                 if bluetoothTransmitter is CGMG7Transmitter {
                     return .DexcomG7Type
                 }
-                
+
+            case .MedtrumTouchCareNanoType:
+                if bluetoothTransmitter is CGMMedtrumTouchCareNanoTransmitter {
+                    return .MedtrumTouchCareNanoType
+                }
+
             }
-            
+
         }
         
         // normally we shouldn't get here, but we need to return a value
@@ -481,15 +501,23 @@ class BluetoothPeripheralManager: NSObject {
             return OmniPodHeartBeatTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate ?? self)
 
         case .DexcomG7Type:
-            
+
             guard let cgmTransmitterDelegate = cgmTransmitterDelegate else {
                 fatalError("in createNewTransmitter, DexcomG7Type, cgmTransmitterDelegate is nil")
             }
-            
+
             return CGMG7Transmitter(address: nil, name: nil, transmitterID: transmitterId, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate ?? self, cGMG7TransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate)
-            
+
+        case .MedtrumTouchCareNanoType:
+
+            guard let cgmTransmitterDelegate = cgmTransmitterDelegate else {
+                fatalError("in createNewTransmitter, MedtrumTouchCareNanoType, cgmTransmitterDelegate is nil")
+            }
+
+            return CGMMedtrumTouchCareNanoTransmitter(address: nil, name: nil, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate ?? self, cGMMedtrumTouchCareNanoTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate)
+
         }
-        
+
     }
 
     public func firstIndexInBluetoothPeripherals(bluetoothPeripheral: BluetoothPeripheral) -> Int? {
@@ -916,18 +944,42 @@ class BluetoothPeripheralManager: NSObject {
                             }
 
                         } else {
-                            
+
                             // bluetoothTransmitters array (which shoul dhave the same number of elements as bluetoothPeripherals) needs to have an empty row for the transmitter
                             bluetoothTransmitters.insert(nil, at: index)
-                            
+
                         }
-                        
+
                     }
-                    
+
+                case .MedtrumTouchCareNanoType:
+
+                    if let medtrumNano = blePeripheral.medtrumTouchCareNano {
+
+                        blePeripheralFound = true
+
+                        let index = insertInBluetoothPeripherals(bluetoothPeripheral: medtrumNano)
+
+                        if medtrumNano.blePeripheral.shouldconnect {
+
+                            bluetoothTransmitters.insert(CGMMedtrumTouchCareNanoTransmitter(address: medtrumNano.blePeripheral.address, name: medtrumNano.blePeripheral.name, bluetoothTransmitterDelegate: self, cGMMedtrumTouchCareNanoTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate), at: index)
+
+                            if bluetoothPeripheralType.category() == .CGM {
+                                currentCgmTransmitterAddress = blePeripheral.address
+                            }
+
+                        } else {
+
+                            bluetoothTransmitters.insert(nil, at: index)
+
+                        }
+
+                    }
+
                 }
 
             }
-            
+
             if !blePeripheralFound {
                 
                 // this is a corruption in the database. blePeripheral was stored witout one of the types being assigned
@@ -1067,7 +1119,7 @@ class BluetoothPeripheralManager: NSObject {
                     bluetoothPeripheral.blePeripheral.parameterUpdateNeededAtNextConnect = true
                 }
              
-            case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType, .DexcomG7Type:
+            case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType, .DexcomG7Type, .MedtrumTouchCareNanoType:
 
                 // nothing to check
                 break

--- a/xDrip/Utilities/Trace.swift
+++ b/xDrip/Utilities/Trace.swift
@@ -640,12 +640,21 @@ class Trace {
 
                     case .DexcomG7Type:
                         if blePeripheral.dexcomG7 != nil {
-                            
+
                             traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
-                            
+
                             traceInfo.appendStringAndNewLine("        15-day G7: " + (blePeripheral.name.startsWith("DXCM") ? UserDefaults.standard.is15DayDexcomG7.description : "n/a (not a G7)"))
                         }
-                        
+
+                    case .MedtrumTouchCareNanoType:
+                        if let medtrumNano = blePeripheral.medtrumTouchCareNano {
+
+                            traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
+                            if let firmware = medtrumNano.firmware {
+                                traceInfo.appendStringAndNewLine("        Firmware: " + firmware)
+                            }
+                        }
+
                     }
                 }
                 

--- a/xDrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Medtrum/TouchCareNano/MedtrumTouchCareNanoBluetoothPeripheralViewModel.swift
+++ b/xDrip/View Controllers/BluetoothPeripheralsNavigationController/BluetoothPeripheralsViewController/BluetoothPeripheralViewController/Models/CGM/Medtrum/TouchCareNano/MedtrumTouchCareNanoBluetoothPeripheralViewModel.swift
@@ -1,0 +1,117 @@
+import UIKit
+
+class MedtrumTouchCareNanoBluetoothPeripheralViewModel {
+
+    private enum Settings: Int, CaseIterable {
+        case dependencyHint = 0
+        case firmware = 1
+    }
+
+    private let sectionNumberForMedtrumSpecificSettings = 0
+
+    private weak var bluetoothPeripheralManager: BluetoothPeripheralManaging?
+
+    private weak var tableView: UITableView?
+
+    private weak var bluetoothPeripheralViewController: BluetoothPeripheralViewController?
+
+    private var bluetoothPeripheral: BluetoothPeripheral?
+
+    private var medtrumNano: MedtrumTouchCareNano? {
+        return bluetoothPeripheral as? MedtrumTouchCareNano
+    }
+
+    deinit {
+        guard let bluetoothPeripheralManager = bluetoothPeripheralManager,
+              let medtrumNano = medtrumNano,
+              let transmitter = bluetoothPeripheralManager.getBluetoothTransmitter(for: medtrumNano, createANewOneIfNecesssary: false),
+              let medtrumTransmitter = transmitter as? CGMMedtrumTouchCareNanoTransmitter else { return }
+        medtrumTransmitter.cGMMedtrumTouchCareNanoTransmitterDelegate = bluetoothPeripheralManager as? CGMMedtrumTouchCareNanoTransmitterDelegate
+    }
+}
+
+extension MedtrumTouchCareNanoBluetoothPeripheralViewModel: BluetoothPeripheralViewModel {
+
+    func configure(bluetoothPeripheral: BluetoothPeripheral?, bluetoothPeripheralManager: BluetoothPeripheralManaging, tableView: UITableView, bluetoothPeripheralViewController: BluetoothPeripheralViewController) {
+        self.bluetoothPeripheralManager = bluetoothPeripheralManager
+        self.tableView = tableView
+        self.bluetoothPeripheralViewController = bluetoothPeripheralViewController
+        self.bluetoothPeripheral = bluetoothPeripheral
+
+        if let bluetoothPeripheral = bluetoothPeripheral {
+            if let medtrumNano = bluetoothPeripheral as? MedtrumTouchCareNano,
+               let transmitter = bluetoothPeripheralManager.getBluetoothTransmitter(for: medtrumNano, createANewOneIfNecesssary: false),
+               let medtrumTransmitter = transmitter as? CGMMedtrumTouchCareNanoTransmitter {
+                medtrumTransmitter.cGMMedtrumTouchCareNanoTransmitterDelegate = self
+            }
+        }
+    }
+
+    func screenTitle() -> String {
+        return BluetoothPeripheralType.MedtrumTouchCareNanoType.rawValue
+    }
+
+    func sectionTitle(forSection section: Int) -> String {
+        return BluetoothPeripheralType.MedtrumTouchCareNanoType.rawValue
+    }
+
+    func update(cell: UITableViewCell, forRow rawValue: Int, forSection section: Int, for bluetoothPeripheral: BluetoothPeripheral) {
+        guard let medtrumNano = bluetoothPeripheral as? MedtrumTouchCareNano else {
+            fatalError("MedtrumTouchCareNanoBluetoothPeripheralViewModel.update: peripheral is not MedtrumTouchCareNano")
+        }
+        cell.accessoryView = nil
+        guard let setting = Settings(rawValue: rawValue) else {
+            fatalError("MedtrumTouchCareNanoBluetoothPeripheralViewModel.update: unexpected row \(rawValue)")
+        }
+
+        switch setting {
+        case .dependencyHint:
+            cell.textLabel?.text = "Requires Medtrum EasyPatch"
+            cell.detailTextLabel?.text = "EasyPatch must be installed and running for sensor data."
+            cell.accessoryType = .none
+        case .firmware:
+            cell.textLabel?.text = Texts_Common.firmware
+            cell.detailTextLabel?.text = medtrumNano.firmware
+            cell.accessoryType = .none
+        }
+    }
+
+    func userDidSelectRow(withSettingRawValue rawValue: Int, forSection section: Int, for bluetoothPeripheral: BluetoothPeripheral, bluetoothPeripheralManager: BluetoothPeripheralManaging) -> SettingsSelectedRowAction {
+        return .nothing
+    }
+
+    func numberOfSettings(inSection section: Int) -> Int {
+        return Settings.allCases.count
+    }
+
+    func numberOfSections() -> Int {
+        return 1
+    }
+}
+
+extension MedtrumTouchCareNanoBluetoothPeripheralViewModel: CGMMedtrumTouchCareNanoTransmitterDelegate {
+
+    func received(firmware: String, from cGMMedtrumTouchCareNanoTransmitter: CGMMedtrumTouchCareNanoTransmitter) {
+        (bluetoothPeripheralManager as? CGMMedtrumTouchCareNanoTransmitterDelegate)?.received(firmware: firmware, from: cGMMedtrumTouchCareNanoTransmitter)
+        reloadRow(row: Settings.firmware.rawValue)
+    }
+
+    private func reloadRow(row: Int) {
+        DispatchQueue.main.async {
+            guard let tableView = self.tableView,
+                  let viewController = self.bluetoothPeripheralViewController else { return }
+            tableView.reloadSections(IndexSet(integer: 0), with: .none)
+            let totalSections = tableView.numberOfSections
+            let section = viewController.numberOfGeneralSections() + self.sectionNumberForMedtrumSpecificSettings
+            guard section < totalSections else {
+                tableView.reloadData()
+                return
+            }
+            if row < tableView.numberOfRows(inSection: section) {
+                tableView.reloadRows(at: [IndexPath(row: row, section: section)], with: .none)
+            } else {
+                tableView.reloadSections(IndexSet(integer: section), with: .none)
+            }
+        }
+    }
+}

--- a/xDrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xDrip/View Controllers/Root View Controller/RootViewController.swift
@@ -1965,6 +1965,10 @@ final class RootViewController: UIViewController, ObservableObject {
                 // no oop web, fixed slope
                 calibrator = Libre1Calibrator()
             }
+
+        case .medtrumTouchCareNano:
+            // values are already in mg/dL after raw/9+1 conversion in the transmitter
+            calibrator = NoCalibrator()
         }
         
         trace("in getCalibrator, calibrator = %{public}@", log: log, category: ConstantsLog.categoryRootView, type: .info, calibrator.description())

--- a/xDrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xDrip/View Controllers/Root View Controller/RootViewController.swift
@@ -1967,7 +1967,8 @@ final class RootViewController: UIViewController, ObservableObject {
             }
 
         case .medtrumTouchCareNano:
-            // values are already in mg/dL after raw/9+1 conversion in the transmitter
+            // Values arrive already calibrated to mg/dL — the transmitter applies the Medtrum per-sensor
+            // calibration factor decoded from each packet, so xDrip should not run its own calibrator.
             calibrator = NoCalibrator()
         }
         

--- a/xdrip.xcodeproj/project.pbxproj
+++ b/xdrip.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -229,6 +229,9 @@
 		47F7B1C62C68BBE100609DA7 /* ConstantsCalibrationAlgorithms.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A1585422EDB706007F5B5D /* ConstantsCalibrationAlgorithms.swift */; };
 		47F7B1CD2C68CC3000609DA7 /* ConstantsCalibrationAlgorithms.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A1585422EDB706007F5B5D /* ConstantsCalibrationAlgorithms.swift */; };
 		47FB28082636B04200042FFB /* StatisticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FB28072636B04200042FFB /* StatisticsManager.swift */; };
+		555D7AA02FBBD04000CA8D68 /* MedtrumTouchCareNano+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555D7A9F2FBBD04000CA8D68 /* MedtrumTouchCareNano+CoreDataProperties.swift */; };
+		555D7AA12FBBD04000CA8D68 /* MedtrumTouchCareNano+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555D7A9E2FBBD04000CA8D68 /* MedtrumTouchCareNano+CoreDataClass.swift */; };
+		555D7AB12FBBD1D200CA8D68 /* BluetoothPeripheralManager+CGMMedtrumTouchCareNanoTransmitterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555D7AB02FBBD1D200CA8D68 /* BluetoothPeripheralManager+CGMMedtrumTouchCareNanoTransmitterDelegate.swift */; };
 		CE1B2FE025D0264B00F642F5 /* LaunchScreen.strings in Resources */ = {isa = PBXBuildFile; fileRef = CE1B2FD125D0264900F642F5 /* LaunchScreen.strings */; };
 		CE1B2FE125D0264B00F642F5 /* Main.strings in Resources */ = {isa = PBXBuildFile; fileRef = CE1B2FD425D0264900F642F5 /* Main.strings */; };
 		D400F8032778BD8000B57648 /* TextsTreatmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D400F8022778BD8000B57648 /* TextsTreatmentsView.swift */; };
@@ -1017,6 +1020,9 @@
 		47F4E09B2E699D6500087889 /* DexcomShareFollowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DexcomShareFollowManager.swift; sourceTree = "<group>"; };
 		47F4E09D2E69C59A00087889 /* DexcomShareModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DexcomShareModels.swift; sourceTree = "<group>"; };
 		47FB28072636B04200042FFB /* StatisticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsManager.swift; sourceTree = "<group>"; };
+		555D7A9E2FBBD04000CA8D68 /* MedtrumTouchCareNano+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MedtrumTouchCareNano+CoreDataClass.swift"; sourceTree = "<group>"; };
+		555D7A9F2FBBD04000CA8D68 /* MedtrumTouchCareNano+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MedtrumTouchCareNano+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		555D7AB02FBBD1D200CA8D68 /* BluetoothPeripheralManager+CGMMedtrumTouchCareNanoTransmitterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BluetoothPeripheralManager+CGMMedtrumTouchCareNanoTransmitterDelegate.swift"; sourceTree = "<group>"; };
 		666E283826F7E54C00ACE4DF /* xDrip.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = xDrip.xcconfig; path = xDrip/xDrip.xcconfig; sourceTree = "<group>"; };
 		666E283926F7E54C00ACE4DF /* Version.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Version.xcconfig; path = xDrip/Version.xcconfig; sourceTree = "<group>"; };
 		CE1B2FC825D0261500F642F5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Alerts.strings; sourceTree = "<group>"; };
@@ -1788,6 +1794,12 @@
 		F8FDFEA8260DE1A70047597D /* DTCustomColoredAccessory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DTCustomColoredAccessory.m; sourceTree = "<group>"; };
 		F8FDFEAC260DE1B90047597D /* ConstantsUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstantsUI.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		555D7AA52FBBD10F00CA8D68 /* Medtrum */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Medtrum; sourceTree = "<group>"; };
+		555D7AAA2FBBD12C00CA8D68 /* Medtrum */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Medtrum; sourceTree = "<group>"; };
+		555D7AAE2FBBD15D00CA8D68 /* Medtrum */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Medtrum; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		4716A4EA2B406C3D00419052 /* Frameworks */ = {
@@ -2589,6 +2601,7 @@
 				F8A2BC1E25DB0D6D001D1E78 /* BluetoothPeripheralManager+CGMG5TransmitterDelegate.swift */,
 				F8F71D822B7EACC9005076E8 /* BluetoothPeripheralManager+CGMG7TransmitterDelegate.swift */,
 				F8A2BC2A25DB0D6D001D1E78 /* BluetoothPeripheralManager+CGMLibre2TransmitterDelegate.swift */,
+				555D7AB02FBBD1D200CA8D68 /* BluetoothPeripheralManager+CGMMedtrumTouchCareNanoTransmitterDelegate.swift */,
 				F8A2BC2825DB0D6D001D1E78 /* BluetoothPeripheralManager+CGMMiaoMiaoTransmitterDelegate.swift */,
 				F8A2BC2225DB0D6D001D1E78 /* BluetoothPeripheralManager+M5StackBluetoothTransmitterDelegate.swift */,
 				F8A2BC2325DB0D6D001D1E78 /* BluetoothPeripheralManaging.swift */,
@@ -3039,6 +3052,7 @@
 			children = (
 				F8DF766A23ED9AF100063910 /* Dexcom */,
 				F808D2C3240323750084B5DB /* Libre */,
+				555D7AAE2FBBD15D00CA8D68 /* Medtrum */,
 			);
 			path = CGM;
 			sourceTree = "<group>";
@@ -3183,6 +3197,8 @@
 				F85FF3CC252F9FD7004E6FF1 /* SnoozeParameters+CoreDataProperties.swift */,
 				D40C3DA3277542C400111B73 /* TreatmentEntry+CoreDataClass.swift */,
 				D40C3DA52775438F00111B73 /* TreatmentEntry+CoreDataProperties.swift */,
+				555D7A9E2FBBD04000CA8D68 /* MedtrumTouchCareNano+CoreDataClass.swift */,
+				555D7A9F2FBBD04000CA8D68 /* MedtrumTouchCareNano+CoreDataProperties.swift */,
 			);
 			path = classes;
 			sourceTree = "<group>";
@@ -3327,6 +3343,7 @@
 			children = (
 				F8DF765923E350B100063910 /* Dexcom */,
 				F808D2CF240329D40084B5DB /* Libre */,
+				555D7AAA2FBBD12C00CA8D68 /* Medtrum */,
 			);
 			path = CGM;
 			sourceTree = "<group>";
@@ -3383,6 +3400,7 @@
 				F8F971BB23A5915900C3F17D /* Dexcom */,
 				F8F971F023A5915900C3F17D /* Generic */,
 				F8F971D623A5915900C3F17D /* Libre */,
+				555D7AA52FBBD10F00CA8D68 /* Medtrum */,
 			);
 			path = CGM;
 			sourceTree = "<group>";
@@ -3638,6 +3656,11 @@
 				4716A4FD2B406C3F00419052 /* PBXTargetDependency */,
 				47DE41B12B864EE50041DA19 /* PBXTargetDependency */,
 				47CD641F2BE9506C002BDA68 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				555D7AA52FBBD10F00CA8D68 /* Medtrum */,
+				555D7AAA2FBBD12C00CA8D68 /* Medtrum */,
+				555D7AAE2FBBD15D00CA8D68 /* Medtrum */,
 			);
 			name = xdrip;
 			packageProductDependencies = (
@@ -4212,6 +4235,8 @@
 				F821CF61229BF4A2005C1E43 /* NightscoutSyncManager.swift in Sources */,
 				F8F9721023A5915900C3F17D /* TransmitterVersionRxMessage.swift in Sources */,
 				F8A1587122EDC865007F5B5D /* ConstantsSpeakReadingLanguages.swift in Sources */,
+				555D7AA02FBBD04000CA8D68 /* MedtrumTouchCareNano+CoreDataProperties.swift in Sources */,
+				555D7AA12FBBD04000CA8D68 /* MedtrumTouchCareNano+CoreDataClass.swift in Sources */,
 				F8A1585522EDB706007F5B5D /* ConstantsCalibrationAlgorithms.swift in Sources */,
 				4752B4062635878E0081D551 /* SettingsViewStatisticsSettingsViewModel.swift in Sources */,
 				F897AAF92200F2D200CDDD10 /* CBPeripheralState.swift in Sources */,
@@ -4256,6 +4281,7 @@
 				F8B3A830227F085A004BA588 /* SettingsTableViewCell.swift in Sources */,
 				476404892EA29034006CBE03 /* SceneDelegate.swift in Sources */,
 				F82436FC24BE014000BED341 /* TextsLibreStates.swift in Sources */,
+				555D7AB12FBBD1D200CA8D68 /* BluetoothPeripheralManager+CGMMedtrumTouchCareNanoTransmitterDelegate.swift in Sources */,
 				F8F71D7A2B7E9DFB005076E8 /* ConstantsDexcomG7.swift in Sources */,
 				47DB06C22A6FC02200267BE3 /* SettingsViewDataSourceSettingsViewModel.swift in Sources */,
 				F8F7B8EB259A7B1C00C47B04 /* SavitzkyGolaySmoothableArray.swift in Sources */,
@@ -5115,7 +5141,7 @@
 				CODE_SIGN_IDENTITY = "$(XDRIP_CODE_SIGN_IDENTITY_DEBUG)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = "$(XDRIP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = B752ANUKC3;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "xDrip Widget/Info.plist";
@@ -5151,7 +5177,7 @@
 				CODE_SIGN_IDENTITY = "$(XDRIP_CODE_SIGN_IDENTITY_RELEASE)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = "$(XDRIP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = B752ANUKC3;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "xDrip Widget/Info.plist";
@@ -5185,7 +5211,7 @@
 				CODE_SIGN_ENTITLEMENTS = "xDrip Watch Complication Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = "$(XDRIP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = B752ANUKC3;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "xDrip Watch Complication/Info.plist";
@@ -5222,7 +5248,7 @@
 				CODE_SIGN_ENTITLEMENTS = "xDrip Watch Complication Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = "$(XDRIP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = B752ANUKC3;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "xDrip Watch Complication/Info.plist";
@@ -5259,7 +5285,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DEVELOPMENT_ASSET_PATHS = "\"xDrip Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = "$(XDRIP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = B752ANUKC3;
 				ENABLE_PREVIEWS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -5299,7 +5325,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DEVELOPMENT_ASSET_PATHS = "\"xDrip Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = "$(XDRIP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = B752ANUKC3;
 				ENABLE_PREVIEWS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -5337,7 +5363,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = "$(XDRIP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = B752ANUKC3;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "xDrip Notification Context Extension/Info.plist";
@@ -5372,7 +5398,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = "$(XDRIP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = B752ANUKC3;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "xDrip Notification Context Extension/Info.plist";
@@ -5537,7 +5563,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = "$(XDRIP_CODE_SIGN_STYLE)";
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = "$(XDRIP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = B752ANUKC3;
 				INFOPLIST_FILE = "xdrip/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5566,7 +5592,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = "$(XDRIP_CODE_SIGN_STYLE)";
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = "$(XDRIP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = B752ANUKC3;
 				INFOPLIST_FILE = "xdrip/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
## Summary

Adds support for the **Medtrum TouchCare Nano CGM** as a first-class CGM source in xDrip, alongside Dexcom, Libre,
MiaoMiao, etc. The sensor's data is delivered over BLE without requiring an internet connection, by passively
co-listening on the BLE link the official **Medtrum EasyPatch** app already maintains with the patch pump.

This complements the existing `MedtrumEasyViewFollowManager` (cloud-based follower), removing the internet dependency.

## Why

The Medtrum TouchCare Nano CGM has no public BLE protocol spec and no existing OSS implementation for the current A8/Nano sensor family (xDrip+'s Medtrum support is for the older A6 only). Previously the only way to surface its readings in xDrip was the EasyView cloud follower, which depends on internet connectivity. Reverse-engineered the BLE protocol, decoded the glucose packet format, and wired it into xDrip's standard `CGMTransmitter` pipeline so alarms, charts, Nightscout upload, etc. all "just work."

## How it works

The transmitter relays CGM readings over BLE on service `669A9001-0008-968F-E311-6050405558B3`. EasyPatch handles authentication/bonding with the transmitter.

iOS's CoreBluetooth multiplexes a single ACL connection across multiple apps sharing the same bond. xDrip uses `retrieveConnectedPeripherals(withServices:)` to find the system-connected pump (works even while EasyPatch holds it), subscribes to the same notification characteristic, and parses the packets EasyPatch already triggers. **No
auth required on our side** — EasyPatch does that work; we just listen.

## Glucose packet format (reverse engineered)

Notifications arrive on characteristic `669A9141` every ~2 min (one per CGM cycle). 20-byte payload:

| Offset | Bytes | Meaning |
|---|---|---|
| 0 | 1 | status flags (varies; not parsed) |
| 1 | 1 | **packet type marker `0x02`** — used to identify CGM packets |
| 2 | 1 | status flag (varies) |
| 3 | 1 | status flag (varies) |
| 4–5 | 2 | LE uint16 — reading counter (+1 per 2-min cycle since sensor start) |
| 6–7 | 2 | session bytes |
| 8–9 | 2 | LE uint16 — **current glucose raw value** |
| 10–15 | 6 | LE uint16 × 3 — previous 3 readings (shift register) |
| 16–17 | 2 | small varying counter |
| 18–19 | 2 | LE uint16 — **per-sensor calibration factor** |

**Glucose conversion:** `mg/dL = raw × 1000 / calibrationFactor`

The calibration factor updates automatically when the user calibrates the sensor in EasyPatch, so xDrip's readings
stay in sync without any user action.

Verified against EasyPatch ground-truth at multiple calibration epochs (factor 8932 and 10333) and 9+ paired (counter, raw, mg/dL) samples, accurate to within rounding (±1 mg/dL — EasyPatch truncates, xDrip rounds).