### PR TITLE
#723 backfill frequent readings from nightscout

### DIFF
--- a/xDrip/Managers/Nightscout/NightscoutFollowManager.swift
+++ b/xDrip/Managers/Nightscout/NightscoutFollowManager.swift
@@ -169,8 +169,10 @@ class NightscoutFollowManager: NSObject {
             return
         }
         
-        // calculate count, which is a parameter in the nightscout API - divide by 300, we're assuming readings every 5 minutes = 300 seconds
-        let count = Int(-timeStampOfFirstBgReadingToDowload.timeIntervalSinceNow / 300 + 1)
+        // calculate count, which is a parameter in the nightscout API - use the same reading interval as uploads
+        let minimiumTimeBetweenTwoReadingsInMinutes = UserDefaults.standard.storeFrequentReadingsInNightscout ? ConstantsNightscout.minimiumTimeBetweenTwoReadingsInMinutesFrequentUploads : ConstantsNightscout.minimiumTimeBetweenTwoReadingsInMinutes
+        let secondsBetweenReadings = minimiumTimeBetweenTwoReadingsInMinutes * 60.0
+        let count = Int(-timeStampOfFirstBgReadingToDowload.timeIntervalSinceNow / secondsBetweenReadings + 1)
         
         // ceate endpoint to get latest entries
         let latestEntriesEndpoint = Endpoint.getEndpointForLatestNSEntries(hostAndScheme: nightscoutUrl, count: count, token: UserDefaults.standard.nightscoutToken)


### PR DESCRIPTION
This ensures we can fetch all missed readings from nightscout when it has per-minute readings from Freestyle Libre sensors.

Code previously assumed all nightscout instances store data for 5-minutely readings, but libre generates a reading every minute. We now use the `storeFrequentReadingsInNightscout` setting to affect downloads as well as uploads.