### PR TITLE
Add Syai / Ottai CGM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Master mode currently includes:
 - Dexcom G7, ONE+ and Stelo
 - Libre 2 and Libre 2 Plus EU sensors over direct Bluetooth
 - Compatible Libre sensors through MiaoMiao or Nano/Bubble/Bubble Mini transmitters
+- Syai and Ottai
 
 Follower mode supports:
 

--- a/xDrip Tests/OttaiStartupBackfillTests.swift
+++ b/xDrip Tests/OttaiStartupBackfillTests.swift
@@ -1,0 +1,77 @@
+//
+//  OttaiStartupBackfillTests.swift
+//  xdripTests
+//
+//  Covers what the Ottai/Syai driver asks the sensor for right after a start.
+//  Copyright © 2026 Johan Degraeve. All rights reserved.
+//
+
+import XCTest
+@testable import xdrip
+
+final class OttaiStartupBackfillTests: XCTestCase {
+
+    private let dayOfRecords = 24 * 60
+
+    func testNothingKnownAsksForTheLastDay() {
+        let range = CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 5000, lastDataNo: 0, deliveredDataNo: 0)
+        XCTAssertEqual(range?.start, 5000 - dayOfRecords)
+        XCTAssertEqual(range?.count, dayOfRecords)
+    }
+
+    func testUntrustedLastDataNoAlsoAsksForTheLastDay() {
+        let range = CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 5000, lastDataNo: -1, deliveredDataNo: 4990)
+        XCTAssertEqual(range?.start, 5000 - dayOfRecords)
+        XCTAssertEqual(range?.count, dayOfRecords)
+    }
+
+    func testYoungSensorStartsAtZero() {
+        let range = CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 30, lastDataNo: 0, deliveredDataNo: 0)
+        XCTAssertEqual(range?.start, 0)
+        XCTAssertEqual(range?.count, 30)
+    }
+
+    func testOnlyTheRecordsSinceTheLastSeenOneAreRequested() {
+        let range = CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 5000, lastDataNo: 4990, deliveredDataNo: 4990)
+        XCTAssertEqual(range?.start, 4991)
+        XCTAssertEqual(range?.count, 9)
+    }
+
+    func testDeliveredMarkBehindLastSeenWins() {
+        let range = CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 5000, lastDataNo: 4998, deliveredDataNo: 4980)
+        XCTAssertEqual(range?.start, 4981)
+        XCTAssertEqual(range?.count, 19)
+    }
+
+    func testMissingDeliveredMarkFallsBackToLastSeen() {
+        let range = CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 5000, lastDataNo: 4990, deliveredDataNo: 0)
+        XCTAssertEqual(range?.start, 4991)
+        XCTAssertEqual(range?.count, 9)
+    }
+
+    func testNothingMissingGivesNil() {
+        XCTAssertNil(CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 5000, lastDataNo: 4999, deliveredDataNo: 4999))
+        XCTAssertNil(CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 5000, lastDataNo: 4999, deliveredDataNo: 0))
+    }
+
+    func testLastSeenSlightlyAheadOfLiveGivesNil() {
+        XCTAssertNil(CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 5000, lastDataNo: 5003, deliveredDataNo: 5003))
+    }
+
+    func testLongAbsenceIsCappedToOneDay() {
+        let range = CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 9000, lastDataNo: 2000, deliveredDataNo: 2000)
+        XCTAssertEqual(range?.start, 9000 - dayOfRecords)
+        XCTAssertEqual(range?.count, dayOfRecords)
+    }
+
+    func testEndedSensorIncludesItsLastRecordWhenNeverDelivered() {
+        // The ended path passes lastDataNo + 1 as the end, so the last record itself is inside the range.
+        let range = CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 5001, lastDataNo: 4990, deliveredDataNo: 4990)
+        XCTAssertEqual(range?.start, 4991)
+        XCTAssertEqual(range?.count, 10)
+    }
+
+    func testNoLiveRecordGivesNil() {
+        XCTAssertNil(CGMOttaiTransmitter.startupBackfillRange(liveDataNo: 0, lastDataNo: 0, deliveredDataNo: 0))
+    }
+}

--- a/xDrip/BluetoothPeripheral/CGM/Ottai/Ottai+BluetoothPeripheral.swift
+++ b/xDrip/BluetoothPeripheral/CGM/Ottai/Ottai+BluetoothPeripheral.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension Ottai: BluetoothPeripheral {
+
+    func bluetoothPeripheralType() -> BluetoothPeripheralType {
+        return .OttaiType
+    }
+}

--- a/xDrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
+++ b/xDrip/BluetoothPeripheral/Generic/BluetoothPeripheralType.swift
@@ -21,7 +21,10 @@ enum BluetoothPeripheralType: String, CaseIterable {
     
     /// bubble
     case BubbleType = "Nano/Bubble/Bubble Mini"
-    
+
+    /// Ottai / Syai CGM
+    case OttaiType = "Ottai/Syai CGM"
+
     /// 2026-08-13: G5 remains supported for existing devices, but is no longer
     /// advertised as an option when adding a new Dexcom transmitter.
     case DexcomType = "Dexcom G6/ONE"
@@ -59,7 +62,10 @@ enum BluetoothPeripheralType: String, CaseIterable {
             
         case .BubbleType:
             return Bubble(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
-            
+
+        case .OttaiType:
+            return Ottai(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
+
         case .MiaoMiaoType:
             return MiaoMiao(address: address, name: name, alias: nil, nsManagedObjectContext: nsManagedObjectContext)
             
@@ -93,7 +99,7 @@ enum BluetoothPeripheralType: String, CaseIterable {
         case .M5StackType, .M5StickCType:
             return .M5Stack
             
-        case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .DexcomG7Type, .MedtrumTouchCareNanoType:
+        case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .DexcomG7Type, .OttaiType, .MedtrumTouchCareNanoType:
             return .CGM
 
         case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:

--- a/xDrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Generic/CGMTransmitter.swift
@@ -102,6 +102,9 @@ enum CGMTransmitterType:String, CaseIterable {
     /// Libre2
     case Libre2 = "Libre2"
 
+    /// Ottai / Syai
+    case ottai = "Ottai/Syai"
+
     /// Medtrum TouchCare Nano Pump with integrated CGM data relayed via the pump BLE session.
     /// Keep this raw value stable because it is persisted in UserDefaults.
     case medtrumTouchCareNano = "Medtrum Nano"
@@ -119,20 +122,21 @@ enum CGMTransmitterType:String, CaseIterable {
 
     /// what sensorType does this CGMTransmitter type support
     func sensorType() -> CGMSensorType {
-        
+
         switch self {
-            
+
         case .dexcom, .dexcomG7:
             return .Dexcom
-            
-        case .miaomiao, .Bubble, .Libre2:
+
+        case .miaomiao, .Bubble, .Libre2, .ottai:
+            // Ottai sends glucose that is already calibrated like Libre.
             return .Libre
 
         case .medtrumTouchCareNano:
             return .Medtrum
 
         }
-        
+
     }
     
     /// if true, then a class conforming to the protocol CGMTransmitterDelegate will call newSensorDetected if it detects a new sensor is placed. Means there's no need to let the user start and stop a sensor
@@ -154,8 +158,12 @@ enum CGMTransmitterType:String, CaseIterable {
             
         case .Libre2:
             return true
-            
+
         case .dexcomG7:
+            return true
+
+        case .ottai:
+            // Ottai sends the sensor age itself, in cgmTransmitterInfoReceived.
             return true
 
         case .medtrumTouchCareNano:
@@ -166,7 +174,7 @@ enum CGMTransmitterType:String, CaseIterable {
 
         }
     }
-    
+
     /// this function says if the user should be able to manually start the sensor.
     ///
     /// Would normally not be required, because if canDetectNewSensor returns true, then manual start shouldn't e necessary.
@@ -179,9 +187,13 @@ enum CGMTransmitterType:String, CaseIterable {
             
         case .miaomiao, .Bubble, .Libre2:
             return true
-            
+
         case .dexcomG7:
             return false
+
+        case .ottai:
+            // "start sensor" starts the Ottai activation. It cannot be undone.
+            return true
 
         case .medtrumTouchCareNano:
             // EasyPatch owns sensor lifecycle; xDrip should not offer a manual start UI.
@@ -210,6 +222,10 @@ enum CGMTransmitterType:String, CaseIterable {
             // we don't use this
             return ConstantsDefaultAlertLevels.defaultBatteryAlertLevelDexcomG5
 
+        case .ottai:
+            // Ottai does not send a battery level, so this value is not used.
+            return ConstantsDefaultAlertLevels.defaultBatteryAlertLevelDexcomG5
+
         case .medtrumTouchCareNano:
             // No pump-battery surface in xDrip; reuse the generic threshold so the UI has a sane default.
             return ConstantsDefaultAlertLevels.defaultBatteryAlertLevelLibre2
@@ -232,12 +248,12 @@ enum CGMTransmitterType:String, CaseIterable {
             
         case .Libre2:
             return "%"
-            
+
         case .dexcomG7:
             // we don't use this
             return ""
 
-        case .medtrumTouchCareNano:
+        case .ottai, .medtrumTouchCareNano:
             return ""
 
         }

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/CGMOttaiTransmitter.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/CGMOttaiTransmitter.swift
@@ -1,0 +1,1676 @@
+//
+//  CGMOttaiTransmitter.swift
+//  xdrip
+//
+//  Ottai / Syai CGM Bluetooth transmitter.
+//
+//  This is a Swift copy of OttaiBleManager.kt from JugglucoNG (the working
+//  Android driver), built on xDrip's BluetoothTransmitter class. The
+//  encryption, login math, packet parsing and the glucose formula live in the
+//  Core/ files. This class talks to the sensor step by step, checks every
+//  reading the same way the Android code does, and gives the good readings to
+//  xDrip.
+//
+//  Same as the Kotlin where iOS allows it:
+//    - connect -> reset -> find services -> turn on notifications (history,
+//      live, cgm-info) -> login (Auth V2) -> read the command byte:
+//      3 = streaming, 0..2 = needs activation, 4 or more = sensor ended
+//      (read the live buffer only to learn the last dataNo, fetch history, no live)
+//    - the live poll time comes from the 0x0777 cgm-info packet (4 or more
+//      bytes, 5..3600 s, at most 60 s); the poll waits while live
+//      notifications keep coming
+//    - sample times come from a "stream anchor" (start = sample - dataNo * 60 s);
+//      the start is saved as the activation time only after two anchors agree
+//    - a dataNo limit against broken packets, with a "stop trusting the limit" rule
+//    - all the checks, in this order: hard reject -> recently rejected -> warmup
+//      -> continuity (one-minute jump, lonely spike in history) -> freshness
+//    - history comes in blocks of 270 records, 750 ms apart, with a 12 s watchdog
+//  Different on purpose (xDrip has no Room database):
+//    - the first readings after connect are collected and given to xDrip ONCE,
+//      newest first, so its 5-minute filter can fill the chart from empty
+//    - the first backfill is a fixed 24 h window (not a database diff), and
+//      there is no list of missing windows saved between sessions
+//    - NFC wake, connection priority and the outage probe do not exist on iOS
+//
+//  Threads: everything in this class runs on `workQueue` (one at a time).
+//  CoreBluetooth callbacks are sent there in order. The base class helpers
+//  (read, write, notify, disconnect) switch to their own queue, so we can call
+//  them from `workQueue`. Readings go to xDrip on the main queue (Core Data).
+//
+
+import CoreBluetooth
+import Foundation
+import os
+
+final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
+
+    // MARK: - constants (same values as OttaiBleManager.kt)
+
+    private let log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryCGMOttai)
+
+    private static let mgdlPerMmoll: Double = 18.0
+    private static let recordIntervalMs: Int64 = 60_000
+    private static let maxLivePollIntervalMs: Int64 = 60_000
+    private static let historyRequestChunkRecords = 270
+    private static let historyChunkDelay: TimeInterval = 0.75
+    private static let historyPageTimeout: TimeInterval = 12.0
+    private static let historyMaxRetries = 3
+    private static let historyRequestCooldownMs: Int64 = 60_000
+    private static let recentHistoryRecords = 60
+    /// xDrip only: how far back the first backfill goes (the Kotlin uses a database diff instead).
+    private static let initialBackfillRecords = 24 * 60
+    private static let initialHistoryDelay: TimeInterval = 4.0
+    private static let initialHistoryMinSensorAgeMs: Int64 = 3 * 60_000
+    private static let maxReasonableDataNoAhead = 120
+    private static let maxConsecutiveCeilingFullDrops = 3
+    private static let currentSampleFreshMs: Int64 = 120_000
+    private static let currentSampleFloorGraceMs: Int64 = recordIntervalMs
+    private static let confirmedStartAgreementMs: Int64 = 2 * recordIntervalMs
+    private static let maxConsecutiveContinuityRejects = 3
+    private static let postActivationConfirmDelay: TimeInterval = 1.0
+    private static let postActivationConfirmRetry: TimeInterval = 1.5
+    private static let postActivationConfirmMaxAttempts = 4
+    private static let reauthDelay: TimeInterval = 3.0
+
+    // MARK: - identity / materials
+
+    private let sensorId: String
+    private var materials: OttaiRegistry.DeviceMaterials
+    private var authKeys: [[UInt8]]?
+    private var macBytes: [UInt8] { OttaiCrypto.hexToBytes(sensorId) }
+
+    private weak var cgmTransmitterDelegate: CGMTransmitterDelegate?
+
+    /// xDrip only: sends the accepted readings to the Syai cloud when the user turned that on.
+    private let cloudUploader: OttaiCloudUploader
+
+    // MARK: - state for one connection (reset on every connect)
+
+    private enum Phase { case idle, enablingNotify, auth, streaming }
+    private enum AuthStep { case none, readDeviceTime, readDeviceParam, readDeviceSign, writeAppParam, writeAppSign, done }
+    private enum ActStep { case none, rtc, maxActive, destruction, command, done }
+
+    private var phase: Phase = .idle
+    private var authStep: AuthStep = .none
+    private var actStep: ActStep = .none
+    private var commandStatus = -1
+    private var connectionGeneration = 0
+
+    private var characteristics: [String: CBCharacteristic] = [:]
+    private var discoveredServices = Set<CBUUID>()
+    private weak var connectedPeripheral: CBPeripheral?
+
+    private var deviceTimeBytes: [UInt8] = []
+    private var deviceParamIndex = 0
+    private var deviceParamTime: [UInt8] = []
+    private var devicePubX: [UInt8] = []
+    private var devicePubY: [UInt8] = []
+    private var appKeyPair: OttaiBleAuth.KeyPair?
+    private var appIndex = 0
+    private var appTime3: [UInt8] = []
+    private var sessionKeyHex = ""
+    private var lastAuthDevHex = ""
+    private var serverAuthHostBytes: [UInt8]?
+    private var serverAuthFlagBytes: [UInt8]?
+
+    private var pendingActivation = false
+    private var rediscoveredServices = Set<CBUUID>()
+    /// How many services the sensor reported in the re-discovery before activation.
+    private var expectedRediscoveryCount = 0
+    private var activationConfirmAttempt = 0
+
+    /// The three services the normal (streaming) connection needs.
+    private static let requiredServices: Set<CBUUID> = [
+        CBUUID(string: OttaiConstants.serviceAuth),
+        CBUUID(string: OttaiConstants.serviceCgm),
+        CBUUID(string: OttaiConstants.serviceDeviceInfo),
+    ]
+
+    private var livePollTimer: DispatchSourceTimer?
+    private var liveReadInFlight = false
+
+    // history block chain (for one connection)
+    private var activeHistoryStart = -1
+    private var activeHistoryEndExclusive = -1
+    private var pendingHistoryReason: String?
+    private var pendingHistoryNextStart = 0
+    private var pendingHistoryEndExclusive = 0
+    private var historyRetryCount = 0
+    private var historyChunkBestDataNo = -1
+    private var historyWatchdog: DispatchWorkItem?
+    private var historyChunkWork: DispatchWorkItem?
+    private var lastHistoryRequestAtMs: Int64 = 0
+
+    // MARK: - state that stays across reconnects
+
+    private var lastDataNo = 0
+    private var lastGlucoseAtMs: Int64 = 0
+    private var lastLiveFrameAtMs: Int64 = 0
+    private var lastLiveNotifyAtMs: Int64 = 0
+    private var livePollIntervalMs: Int64 = recordIntervalMs
+    private var activatedMaxActiveMs: Int64 = 0
+    private var activationRequested = false
+    private var activationCommandSentAtMs: Int64 = 0
+    private var maxActiveCandidatesMs: [Int64] = []
+    private var maxActiveCandidateIndex = 0
+    private var maxActiveAttemptMs: Int64 = 0
+
+    // stream time anchor (see seedStreamTimeAnchor / offerConfirmedActiveTime)
+    private var provisionalActiveTimeMs: Int64 = 0
+    private var streamStartTimeMs: Int64 = 0
+    private var streamStartReliable = false
+    private var pendingConfirmedStartMs: Int64 = 0
+
+    // dataNo limit
+    private var consecutiveCeilingFullDrops = 0
+    private var ceilingDistrusted = false
+
+    // wrong-sensor guard. On iOS the stored BLE address is not the sensor id, so it
+    // can point to an old sensor while the keys are for a new one. When the login
+    // fails twice with a bad device signature, we forget that peripheral and scan
+    // again, skipping the rejected one for the rest of this app run.
+    private var lastVerifyFailed = false
+    private var wrongSensorStrikes = 0
+    private var rejectedPeripheralIdentifiers = Set<String>()
+    private let rejectedIdentifiersLock = NSLock()
+
+    // continuity check
+    private struct RejectedSample { let rawCurrent: Int; let mmol: Float }
+    private var recentlyRejectedSamples: [Int: RejectedSample] = [:]
+    private var recentlyRejectedOrder: [Int] = []
+    private var lastAcceptedDataNo = -1
+    private var lastAcceptedSampleMs: Int64 = 0
+    private var lastAcceptedMmol: Float = 0
+    private var lastAcceptedRawCurrent = 0
+    private var lastEvaluatedDataNo = -1
+    private var lastEvaluatedSampleMs: Int64 = 0
+    private var consecutiveContinuityRejects = 0
+
+    // xDrip only: the last sensor session start reported to xDrip (see reportSensorSessionIfNeeded)
+    private var lastReportedSensorStartMs: Int64 = 0
+
+    // xDrip only: the first readings are collected here (see the file header)
+    private var initialFlushDone = false
+    private var initialHistoryRequested = false
+    private var initialBuffer: [Int: GlucoseData] = [:]
+    private var flushGeneration = 0
+
+    private let workQueue = DispatchQueue(label: "CGMOttaiTransmitter.work")
+
+    // MARK: - init
+
+    init(address: String?, name: String?, sensorId: String,
+         bluetoothTransmitterDelegate: BluetoothTransmitterDelegate,
+         cGMTransmitterDelegate: CGMTransmitterDelegate) {
+
+        let canonical = OttaiConstants.canonicalSensorId(sensorId).isEmpty ? sensorId : OttaiConstants.canonicalSensorId(sensorId)
+        self.sensorId = canonical
+        self.materials = OttaiRegistry.loadMaterials(sensorId: canonical)
+        self.authKeys = materials.authKeys
+        self.cgmTransmitterDelegate = cGMTransmitterDelegate
+        self.cloudUploader = OttaiCloudUploader(sensorId: canonical)
+
+        // load the saved state (restoreFromPersistence in the Kotlin)
+        self.lastDataNo = OttaiRegistry.loadLastDataNo(canonical)
+        self.activatedMaxActiveMs = OttaiRegistry.loadAcceptedMaxActive(canonical)
+        if materials.activeTimeMs > 0 {
+            OttaiRegistry.saveProvisionalActiveTime(canonical, 0)
+            self.provisionalActiveTimeMs = 0
+        } else {
+            self.provisionalActiveTimeMs = OttaiRegistry.loadProvisionalActiveTime(canonical)
+        }
+        if let b = OttaiRegistry.loadContinuityBaseline(canonical) {
+            lastAcceptedDataNo = b.dataNo
+            lastAcceptedSampleMs = b.sampleMs
+            lastAcceptedMmol = b.mmol
+            lastAcceptedRawCurrent = b.rawCurrent
+            lastEvaluatedDataNo = b.dataNo
+            lastEvaluatedSampleMs = b.sampleMs
+        }
+
+        // On iOS the "address" is a CoreBluetooth id, not the sensor MAC. If we have
+        // one (reconnect), use it. If not, scan for a new device.
+        let storedAddress = address ?? OttaiRegistry.findRecord(canonical)?.address
+        let newAddressAndName: BluetoothTransmitter.DeviceAddressAndName
+        if let a = storedAddress, !a.isEmpty {
+            newAddressAndName = .alreadyConnectedBefore(address: a, name: name)
+        } else {
+            newAddressAndName = .notYetConnected(expectedName: nil)
+        }
+
+        super.init(addressAndName: newAddressAndName,
+                   CBUUID_Advertisement: "181F",
+                   servicesCBUUIDs: [CBUUID(string: OttaiConstants.serviceAuth),
+                                     CBUUID(string: OttaiConstants.serviceCgm),
+                                     CBUUID(string: OttaiConstants.serviceDeviceInfo)],
+                   CBUUID_ReceiveCharacteristic: OttaiConstants.charGlucoseLive,
+                   CBUUID_WriteCharacteristic: OttaiConstants.charCommand,
+                   bluetoothTransmitterDelegate: bluetoothTransmitterDelegate)
+    }
+
+    // MARK: - CGMTransmitter
+
+    func cgmTransmitterType() -> CGMTransmitterType { .ottai }
+    func getCBUUID_Service() -> String { OttaiConstants.serviceCgm }
+    func getCBUUID_Receive() -> String { OttaiConstants.charGlucoseLive }
+    func maxSensorAgeInDays() -> Double? {
+        let ms = OttaiConstants.expectedLifetimeMs(cloudActiveExpireMs: materials.activeExpireTimeMs, acceptedMaxActiveMs: activatedMaxActiveMs)
+        return Double(ms) / Double(24 * 3600 * 1000)
+    }
+    func needsSensorStartTime() -> Bool { false }
+    func needsSensorStartCode() -> Bool { false }
+    /// The sensor sends glucose that is already calibrated (the cloud formula does it).
+    /// Without this, xDrip keeps asking the user for a calibration value.
+    func isWebOOPEnabled() -> Bool { true }
+    /// The user cannot switch the calibrated mode off.
+    func nonWebOOPAllowed() -> Bool { false }
+
+    /// xDrip "start sensor" = the Ottai activation. It cannot be undone.
+    /// The sensor's last command byte (3 = active, 4+ = ended, 0..2 = not started).
+    /// The settings screen uses it to warn before a repeated activation.
+    var sensorCommandStatus: Int { commandStatus }
+
+    /// Same as `requestForceActivation()` in JugglucoNG: the user's Activate button is
+    /// always a "force" request. It also runs on a sensor that is already active or has
+    /// ended, so the user can try to start it again (for example to extend the lifetime).
+    /// The warning is shown by the settings screen before this is called.
+    func startSensor(sensorCode: String?, startDate: Date) {
+        workQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.effectiveActiveTimeMs() > 0 || self.activationCommandSentAtMs > 0 {
+                trace("FORCE activation (bypassing already-started guard)", log: self.log, category: ConstantsLog.categoryCGMOttai, type: .info)
+            }
+            self.activationRequested = true
+            OttaiRegistry.setActivationAttempted(self.sensorId, true)
+            if self.phase == .streaming, !self.sessionKeyHex.isEmpty {
+                self.requestActivationWithRediscovery()
+            } else {
+                trace("activation refused for now — not authenticated (phase=%{public}@); will run after the next login", log: self.log, category: ConstantsLog.categoryCGMOttai, type: .info, "\(self.phase)")
+            }
+        }
+    }
+
+    // MARK: - connect / disconnect
+
+    /// Every connection starts from zero. The sensor gives a new login challenge
+    /// each time, and the characteristic objects from the old connection are no
+    /// longer valid. Without this reset, a reconnect after a Bluetooth drop kept
+    /// the old session key and old handles: no new login, every write failed with
+    /// "The handle is invalid", the sensor dropped the link again, and so on until
+    /// the user switched the connection off and on by hand.
+    private func resetConnectionState() {
+        connectionGeneration += 1
+        phase = .idle
+        authStep = .none
+        actStep = .none
+        commandStatus = -1
+        discoveredServices.removeAll()
+        rediscoveredServices.removeAll()
+        characteristics.removeAll()
+        connectedPeripheral = nil
+        deviceTimeBytes = []
+        appKeyPair = nil
+        sessionKeyHex = ""
+        serverAuthHostBytes = nil
+        serverAuthFlagBytes = nil
+        pendingActivation = false
+        expectedRediscoveryCount = 0
+        liveReadInFlight = false
+        lastVerifyFailed = false
+        livePollTimer?.cancel()
+        livePollTimer = nil
+        clearPendingHistoryRange()
+    }
+
+    override func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        // This is queued BEFORE super starts service discovery. The discovery
+        // callbacks go to the same queue, so the reset always runs first.
+        workQueue.async { [weak self] in self?.resetConnectionState() }
+        super.centralManager(central, didConnect: peripheral)
+    }
+
+    override func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        workQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.livePollTimer?.cancel()
+            self.livePollTimer = nil
+            self.phase = .idle
+            self.sessionKeyHex = ""
+            self.clearPendingHistoryRange()
+        }
+        super.centralManager(central, didDisconnectPeripheral: peripheral, error: error)
+    }
+
+    /// Drop the link, so the base class reconnects and the login starts again.
+    /// Does nothing if a newer connection came in the meantime.
+    private func recoverAndReconnect(_ reason: String) {
+        let gen = connectionGeneration
+        trace("%{public}@ — reconnecting", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, reason)
+        workQueue.asyncAfter(deadline: .now() + Self.reauthDelay) { [weak self] in
+            guard let self = self, self.connectionGeneration == gen else { return }
+            self.disconnect()
+        }
+    }
+
+    /// The sensor refused the auth write. When the device signature also failed, we
+    /// are most likely talking to the wrong physical sensor (an old one with the same
+    /// name). After two such logins, forget it and scan for another sensor.
+    private func handleAuthWriteFailure() {
+        if lastVerifyFailed { wrongSensorStrikes += 1 }
+        if lastVerifyFailed && wrongSensorStrikes >= 2 {
+            rotateAwayFromWrongSensor()
+        } else {
+            recoverAndReconnect("auth write failed")
+        }
+    }
+
+    private func rotateAwayFromWrongSensor() {
+        wrongSensorStrikes = 0
+        if let address = deviceAddress {
+            rejectedIdentifiersLock.lock()
+            rejectedPeripheralIdentifiers.insert(address)
+            rejectedIdentifiersLock.unlock()
+        }
+        trace("login keeps failing with a bad device signature — this looks like the wrong sensor; forgetting it and scanning for another one", log: log, category: ConstantsLog.categoryCGMOttai, type: .error)
+        disconnectAndForget()
+        workQueue.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            _ = self?.startScanning()
+        }
+    }
+
+    override func shouldConnectToDiscoveredPeripheral(_ peripheral: CBPeripheral) -> Bool {
+        rejectedIdentifiersLock.lock()
+        let rejected = rejectedPeripheralIdentifiers.contains(peripheral.identifier.uuidString)
+        rejectedIdentifiersLock.unlock()
+        return !rejected
+    }
+
+    private func afterDelay(_ seconds: TimeInterval, _ block: @escaping () -> Void) {
+        let gen = connectionGeneration
+        workQueue.asyncAfter(deadline: .now() + seconds) { [weak self] in
+            guard let self = self, self.connectionGeneration == gen else { return }
+            block()
+        }
+    }
+
+    // MARK: - service discovery
+
+    override func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        // Remember how many services the sensor has, so the re-discovery before an
+        // activation waits for ALL of them (like Android's all-or-nothing discovery).
+        let count = peripheral.services?.count ?? 0
+        workQueue.async { [weak self] in
+            guard let self = self, self.pendingActivation else { return }
+            self.expectedRediscoveryCount = count
+        }
+        super.peripheral(peripheral, didDiscoverServices: error)
+    }
+
+    override func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        let chars = service.characteristics ?? []
+        let serviceUUID = service.uuid
+        workQueue.async { [weak self] in
+            guard let self = self else { return }
+            if let error = error {
+                trace("in didDiscoverCharacteristicsFor, error %{public}@", log: self.log, category: ConstantsLog.categoryCGMOttai, type: .error, error.localizedDescription)
+            }
+            self.connectedPeripheral = peripheral
+            for ch in chars { self.characteristics[ch.uuid.full128] = ch }
+            if self.phase == .idle {
+                self.discoveredServices.insert(serviceUUID)
+                if Self.requiredServices.isSubset(of: self.discoveredServices) { self.onServicesDiscovered() }
+            } else if self.pendingActivation {
+                self.rediscoveredServices.insert(serviceUUID)
+                if self.expectedRediscoveryCount > 0, self.rediscoveredServices.count >= self.expectedRediscoveryCount {
+                    self.pendingActivation = false
+                    trace("post-auth re-discovery complete — starting activation", log: self.log, category: ConstantsLog.categoryCGMOttai, type: .info)
+                    self.startActivationWrites()
+                }
+            }
+        }
+    }
+
+    private func char(_ uuidString: String) -> CBCharacteristic? {
+        characteristics[CBUUID(string: uuidString).full128]
+    }
+
+    private func onServicesDiscovered() {
+        authKeys = materials.authKeys
+        switch ottaiAuthEntryMode(
+            hasAuthKeys: authKeys != nil,
+            bootstrapPending: OttaiRegistry.isV3CredentialBootstrapPending(sensorId),
+            cnSessionAvailable: OttaiRegistry.loadSessionProfile() == .cnPhone && !OttaiRegistry.loadAccessToken().isEmpty,
+            validatedDeviceVersion: OttaiRegistry.loadLastValidatedDeviceVersion(sensorId: sensorId)
+        ) {
+        case .storedMaterialAuth:
+            phase = .enablingNotify
+            // order: history, live, cgm-info
+            for uuid in [OttaiConstants.charGlucoseHistory, OttaiConstants.charGlucoseLive, OttaiConstants.charCgmInfoNotify] {
+                if let ch = char(uuid) { setNotifyValue(true, for: ch) }
+            }
+            afterDelay(0.6) { [weak self] in self?.startAuth() }
+        case .v3CredentialBootstrap:
+            trace("starting V3 credential bootstrap", log: log, category: ConstantsLog.categoryCGMOttai, type: .info)
+            startAuth()
+        case .blocked:
+            // No keys yet (first Scan, before the cloud id and fetch). Stay connected
+            // and do nothing: the connection creates the device entry and shows the
+            // setup screen.
+            trace("no auth keys and no authorized V3 bootstrap — idle until credentials are set", log: log, category: ConstantsLog.categoryCGMOttai, type: .error)
+        }
+    }
+
+    // MARK: - login (Auth V2 / V3)
+
+    private func startAuth() {
+        phase = .auth
+        serverAuthHostBytes = nil
+        serverAuthFlagBytes = nil
+        authStep = .readDeviceTime
+        readChar(OttaiConstants.charCurrentTime)
+    }
+
+    override func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        let uuid = characteristic.uuid.full128
+        let value = [UInt8](characteristic.value ?? Data())
+        workQueue.async { [weak self] in
+            guard let self = self else { return }
+            if let error = error {
+                trace("read err %{public}@ %{public}@ phase=%{public}@", log: self.log, category: ConstantsLog.categoryCGMOttai, type: .error, characteristic.uuid.uuidString, error.localizedDescription, "\(self.phase)")
+                // The maxActive read is only for display. Never let it break a stream.
+                if uuid == OttaiConstants.charMaxActiveTime { return }
+                if self.phase == .auth { self.recoverAndReconnect("auth read failed") }
+                return
+            }
+            self.handleValue(uuid: uuid, value: value)
+        }
+    }
+
+    private func handleValue(uuid: String, value: [UInt8]) {
+        switch uuid {
+        case OttaiConstants.charCurrentTime:
+            deviceTimeBytes = value
+            authStep = .readDeviceParam
+            readChar(OttaiConstants.charAuthDeviceParam)
+        case OttaiConstants.charAuthDeviceParam:
+            lastAuthDevHex = OttaiCrypto.bytesToHex(value)
+            parseDeviceAuthParam(value)
+            authStep = .readDeviceSign
+            readChar(OttaiConstants.charAuthSign)
+        case OttaiConstants.charAuthSign:
+            handleAuthSign(value)
+        case OttaiConstants.charCgmInfoNotify:
+            handleCgmInfo(value)
+        case OttaiConstants.charGlucoseLive:
+            // CoreBluetooth gives notifications and read answers the same way. A live
+            // value that comes while no read is running must be a notification.
+            if liveReadInFlight { liveReadInFlight = false } else { lastLiveNotifyAtMs = nowMs() }
+            handleGlucosePayload(value, live: true)
+        case OttaiConstants.charGlucoseHistory:
+            handleGlucosePayload(value, live: false)
+        case OttaiConstants.charCommand:
+            handleCommandStatus(value.first.map { Int($0) } ?? -1)
+        case OttaiConstants.charMaxActiveTime:
+            handleMaxActiveRead(value)
+        default:
+            break
+        }
+    }
+
+    private func parseDeviceAuthParam(_ v: [UInt8]) {
+        guard v.count >= 68 else { return }
+        deviceParamIndex = Int(v[0])
+        deviceParamTime = Array(v[1 ..< 4])
+        devicePubX = Array(v[4 ..< 36])
+        devicePubY = Array(v[36 ..< 68])
+    }
+
+    private func handleAuthSign(_ value: [UInt8]) {
+        let authFlagHex = OttaiCrypto.bytesToHex(value)
+        if OttaiRegistry.isV3CredentialBootstrapPending(sensorId) && authKeys == nil {
+            requestCgmAuthVerify(authDevHex: lastAuthDevHex, authFlagHex: authFlagHex)
+            return
+        }
+        _ = verifyDeviceSign(value)
+        writeAppParam()
+    }
+
+    @discardableResult
+    private func verifyDeviceSign(_ deviceSign: [UInt8]) -> Bool {
+        guard let keys = authKeys, deviceParamIndex >= 0, deviceParamIndex < keys.count else { return false }
+        let ok = OttaiBleAuth.verifyDeviceSign(
+            deviceSign: deviceSign,
+            authKeyHex: OttaiCrypto.bytesToHex(keys[deviceParamIndex]),
+            macHex: OttaiCrypto.bytesToHex(macBytes),
+            devPubX: devicePubX, devPubY: devicePubY, devTime: deviceParamTime)
+        // The result is not reliable in the original app, so we only log it. But when
+        // the login then also fails, a failed verify points to a wrong physical sensor.
+        lastVerifyFailed = !ok
+        trace("device sign verify=%{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, ok.description)
+        return ok
+    }
+
+    private func writeAppParam() {
+        if let host = serverAuthHostBytes, !host.isEmpty {
+            authStep = .writeAppParam
+            writeChar(OttaiConstants.charAuthAppParam, host)
+            return
+        }
+        guard let keys = authKeys, !keys.isEmpty else {
+            trace("cannot write auth parameter without stored auth keys", log: log, category: ConstantsLog.categoryCGMOttai, type: .error)
+            return
+        }
+        let kp = OttaiBleAuth.generateKeyPair()
+        appKeyPair = kp
+        appTime3 = OttaiBleAuth.appTime3(deviceTimeBytes)
+        appIndex = Int.random(in: 0 ..< keys.count)
+        let param = OttaiBleAuth.appAuthParameter(selectedIndex: appIndex, time3: appTime3, pubX: kp.pubX, pubY: kp.pubY)
+        authStep = .writeAppParam
+        writeChar(OttaiConstants.charAuthAppParam, param)
+    }
+
+    override func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        let uuid = characteristic.uuid.full128
+        workQueue.async { [weak self] in
+            guard let self = self else { return }
+            if let error = error {
+                trace("write err %{public}@ %{public}@ authStep=%{public}@ actStep=%{public}@", log: self.log, category: ConstantsLog.categoryCGMOttai, type: .error, characteristic.uuid.uuidString, error.localizedDescription, "\(self.authStep)", "\(self.actStep)")
+                if self.actStep == .maxActive, uuid == OttaiConstants.charMaxActiveTime, self.retryMaxActiveTime() { return }
+                if self.actStep != .none {
+                    self.failActivation("aborted after \(self.actStep) write error")
+                } else if self.authStep == .writeAppParam || self.authStep == .writeAppSign {
+                    self.handleAuthWriteFailure()
+                } else if uuid == OttaiConstants.charHistoryRequest, self.activeHistoryEndExclusive > 0 {
+                    // The sensor said no to this window (for example the start is past its
+                    // last record). Treat it as an empty answer, so the chain goes on.
+                    self.cancelHistoryWatchdog()
+                    self.historyRetryCount = 0
+                    self.advanceHistoryChunkChain()
+                }
+                return
+            }
+            self.handleWriteAck(uuid: uuid)
+        }
+    }
+
+    private func handleWriteAck(uuid: String) {
+        if uuid == OttaiConstants.charHistoryRequest { return }
+        if authStep == .writeAppParam, uuid == OttaiConstants.charAuthAppParam {
+            if let serverFlag = serverAuthFlagBytes, !serverFlag.isEmpty {
+                authStep = .writeAppSign
+                writeChar(OttaiConstants.charAuthSign, serverFlag)
+                return
+            }
+            guard let keys = authKeys, let kp = appKeyPair else { return }
+            let sign = OttaiBleAuth.authSignHex(authKeyHex: OttaiCrypto.bytesToHex(keys[appIndex]),
+                                                macHex: OttaiCrypto.bytesToHex(macBytes),
+                                                pubX: kp.pubX, pubY: kp.pubY, time3: appTime3)
+            authStep = .writeAppSign
+            writeChar(OttaiConstants.charAuthSign, sign)
+            return
+        }
+        if authStep == .writeAppSign, uuid == OttaiConstants.charAuthSign {
+            if serverAuthFlagBytes != nil {
+                serverAuthHostBytes = nil
+                serverAuthFlagBytes = nil
+                authStep = .done
+                phase = .streaming
+                sessionKeyHex = ""
+                trace("server active-auth write-back complete; fetching credentials", log: log, category: ConstantsLog.categoryCGMOttai, type: .info)
+                scheduleV3BindAfterActiveAuth()
+                return
+            }
+            deriveSession()
+            authStep = .done
+            if sessionKeyHex.isEmpty {
+                recoverAndReconnect("auth complete; session=FAILED — no session key derived")
+                return
+            }
+            phase = .streaming
+            reportSensorSessionIfNeeded()
+            lastVerifyFailed = false
+            wrongSensorStrikes = 0
+            rejectedIdentifiersLock.lock()
+            rejectedPeripheralIdentifiers.removeAll()
+            rejectedIdentifiersLock.unlock()
+            trace("auth complete; session ok", log: log, category: ConstantsLog.categoryCGMOttai, type: .info)
+            OttaiRegistry.ensureSensorRecord(sensorId: sensorId, address: deviceAddress ?? "", displayName: OttaiConstants.defaultDisplayName)
+            // The command byte tells the true state: 0..2 = activate, 3 = stream,
+            // 4 or more = the sensor has ended.
+            readChar(OttaiConstants.charCommand)
+            return
+        }
+        if actStep != .none {
+            if actStep == .maxActive, uuid == OttaiConstants.charMaxActiveTime { markMaxActiveAccepted() }
+            advanceActivation()
+        }
+    }
+
+    private func deriveSession() {
+        guard let kp = appKeyPair else { return }
+        sessionKeyHex = OttaiBleAuth.deriveSessionKey(devPubX: devicePubX, devPubY: devicePubY, ourPrivate: kp.privateKey) ?? ""
+        trace("session key derived len=%{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, "\(sessionKeyHex.count)")
+    }
+
+    // MARK: - V3 cgmAuth/verify + bindV3
+
+    private func requestCgmAuthVerify(authDevHex: String, authFlagHex: String) {
+        if authFlagHex.allSatisfy({ $0 == "0" }) { return }
+        let mac = OttaiCrypto.bytesToHex(macBytes)
+        let gen = connectionGeneration
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let material = OttaiCloudClient.cgmAuthVerify(mac: mac, authDevHex: authDevHex, authFlagHex: authFlagHex)
+            self?.workQueue.async { [weak self] in
+                guard let self = self, self.connectionGeneration == gen, self.phase == .auth else { return }
+                if let m = material,
+                   let host = try? OttaiCrypto.hexToBytesStrict(m.authHost),
+                   let flag = try? OttaiCrypto.hexToBytesStrict(m.authFlag),
+                   !host.isEmpty, !flag.isEmpty {
+                    self.serverAuthHostBytes = host
+                    self.serverAuthFlagBytes = flag
+                    self.writeAppParam()
+                } else {
+                    self.recoverAndReconnect("V3 credential bootstrap failed: no server material")
+                }
+            }
+        }
+    }
+
+    private func scheduleV3BindAfterActiveAuth() {
+        let id = sensorId
+        let fallbackVersion = materials.deviceVersion
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 2.5) { [weak self] in
+            let version = OttaiRegistry.loadLastValidatedDeviceVersion(sensorId: id) ?? fallbackVersion
+            if version.isEmpty { return }
+            guard let resp = OttaiCloudClient.bindV3(mac: id, deviceVersion: version), !resp.keyA.isEmpty,
+                  let mats = OttaiCloudClient.toMaterials(mac: id, resp: resp), mats.authKeys != nil,
+                  OttaiRegistry.saveMaterials(sensorId: id, mats) else {
+                if let self = self {
+                    trace("bindV3 not accepted: %{public}@", log: self.log, category: ConstantsLog.categoryCGMOttai, type: .error, OttaiCloudClient.lastError)
+                }
+                return
+            }
+            self?.workQueue.async { [weak self] in
+                guard let self = self else { return }
+                self.materials = mats
+                self.authKeys = mats.authKeys
+                OttaiRegistry.setV3CredentialBootstrapPending(id, false)
+                self.disconnect() // the next connection will use the normal login with keyA
+            }
+        }
+    }
+
+    // MARK: - command byte
+
+    private func handleCommandStatus(_ status: Int) {
+        let previous = commandStatus
+        commandStatus = status
+        trace("cmd/activation status=%{public}d (official: 3=activated, <3=needs activation)", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, status)
+        if status < 0 { return }
+        if OttaiConstants.commandNeedsActivation(status) {
+            livePollTimer?.cancel(); livePollTimer = nil
+            if OttaiConstants.shouldStartActivation(commandStatus: status, explicitlyRequested: activationRequested),
+               actStep == .none, !pendingActivation {
+                activationRequested = false
+                trace("sensor command status=%{public}d and user requested activation; starting activation sequence", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, status)
+                afterDelay(0.25) { [weak self] in self?.requestActivationWithRediscovery() }
+            } else {
+                trace("sensor needs activation status=%{public}d; awaiting explicit user action", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, status)
+            }
+            return
+        }
+        if status == 3 {
+            // activationCommandSentAtMs is kept on purpose (same as the Kotlin): it is the
+            // warmup anchor for a sensor we just started, until the real start is confirmed.
+            if previous >= 4 { trace("ended-sensor recovery accepted; normal streaming restored", log: log, category: ConstantsLog.categoryCGMOttai, type: .info) }
+            if previous != 3 { startStreamingAfterCommandStatus() }
+            return
+        }
+        // 4 or more = the sensor has ended. We do not try to restart it. We read the
+        // live buffer once, only to learn the last dataNo, and then fetch the history
+        // up to it. No glucose is published from this read.
+        livePollTimer?.cancel(); livePollTimer = nil
+        trace("sensor ended cmd=%{public}d; no lifetime write will be attempted automatically", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, status)
+        afterDelay(0.5) { [weak self] in
+            guard let self = self, self.commandStatus >= 4 else { return }
+            self.readLiveGlucose("ended-history-index")
+        }
+    }
+
+    private func startStreamingAfterCommandStatus() {
+        afterDelay(0.25) { [weak self] in self?.readChar(OttaiConstants.charCgmInfoNotify) }
+        afterDelay(0.7) { [weak self] in
+            self?.readLiveGlucose("command-status-3")
+            self?.scheduleLivePoll()
+        }
+        // Read the real lifetime of a sensor we did not activate ourselves. Only once.
+        if activatedMaxActiveMs <= 0 {
+            afterDelay(1.2) { [weak self] in self?.readChar(OttaiConstants.charMaxActiveTime) }
+        }
+        // History backfill that does not wait for the first live reading.
+        afterDelay(Self.initialHistoryDelay) { [weak self] in self?.runInitialHistoryBackfill() }
+    }
+
+    /// The first history backfill. Only runs if the live path did not do it already.
+    private func runInitialHistoryBackfill() {
+        guard phase == .streaming, !sessionKeyHex.isEmpty, commandStatus == 3 else { return }
+        guard !initialHistoryRequested, !initialFlushDone else { return }
+        let sensorAgeMs = warmupAnchorMs() > 0 ? nowMs() - warmupAnchorMs() : -1
+        if sensorAgeMs >= 0 && sensorAgeMs < Self.initialHistoryMinSensorAgeMs {
+            let wait = Double(Self.initialHistoryMinSensorAgeMs - sensorAgeMs) / 1000.0
+            trace("initial history backfill deferred %{public}ds — sensor is %{public}ds old", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, Int(wait), Int(sensorAgeMs / 1000))
+            afterDelay(wait) { [weak self] in self?.runInitialHistoryBackfill() }
+            return
+        }
+        guard lastDataNo > 0 else {
+            readLiveGlucose("initial-history-probe")
+            return
+        }
+        initialHistoryRequested = true
+        let start = max(0, lastDataNo - Self.initialBackfillRecords)
+        _ = requestHistoryRange("initial", start: start, count: lastDataNo - start)
+    }
+
+    // MARK: - live and history packets
+
+    private func handleGlucosePayload(_ cipher: [UInt8], live: Bool) {
+        if sessionKeyHex.isEmpty { return }
+        if live && commandStatus >= 4 {
+            handleEndedLiveBuffer(cipher)
+            return
+        }
+        let receivedAtMs = nowMs()
+        let kind = live ? "live" : "history"
+        guard let payload = OttaiCrypto.decryptPayload(cipher, sessionKeyHex: sessionKeyHex) else {
+            trace("%{public}@ decrypt failed len=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, kind, cipher.count)
+            return
+        }
+        let records = OttaiParser.frameRecords(payload, deviceVersion: materials.deviceVersion)
+        if records.isEmpty {
+            trace("%{public}@ no records payloadLen=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, kind, payload.count)
+            if live {
+                afterDelay(1.8) { [weak self] in _ = self?.requestRecentHistory("empty-live") }
+            } else if activeHistoryEndExclusive > 0 {
+                // An empty answer is still an answer. Do not let it stop the chain.
+                cancelHistoryWatchdog()
+                historyRetryCount = 0
+                advanceHistoryChunkChain()
+            }
+            return
+        }
+        let activeMs = effectiveActiveTimeMs()
+        let readings: [OttaiReading]
+        if live {
+            readings = [OttaiParser.toReading(records.last!, method: materials.method, coefficients: materials.coefficients, activeTimeMs: activeMs)]
+        } else {
+            readings = records.map { OttaiParser.toReading($0, method: materials.method, coefficients: materials.coefficients, activeTimeMs: activeMs) }
+        }
+        let previousDataNo = lastDataNo
+        // A dataNo far past the sensor's real position means a broken packet.
+        // Throw those records away before we change any state.
+        let ceiling = dataNoCeiling(live: live)
+        let plausible = ceiling == Int.max ? readings : readings.filter { $0.record.dataNo <= ceiling }
+        if plausible.count < readings.count {
+            trace("%{public}@ dropped %{public}d corrupt records dataNo>ceiling=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, kind, readings.count - plausible.count, ceiling)
+        }
+        noteCeilingOutcome(offered: readings.count, kept: plausible.count, ceiling: ceiling)
+        if live && !plausible.isEmpty { lastLiveFrameAtMs = receivedAtMs }
+
+        var emitted: [(dataNo: Int, glucose: GlucoseData)] = []
+        for (index, r) in plausible.enumerated() {
+            if !r.valid {
+                trace("%{public}@ record rejected dataNo=%{public}d runtime=%{public}d raw=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, kind, r.record.dataNo, r.record.runtimeSec, r.record.rawCurrent)
+                continue
+            }
+            if materials.method.isEmpty {
+                trace("no method — skipping emit dataNo=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, r.record.dataNo)
+                continue
+            }
+            if let e = emitReading(r, live: live, receivedAtMs: receivedAtMs, batch: plausible, batchIndex: index) {
+                emitted.append(e)
+            }
+        }
+        let newestDataNo = records.map { OttaiParser.parseRecord($0).dataNo }.max() ?? -1
+        trace("%{public}@ decoded records=%{public}d newestDataNo=%{public}d emitted=%{public}d activeMs=%{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, kind, records.count, newestDataNo, emitted.count, "\(effectiveActiveTimeMs())")
+
+        if !emitted.isEmpty { deliverOrBuffer(emitted) }
+
+        if live {
+            let liveDataNo = lastDataNo
+            let previousForHistory = previousDataNoForHistory(previousDataNo, liveDataNo)
+            if !initialFlushDone && !initialHistoryRequested && liveDataNo > 0 {
+                initialHistoryRequested = true
+                let start = max(0, liveDataNo - Self.initialBackfillRecords)
+                _ = requestHistoryRange("room-backfill", start: start, count: liveDataNo - start)
+            } else if previousForHistory < 0 || liveDataNo - previousForHistory - 1 > 0 {
+                afterDelay(1.5) { [weak self] in self?.requestHistoryAfterLive(previousForHistory, liveDataNo) }
+            }
+        } else {
+            if !continueHistoryAfterPayload(plausible) {
+                // A long history burst can end a few minutes behind the clock. Read
+                // live right after it, unless live is already fresh.
+                if shouldReadLiveAfterHistory(receivedAtMs) {
+                    afterDelay(1.0) { [weak self] in
+                        guard let self = self, self.commandStatus < 4 else { return }
+                        self.readLiveGlucose("post-history")
+                        self.scheduleLivePoll()
+                    }
+                }
+            }
+        }
+    }
+
+    /// An ended sensor gives no live readings. We only take the last dataNo from
+    /// the live buffer and fetch history up to it. No glucose is published.
+    private func handleEndedLiveBuffer(_ cipher: [UInt8]) {
+        guard let payload = OttaiCrypto.decryptPayload(cipher, sessionKeyHex: sessionKeyHex) else { return }
+        let latest = OttaiParser.frameRecords(payload, deviceVersion: materials.deviceVersion)
+            .map(OttaiParser.parseRecord).max { $0.dataNo < $1.dataNo }
+        guard let latest = latest else {
+            trace("ended live buffer has no records", log: log, category: ConstantsLog.categoryCGMOttai, type: .info)
+            return
+        }
+        noteSeenDataNo(latest.dataNo)
+        // Only a confirmed activation time may date this backfill. A guessed time
+        // would give wrong dates.
+        if streamStartTimeMs <= 0 && materials.activeTimeMs > 0 {
+            _ = seedStreamTimeAnchor(latest.dataNo, materials.activeTimeMs + Int64(latest.runtimeSec) * 1000, "ended-live")
+        }
+        trace("ended live buffer indexed dataNo=%{public}d; glucose suppressed", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, latest.dataNo)
+        afterDelay(4.5) { [weak self] in
+            guard let self = self, self.commandStatus >= 4, self.phase == .streaming, !self.sessionKeyHex.isEmpty else { return }
+            let end = self.lastDataNo + 1
+            guard end > 0, !self.initialHistoryRequested else { return }
+            self.initialHistoryRequested = true
+            let start = max(0, end - Self.initialBackfillRecords)
+            _ = self.requestHistoryRange("ended-backfill", start: start, count: end - start)
+        }
+    }
+
+    // MARK: - one reading and all its checks (same order as the Kotlin)
+
+    private func emitReading(_ r: OttaiReading, live: Bool, receivedAtMs: Int64, batch: [OttaiReading], batchIndex: Int) -> (dataNo: Int, glucose: GlucoseData)? {
+        let mmol = Float(r.adjustGlucose)
+        let mgdl = Double(mmol) * Self.mgdlPerMmoll
+        if let reason = OttaiOutputFilter.hardRejectReason(record: r.record, mmol: mmol) {
+            return rejectReading(r, mmol: mmol, live: live, reason: "hard-\(reason)")
+        }
+        if mgdl <= 1 { return rejectReading(r, mmol: mmol, live: live, reason: "mgdl=\(mgdl)") }
+        if let reason = recentRejectedSampleReason(r, mmol: mmol) {
+            return rejectReading(r, mmol: mmol, live: live, reason: reason)
+        }
+        repairAheadLastDataNoIfNeeded(acceptedDataNo: r.record.dataNo, live: live)
+        let advancesDataNo = r.record.dataNo > lastDataNo
+        let sampleMs = resolveSampleTimeMs(r, live: live, receivedAtMs: receivedAtMs)
+        if sampleMs <= 0 {
+            trace("no active-time anchor — skipping emit dataNo=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, r.record.dataNo)
+            return nil
+        }
+        if OttaiConstants.isWithinWarmup(activationStartMs: warmupAnchorMs(), sampleMs: sampleMs) {
+            return rejectReading(r, mmol: mmol, live: live, reason: "warmup")
+        }
+        if let reason = continuityRejectReason(r, mmol: mmol, sampleMs: sampleMs, live: live, batch: batch, batchIndex: batchIndex) {
+            noteContinuityRejection(dataNo: r.record.dataNo, sampleMs: sampleMs)
+            return rejectReading(r, mmol: mmol, live: live, reason: reason)
+        }
+        let previousGlucoseAtMs = lastGlucoseAtMs
+        let freshLiveSample = live && isFreshLiveSample(receivedAtMs: receivedAtMs, sampleMs: sampleMs)
+        let newest = sampleMs >= previousGlucoseAtMs
+        if newest && (!live || freshLiveSample) {
+            lastGlucoseAtMs = sampleMs
+        }
+        rememberAcceptedReading(r, mmol: mmol, sampleMs: sampleMs)
+        if advancesDataNo { noteSeenDataNo(r.record.dataNo) }
+        trace("BG dataNo=%{public}d mmol=%{public}.2f mgdl=%{public}.0f raw=%{public}d T=%{public}.1f", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, r.record.dataNo, Double(mmol), mgdl, r.record.rawCurrent, r.record.temperatureC)
+        // Like the Kotlin: history is always kept. A live reading is kept only when
+        // it is fresh and newer than the last one. An old record that comes from the
+        // live characteristic is never shown as the current value.
+        let shouldPersist = !live || (freshLiveSample && sampleMs > previousGlucoseAtMs)
+        if !shouldPersist {
+            trace("live sample not persisted (fresh=%{public}@ newer=%{public}@) dataNo=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, freshLiveSample.description, (sampleMs > previousGlucoseAtMs).description, r.record.dataNo)
+            return nil
+        }
+        // xDrip only: the same reading also goes to the Syai cloud (if turned on)
+        cloudUploader.enqueue(reading: r, mmol: Double(mmol), sampleMs: sampleMs, receivedAtMs: receivedAtMs, live: live)
+        return (r.record.dataNo, GlucoseData(timeStamp: Date(timeIntervalSince1970: Double(sampleMs) / 1000.0), glucoseLevelRaw: mgdl))
+    }
+
+    private func rejectReading(_ r: OttaiReading, mmol: Float, live: Bool, reason: String) -> (dataNo: Int, glucose: GlucoseData)? {
+        rememberRejectedReading(r, mmol: mmol)
+        trace("%{public}@ BG rejected reason=%{public}@ dataNo=%{public}d mmol=%{public}.2f raw=%{public}d T=%{public}.1f", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, live ? "live" : "history", reason, r.record.dataNo, Double(mmol), r.record.rawCurrent, r.record.temperatureC)
+        return nil
+    }
+
+    private func rememberRejectedReading(_ r: OttaiReading, mmol: Float) {
+        let key = r.record.dataNo
+        if recentlyRejectedSamples[key] == nil {
+            recentlyRejectedOrder.append(key)
+            if recentlyRejectedOrder.count > 64 {
+                recentlyRejectedSamples.removeValue(forKey: recentlyRejectedOrder.removeFirst())
+            }
+        }
+        recentlyRejectedSamples[key] = RejectedSample(rawCurrent: r.record.rawCurrent, mmol: mmol)
+    }
+
+    private func recentRejectedSampleReason(_ r: OttaiReading, mmol: Float) -> String? {
+        guard let rejected = recentlyRejectedSamples[r.record.dataNo] else { return nil }
+        let sameRaw = rejected.rawCurrent == r.record.rawCurrent
+        let sameValue = abs(rejected.mmol - mmol) < 0.05
+        return (sameRaw || sameValue) ? "recent-rejected raw=\(rejected.rawCurrent) mmol=\(rejected.mmol)" : nil
+    }
+
+    private func isFreshLiveSample(receivedAtMs: Int64, sampleMs: Int64) -> Bool {
+        receivedAtMs > 0 && sampleMs > 0 &&
+            abs(receivedAtMs - sampleMs) <= Self.currentSampleFreshMs + Self.currentSampleFloorGraceMs
+    }
+
+    private func shouldReadLiveAfterHistory(_ receivedAtMs: Int64) -> Bool {
+        if lastLiveFrameAtMs <= 0 { return true }
+        let since = receivedAtMs - lastLiveFrameAtMs
+        return since < 0 || since >= Self.recordIntervalMs
+    }
+
+    // MARK: - dataNo bookkeeping
+
+    private func noteSeenDataNo(_ dataNo: Int) {
+        if dataNo <= lastDataNo { return }
+        lastDataNo = dataNo
+        OttaiRegistry.saveLastDataNo(sensorId, dataNo)
+    }
+
+    private func isPersistedDataNoAheadOfLive(_ previousDataNo: Int, _ liveDataNo: Int) -> Bool {
+        previousDataNo >= 0 && liveDataNo >= 0 && previousDataNo > liveDataNo + Self.maxReasonableDataNoAhead
+    }
+
+    private func previousDataNoForHistory(_ previousDataNo: Int, _ liveDataNo: Int) -> Int {
+        isPersistedDataNoAheadOfLive(previousDataNo, liveDataNo) ? -1 : previousDataNo
+    }
+
+    private func repairAheadLastDataNoIfNeeded(acceptedDataNo: Int, live: Bool) {
+        guard live, isPersistedDataNoAheadOfLive(lastDataNo, acceptedDataNo) else { return }
+        trace("reset ahead lastDataNo previous=%{public}d acceptedLive=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, lastDataNo, acceptedDataNo)
+        lastDataNo = acceptedDataNo - 1
+        OttaiRegistry.saveLastDataNo(sensorId, lastDataNo)
+    }
+
+    /// The highest dataNo we accept. Only a real activation time (from the cloud
+    /// or confirmed by two anchors) may set this limit.
+    private func dataNoCeiling(live: Bool) -> Int {
+        if ceilingDistrusted { return Int.max }
+        let start = materials.activeTimeMs
+        let now = nowMs()
+        if start > 0 && start < now {
+            let elapsed = Int(min((now - start) / Self.recordIntervalMs, Int64(Int.max / 2)))
+            return elapsed + Self.maxReasonableDataNoAhead
+        }
+        if live { return Int.max }
+        return lastDataNo > 0 ? lastDataNo + Self.maxReasonableDataNoAhead : Int.max
+    }
+
+    private func noteCeilingOutcome(offered: Int, kept: Int, ceiling: Int) {
+        if offered <= 0 || ceiling == Int.max { return }
+        if kept > 0 { consecutiveCeilingFullDrops = 0; return }
+        consecutiveCeilingFullDrops += 1
+        if !ceilingDistrusted && consecutiveCeilingFullDrops >= Self.maxConsecutiveCeilingFullDrops {
+            ceilingDistrusted = true
+            trace("dataNo ceiling=%{public}d rejected %{public}d payloads in a row — distrusting it for this session", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, ceiling, consecutiveCeilingFullDrops)
+        }
+    }
+
+    // MARK: - continuity check (spike filter)
+
+    private func rememberAcceptedReading(_ r: OttaiReading, mmol: Float, sampleMs: Int64) {
+        recentlyRejectedSamples.removeValue(forKey: r.record.dataNo)
+        noteContinuityEvaluated(dataNo: r.record.dataNo, sampleMs: sampleMs)
+        // The baseline only moves forward. An old history record must not replace
+        // a newer baseline.
+        if lastAcceptedDataNo >= 0 && r.record.dataNo < lastAcceptedDataNo { return }
+        lastAcceptedDataNo = r.record.dataNo
+        lastAcceptedSampleMs = sampleMs
+        lastAcceptedMmol = mmol
+        lastAcceptedRawCurrent = r.record.rawCurrent
+        consecutiveContinuityRejects = 0
+        OttaiRegistry.saveContinuityBaseline(sensorId, dataNo: r.record.dataNo, sampleMs: sampleMs, mmol: mmol, rawCurrent: r.record.rawCurrent)
+    }
+
+    private func noteContinuityRejection(dataNo: Int, sampleMs: Int64) {
+        consecutiveContinuityRejects += 1
+        noteContinuityEvaluated(dataNo: dataNo, sampleMs: sampleMs)
+    }
+
+    private func noteContinuityEvaluated(dataNo: Int, sampleMs: Int64) {
+        if dataNo < lastEvaluatedDataNo { return }
+        lastEvaluatedDataNo = dataNo
+        lastEvaluatedSampleMs = sampleMs
+    }
+
+    private func isAdjacentSample(previousDataNo: Int, previousSampleMs: Int64, dataNo: Int, sampleMs: Int64) -> Bool {
+        if previousDataNo < 0 { return false }
+        if (1 ... 2).contains(dataNo - previousDataNo) { return true }
+        if previousSampleMs <= 0 || sampleMs <= previousSampleMs { return false }
+        return (1 ... (2 * Self.recordIntervalMs + 15_000)).contains(sampleMs - previousSampleMs)
+    }
+
+    private func isAdjacentToLastEvaluated(dataNo: Int, sampleMs: Int64) -> Bool {
+        isAdjacentSample(previousDataNo: lastEvaluatedDataNo, previousSampleMs: lastEvaluatedSampleMs, dataNo: dataNo, sampleMs: sampleMs)
+    }
+
+    private func isImmediatelyBeforeLastAccepted(dataNo: Int, sampleMs: Int64) -> Bool {
+        let nextDataNo = lastAcceptedDataNo
+        if nextDataNo < 0 { return false }
+        if (1 ... 2).contains(nextDataNo - dataNo) { return true }
+        let nextMs = lastAcceptedSampleMs
+        if nextMs <= 0 || sampleMs >= nextMs { return false }
+        return (1 ... (2 * Self.recordIntervalMs + 15_000)).contains(nextMs - sampleMs)
+    }
+
+    private func continuityRejectReason(_ r: OttaiReading, mmol: Float, sampleMs: Int64, live: Bool, batch: [OttaiReading], batchIndex: Int) -> String? {
+        // After a few rejections in a row, give up and take the next sample as the
+        // new baseline (the sensor may really have jumped, e.g. an electrode restart).
+        if consecutiveContinuityRejects >= Self.maxConsecutiveContinuityRejects {
+            trace("continuity gate yielding after %{public}d consecutive rejections; re-baselining on dataNo=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, consecutiveContinuityRejects, r.record.dataNo)
+            return nil
+        }
+        if isAdjacentToLastEvaluated(dataNo: r.record.dataNo, sampleMs: sampleMs),
+           OttaiOutputFilter.isOneMinuteRawExcursion(candidateMmol: mmol, candidateRaw: r.record.rawCurrent, baselineMmol: lastAcceptedMmol, baselineRaw: lastAcceptedRawCurrent) {
+            return "continuity-prev dataNo=\(lastAcceptedDataNo) mmol=\(lastAcceptedMmol) raw=\(lastAcceptedRawCurrent)"
+        }
+        if !live,
+           isImmediatelyBeforeLastAccepted(dataNo: r.record.dataNo, sampleMs: sampleMs),
+           OttaiOutputFilter.isOneMinuteRawExcursion(candidateMmol: mmol, candidateRaw: r.record.rawCurrent, baselineMmol: lastAcceptedMmol, baselineRaw: lastAcceptedRawCurrent) {
+            return "continuity-next dataNo=\(lastAcceptedDataNo) mmol=\(lastAcceptedMmol) raw=\(lastAcceptedRawCurrent)"
+        }
+        if !live, let reason = historyIsolatedSpikeReason(batch, batchIndex, r, mmol) { return reason }
+        return nil
+    }
+
+    private struct NeighborSample { let dataNo: Int; let mmol: Float; let rawCurrent: Int }
+
+    private func historyIsolatedSpikeReason(_ batch: [OttaiReading], _ batchIndex: Int, _ candidate: OttaiReading, _ candidateMmol: Float) -> String? {
+        let previous = neighborSample(batch, start: batchIndex - 1, step: -1)
+        let next = neighborSample(batch, start: batchIndex + 1, step: 1)
+        let previousAdjacent = previous.map { (1 ... 2).contains(candidate.record.dataNo - $0.dataNo) } ?? false
+        let nextAdjacent = next.map { (1 ... 2).contains($0.dataNo - candidate.record.dataNo) } ?? false
+        if previousAdjacent, nextAdjacent, let p = previous, let n = next {
+            let neighborsAgree = abs(p.mmol - n.mmol) < OttaiOutputFilter.singleSampleDeltaMmol
+            if neighborsAgree,
+               OttaiOutputFilter.isOneMinuteRawExcursion(candidateMmol: candidateMmol, candidateRaw: candidate.record.rawCurrent, baselineMmol: p.mmol, baselineRaw: p.rawCurrent),
+               OttaiOutputFilter.isOneMinuteRawExcursion(candidateMmol: candidateMmol, candidateRaw: candidate.record.rawCurrent, baselineMmol: n.mmol, baselineRaw: n.rawCurrent) {
+                return "history-isolated prev=\(p.dataNo) next=\(n.dataNo)"
+            }
+        }
+        if !previousAdjacent, nextAdjacent, candidate.record.dataNo <= 5, let n = next,
+           OttaiOutputFilter.isOneMinuteRawExcursion(candidateMmol: candidateMmol, candidateRaw: candidate.record.rawCurrent, baselineMmol: n.mmol, baselineRaw: n.rawCurrent) {
+            return "history-start next=\(n.dataNo)"
+        }
+        return nil
+    }
+
+    private func neighborSample(_ batch: [OttaiReading], start: Int, step: Int) -> NeighborSample? {
+        var index = start
+        while batch.indices.contains(index) {
+            let reading = batch[index]
+            if reading.valid {
+                let mmol = Float(reading.adjustGlucose)
+                if OttaiOutputFilter.hardRejectReason(record: reading.record, mmol: mmol) == nil {
+                    return NeighborSample(dataNo: reading.record.dataNo, mmol: mmol, rawCurrent: reading.record.rawCurrent)
+                }
+            }
+            index += step
+        }
+        return nil
+    }
+
+    // MARK: - sample times
+
+    private func effectiveActiveTimeMs() -> Int64 {
+        if materials.activeTimeMs > 0 { return materials.activeTimeMs }
+        if streamStartTimeMs > 0 { return streamStartTimeMs }
+        return provisionalActiveTimeMs > 0 ? provisionalActiveTimeMs : 0
+    }
+
+    /// The start time the warmup check may trust: the cloud time, or else the
+    /// moment we sent the activation command. Never a guessed time.
+    private func warmupAnchorMs() -> Int64 {
+        materials.activeTimeMs > 0 ? materials.activeTimeMs : (activationCommandSentAtMs > 0 ? activationCommandSentAtMs : 0)
+    }
+
+    private func resolveSampleTimeMs(_ r: OttaiReading, live: Bool, receivedAtMs: Int64) -> Int64 {
+        if streamStartTimeMs > 0 && (materials.activeTimeMs > 0 || !live) {
+            return streamStartTimeMs + Int64(r.record.dataNo) * Self.recordIntervalMs
+        }
+        if live && receivedAtMs > 0 && r.record.dataNo >= 0 {
+            let monitorMs = r.monitorTimeMs
+            if monitorMs > 0 && abs(receivedAtMs - monitorMs) <= Self.currentSampleFreshMs {
+                return seedStreamTimeAnchor(r.record.dataNo, monitorMs, "monitor-live", reliable: true)
+            }
+            if monitorMs > 0 {
+                trace("ignore stale live monitor timestamp dataNo=%{public}d delta=%{public}ds", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, r.record.dataNo, Int(abs(receivedAtMs - monitorMs) / 1000))
+            }
+            return seedStreamTimeAnchor(r.record.dataNo, receivedAtMs, "live", reliable: true)
+        }
+        if r.monitorTimeMs > 0 {
+            return seedStreamTimeAnchor(r.record.dataNo, r.monitorTimeMs, "monitor")
+        }
+        let activeMs = effectiveActiveTimeMs()
+        if activeMs > 0 {
+            return seedStreamTimeAnchor(r.record.dataNo, activeMs + Int64(r.record.runtimeSec) * 1000, "active")
+        }
+        return r.monitorTimeMs
+    }
+
+    private func seedStreamTimeAnchor(_ dataNo: Int, _ sampleHintMs: Int64, _ reason: String, reliable: Bool = false) -> Int64 {
+        if dataNo < 0 || sampleHintMs <= 0 { return sampleHintMs }
+        let sampleMs = (sampleHintMs / Self.recordIntervalMs) * Self.recordIntervalMs
+        let start = sampleMs - Int64(dataNo) * Self.recordIntervalMs
+        if start > 0 {
+            let old = streamStartTimeMs
+            // A time from the real clock is never replaced by a guessed time.
+            if old > 0 && streamStartReliable && !reliable {
+                return old + Int64(dataNo) * Self.recordIntervalMs
+            }
+            streamStartTimeMs = start
+            streamStartReliable = reliable
+            if old == 0 || abs(old - start) > Self.recordIntervalMs {
+                trace("stream time anchor dataNo=%{public}d start=%{public}@ source=%{public}@ reliable=%{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, dataNo, "\(start / 1000)", reason, reliable.description)
+            }
+            if reliable { offerConfirmedActiveTime(start) }
+        }
+        return sampleMs
+    }
+
+    /// Two start times, found on their own, must agree before we save the
+    /// activation time. A broken dataNo gives a time far away; a real pair is
+    /// within a minute or two.
+    private func offerConfirmedActiveTime(_ startMs: Int64) {
+        if startMs <= 0 || materials.activeTimeMs > 0 { return }
+        let now = nowMs()
+        if startMs > now || now - startMs > OttaiConstants.extendedLifetimeMs {
+            trace("implausible activation start=%{public}@ ignored", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, "\(startMs / 1000)")
+            return
+        }
+        let pending = pendingConfirmedStartMs
+        if pending <= 0 {
+            pendingConfirmedStartMs = startMs
+            trace("activation start candidate=%{public}@ awaiting corroboration", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, "\(startMs / 1000)")
+            return
+        }
+        if abs(pending - startMs) <= Self.confirmedStartAgreementMs {
+            materials.activeTimeMs = startMs
+            provisionalActiveTimeMs = 0
+            OttaiRegistry.saveActiveTimeMs(sensorId, startMs)
+            OttaiRegistry.saveProvisionalActiveTime(sensorId, 0)
+            trace("confirmed activeTime=%{public}@ persisted from live anchor", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, "\(startMs / 1000)")
+            reportSensorSessionIfNeeded()
+            return
+        }
+        trace("activation start candidates disagree: %{public}@ vs %{public}@; re-arming corroboration", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, "\(pending / 1000)", "\(startMs / 1000)")
+        pendingConfirmedStartMs = startMs
+    }
+
+    private func setProvisionalActiveTime(_ activeTimeMs: Int64, _ reason: String) {
+        if activeTimeMs <= 0 || materials.activeTimeMs > 0 { return }
+        // The guessed time may only move to an earlier moment.
+        if provisionalActiveTimeMs > 0 && activeTimeMs >= provisionalActiveTimeMs { return }
+        provisionalActiveTimeMs = activeTimeMs
+        OttaiRegistry.saveProvisionalActiveTime(sensorId, activeTimeMs)
+        trace("provisional activeTime set source=%{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, reason)
+    }
+
+    private func sensorAgeTimeInterval() -> TimeInterval? {
+        let start = effectiveActiveTimeMs()
+        if start <= 0 { return nil }
+        return TimeInterval(Double(nowMs() - start) / 1000.0)
+    }
+
+    /// xDrip only: tell xDrip when this sensor started, so the home screen shows the
+    /// warm-up countdown and the sensor age. Without this, the session is only created
+    /// when the first reading is processed — and during the warm-up no reading is
+    /// processed, so the screen said "waiting for data" with no countdown.
+    /// Reports each start once. Does nothing when xDrip already has a session within
+    /// 10 minutes of ours (a report stops and starts the xDrip sensor session).
+    private func reportSensorSessionIfNeeded() {
+        let startMs = effectiveActiveTimeMs()
+        guard startMs > 0, startMs != lastReportedSensorStartMs else { return }
+        lastReportedSensorStartMs = startMs
+        if let existing = UserDefaults.standard.activeSensorStartDate,
+           abs(existing.timeIntervalSince1970 - Double(startMs) / 1000.0) < 10 * 60 {
+            return
+        }
+        trace("reporting sensor session start=%{public}@ to xDrip", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, "\(startMs / 1000)")
+        DispatchQueue.main.async { [weak self] in
+            self?.cgmTransmitterDelegate?.newSensorDetected(sensorStartDate: Date(timeIntervalSince1970: Double(startMs) / 1000.0))
+        }
+    }
+
+    // MARK: - giving readings to xDrip (see the file header)
+
+    private func deliverOrBuffer(_ emitted: [(dataNo: Int, glucose: GlucoseData)]) {
+        if !initialFlushDone {
+            for p in emitted { initialBuffer[p.dataNo] = p.glucose }
+            flushGeneration += 1
+            let gen = flushGeneration
+            workQueue.asyncAfter(deadline: .now() + 5.0) { [weak self] in self?.flushInitialBufferIfIdle(gen) }
+        } else {
+            deliver(emitted.map { $0.glucose }.sorted { $0.timeStamp > $1.timeStamp })
+        }
+    }
+
+    private func flushInitialBufferIfIdle(_ generation: Int) {
+        guard !initialFlushDone, flushGeneration == generation else { return }
+        initialFlushDone = true
+        let arr = Array(initialBuffer.values).sorted { $0.timeStamp > $1.timeStamp }
+        initialBuffer.removeAll()
+        guard !arr.isEmpty else { return }
+        trace("flushing initial backfill count=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, arr.count)
+        deliver(arr)
+    }
+
+    private func deliver(_ readings: [GlucoseData]) {
+        guard !readings.isEmpty else { return }
+        let sensorAge = sensorAgeTimeInterval()
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            var arr = readings
+            self.cgmTransmitterDelegate?.cgmTransmitterInfoReceived(glucoseData: &arr, transmitterBatteryInfo: nil, sensorAge: sensorAge)
+        }
+    }
+
+    // MARK: - cgm-info packets
+
+    private func handleCgmInfo(_ value: [UInt8]) {
+        let head = value.prefix(2).map { String(format: "%02x", $0) }.joined()
+        trace("cgm-info len=%{public}d head=%{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, value.count, head)
+        // Note: the 0x0477 packet is NOT glucose. Nothing is published from cgm-info.
+        guard value.count >= 4, value[0] == 0x07, value[1] == 0x77 else { return }
+        let seconds = Int(value[2]) | (Int(value[3]) << 8)
+        guard seconds >= 5, seconds <= 3600 else { return }
+        let next = min(Int64(seconds) * 1000, Self.maxLivePollIntervalMs)
+        if next == livePollIntervalMs { return }
+        livePollIntervalMs = next
+        trace("live poll interval=%{public}ds from cgm-info raw=%{public}ds", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, Int(next / 1000), seconds)
+        if phase == .streaming, !sessionKeyHex.isEmpty { scheduleLivePoll() }
+    }
+
+    private func handleMaxActiveRead(_ value: [UInt8]) {
+        let plain = OttaiCrypto.decryptPayload(value, sessionKeyHex: sessionKeyHex) ?? value
+        guard plain.count >= 4 else { return }
+        let n = plain.count >= 8 ? 8 : 4
+        var secs: Int64 = 0
+        for i in 0 ..< n { secs |= Int64(plain[i]) << (i * 8) }
+        if secs < 10 * 86_400 || secs > 45 * 86_400 { return }
+        adoptActivatedMaxActive(secs * 1000, "sensor-readback")
+    }
+
+    // MARK: - live poll
+
+    private func scheduleLivePoll() {
+        livePollTimer?.cancel()
+        guard phase == .streaming, !sessionKeyHex.isEmpty else { return }
+        let delayMs = min(max(livePollIntervalMs, 5_000), 3_600_000)
+        let timer = DispatchSource.makeTimerSource(queue: workQueue)
+        timer.schedule(deadline: .now() + .milliseconds(Int(delayMs)))
+        timer.setEventHandler { [weak self] in self?.livePollFired() }
+        timer.resume()
+        livePollTimer = timer
+    }
+
+    private func livePollFired() {
+        guard phase == .streaming, !sessionKeyHex.isEmpty, commandStatus < 4 else { return }
+        // Wait while notifications keep coming on time.
+        let sinceNotifyMs = nowMs() - lastLiveNotifyAtMs
+        if lastLiveNotifyAtMs > 0 && sinceNotifyMs < livePollIntervalMs {
+            scheduleLivePoll()
+            return
+        }
+        readLiveGlucose("poll")
+        scheduleLivePoll()
+    }
+
+    // MARK: - history requests, block chain and watchdog
+
+    @discardableResult
+    private func requestRecentHistory(_ reason: String) -> Bool {
+        let endExclusive = lastDataNo
+        guard endExclusive > 0 else { return false }
+        let start = max(0, endExclusive - Self.recentHistoryRecords)
+        return requestHistoryRange(reason, start: start, count: endExclusive - start)
+    }
+
+    private func requestHistoryAfterLive(_ previousDataNo: Int, _ liveDataNo: Int) {
+        guard liveDataNo > 0 else { return }
+        let missingBeforeLive = liveDataNo - previousDataNo - 1
+        if previousDataNo >= 0 && missingBeforeLive <= 0 { return }
+        let count = previousDataNo < 0 ? liveDataNo : missingBeforeLive
+        guard count > 0, count <= 0xFFFF else { return }
+        let start = previousDataNo < 0 ? 0 : previousDataNo + 1
+        _ = requestHistoryRange("post-live", start: start, count: count)
+    }
+
+    @discardableResult
+    private func requestHistoryRange(_ reason: String, start: Int, count: Int) -> Bool {
+        if start < 0 || count <= 0 || count > 0xFFFF { return false }
+        let bypassCooldown = reason == "manual" || reason == "room-backfill" || reason == "initial" || reason == "ended-backfill"
+        if !bypassCooldown && nowMs() - lastHistoryRequestAtMs < Self.historyRequestCooldownMs { return false }
+        clearPendingHistoryRange()
+        let requestCount = min(count, Self.historyRequestChunkRecords)
+        let issued = issueHistoryRequest(reason, start: start, count: requestCount)
+        if issued && requestCount < count {
+            pendingHistoryReason = reason
+            pendingHistoryNextStart = start + requestCount
+            pendingHistoryEndExclusive = start + count
+            trace("history chunked reason=%{public}@ start=%{public}d count=%{public}d first=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, reason, start, count, requestCount)
+        }
+        return issued
+    }
+
+    private func issueHistoryRequest(_ reason: String, start: Int, count: Int) -> Bool {
+        guard phase == .streaming, !sessionKeyHex.isEmpty, start >= 0, count > 0 else { return false }
+        let payload = shortLE(start) + shortLE(count)
+        guard writeChar(OttaiConstants.charHistoryRequest, payload) else { return false }
+        lastHistoryRequestAtMs = nowMs()
+        if start != activeHistoryStart || start + count != activeHistoryEndExclusive { historyChunkBestDataNo = -1 }
+        activeHistoryStart = start
+        activeHistoryEndExclusive = start + count
+        armHistoryWatchdog()
+        trace("request history reason=%{public}@ start=%{public}d count=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, reason, start, count)
+        return true
+    }
+
+    private func requestPendingHistoryChunk() {
+        guard let reason = pendingHistoryReason else { return }
+        let start = pendingHistoryNextStart
+        let endExclusive = pendingHistoryEndExclusive
+        let remaining = endExclusive - start
+        if remaining <= 0 { clearPendingHistoryRange(); return }
+        let count = min(remaining, Self.historyRequestChunkRecords)
+        guard issueHistoryRequest("\(reason)-chunk", start: start, count: count) else {
+            clearPendingHistoryRange()
+            return
+        }
+        pendingHistoryNextStart = start + count
+        if pendingHistoryNextStart >= endExclusive {
+            pendingHistoryReason = nil
+            pendingHistoryNextStart = 0
+            pendingHistoryEndExclusive = 0
+        }
+    }
+
+    /// Returns true while the chain is still running.
+    private func continueHistoryAfterPayload(_ readings: [OttaiReading]) -> Bool {
+        let activeEnd = activeHistoryEndExclusive
+        if activeEnd <= 0 { return pendingHistoryReason != nil }
+        guard let maxDataNo = readings.map({ $0.record.dataNo }).max() else { return false }
+        if maxDataNo > historyChunkBestDataNo { historyRetryCount = 0; historyChunkBestDataNo = maxDataNo }
+        if maxDataNo + 1 < activeEnd {
+            armHistoryWatchdog() // only part of the block came
+            return true
+        }
+        cancelHistoryWatchdog()
+        activeHistoryEndExclusive = -1
+        activeHistoryStart = -1
+        if pendingHistoryReason == nil { return false }
+        scheduleNextChunk()
+        trace("history chunk complete through=%{public}d next=%{public}d end=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, maxDataNo, pendingHistoryNextStart, pendingHistoryEndExclusive)
+        return true
+    }
+
+    private func advanceHistoryChunkChain() {
+        activeHistoryEndExclusive = -1
+        activeHistoryStart = -1
+        if pendingHistoryReason == nil { return }
+        scheduleNextChunk()
+    }
+
+    private func scheduleNextChunk() {
+        historyChunkWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.requestPendingHistoryChunk() }
+        historyChunkWork = work
+        workQueue.asyncAfter(deadline: .now() + Self.historyChunkDelay, execute: work)
+    }
+
+    private func armHistoryWatchdog() {
+        historyWatchdog?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.checkHistoryWatchdog() }
+        historyWatchdog = work
+        workQueue.asyncAfter(deadline: .now() + Self.historyPageTimeout, execute: work)
+    }
+
+    private func cancelHistoryWatchdog() {
+        historyWatchdog?.cancel()
+        historyWatchdog = nil
+    }
+
+    private func checkHistoryWatchdog() {
+        guard phase == .streaming, !sessionKeyHex.isEmpty else { return }
+        let end = activeHistoryEndExclusive
+        let start = activeHistoryStart
+        if end <= 0 { return }
+        if start < 0 || end <= start { historyRetryCount = 0; advanceHistoryChunkChain(); return }
+        if historyRetryCount < Self.historyMaxRetries {
+            historyRetryCount += 1
+            trace("history page watchdog: no progress for chunk [%{public}d,%{public}d) — retry %{public}d/%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, start, end, historyRetryCount, Self.historyMaxRetries)
+            if !issueHistoryRequest("watchdog-retry", start: start, count: end - start) { advanceHistoryChunkChain() }
+        } else {
+            trace("history page watchdog: chunk [%{public}d,%{public}d) failed after retries — skipping", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, start, end)
+            historyRetryCount = 0
+            advanceHistoryChunkChain()
+        }
+    }
+
+    private func clearPendingHistoryRange() {
+        historyChunkWork?.cancel(); historyChunkWork = nil
+        cancelHistoryWatchdog()
+        historyRetryCount = 0
+        historyChunkBestDataNo = -1
+        pendingHistoryReason = nil
+        pendingHistoryNextStart = 0
+        pendingHistoryEndExclusive = 0
+        activeHistoryEndExclusive = -1
+        activeHistoryStart = -1
+    }
+
+    // MARK: - activation (cannot be undone)
+
+    /// Android looks up the services again before the activation writes. The
+    /// handles found before login gave "invalid handle" for b8fd9848 / 6aa799b6.
+    /// We do the same and start the writes when all services are back.
+    private func requestActivationWithRediscovery() {
+        guard let peripheral = connectedPeripheral else {
+            trace("activation refused — no connected peripheral", log: log, category: ConstantsLog.categoryCGMOttai, type: .error)
+            return
+        }
+        pendingActivation = true
+        rediscoveredServices.removeAll()
+        expectedRediscoveryCount = 0
+        trace("re-discovering services before activation", log: log, category: ConstantsLog.categoryCGMOttai, type: .info)
+        // All services, like Android's gatt.discoverServices(); this also brings in the
+        // destruction service (84c5b711), which the normal connection does not look up.
+        peripheral.discoverServices(nil)
+        afterDelay(10.0) { [weak self] in
+            guard let self = self, self.pendingActivation else { return }
+            // Same as Android: a discovery that does not finish means the link is bad.
+            // Reconnect and try again after the next login (activationRequested stays set).
+            self.pendingActivation = false
+            self.activationRequested = true
+            self.recoverAndReconnect("service discovery callback timeout")
+        }
+    }
+
+    private func startActivationWrites() {
+        if maxActiveCandidatesMs.isEmpty {
+            let cloudExpireMs = materials.activeExpireTimeMs > 0 ? materials.activeExpireTimeMs : OttaiConstants.defaultActiveExpireMs
+            maxActiveCandidatesMs = OttaiConstants.activationMaxActiveCandidatesMs(cloudActiveExpireMs: cloudExpireMs)
+            maxActiveCandidateIndex = 0
+        }
+        trace("starting activation sequence attempt=%{public}d/%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, maxActiveCandidateIndex + 1, maxActiveCandidatesMs.count)
+        actStep = .rtc
+        writeRtc()
+    }
+
+    private func advanceActivation() {
+        switch actStep {
+        case .rtc: actStep = .maxActive; writeMaxActiveTime()
+        case .maxActive: actStep = .destruction; writeDestructionTime()
+        case .destruction: actStep = .command; writeActivateCmd()
+        case .command: actStep = .done; markActivationCommandSent()
+        default: break
+        }
+    }
+
+    private func writeRtc() {
+        let secs = Int32(truncatingIfNeeded: Int64(Date().timeIntervalSince1970))
+        if !writeChar(OttaiConstants.charCurrentTime, OttaiBleAuth.intToBytesLE(secs)) {
+            failActivation("RTC characteristic is unavailable")
+        }
+    }
+
+    private func writeMaxActiveTime() {
+        let cloudExpireMs = materials.activeExpireTimeMs > 0 ? materials.activeExpireTimeMs : OttaiConstants.defaultActiveExpireMs
+        let expireMs = maxActiveCandidatesMs.indices.contains(maxActiveCandidateIndex) ? maxActiveCandidatesMs[maxActiveCandidateIndex] : cloudExpireMs
+        maxActiveAttemptMs = expireMs
+        trace("maxActive attempt=%{public}d/%{public}d target=%{public}ds", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, maxActiveCandidateIndex + 1, maxActiveCandidatesMs.count, Int(expireMs / 1000))
+        guard let payload = OttaiCrypto.encryptPayload(longToBytesLE(expireMs / 1000), sessionKeyHex: sessionKeyHex) else {
+            failActivation("maxActive encryption failed"); return
+        }
+        if !writeChar(OttaiConstants.charMaxActiveTime, payload) {
+            trace("maxActive char absent — skipping to destruction", log: log, category: ConstantsLog.categoryCGMOttai, type: .error)
+            advanceActivation()
+        }
+    }
+
+    /// The sensor said no to this lifetime. Try the next shorter one on a new connection.
+    private func retryMaxActiveTime() -> Bool {
+        let nextIndex = maxActiveCandidateIndex + 1
+        guard maxActiveCandidatesMs.indices.contains(nextIndex) else { return false }
+        trace("maxActive rejected duration=%{public}ds; will reconnect and retry %{public}ds", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, Int(maxActiveAttemptMs / 1000), Int(maxActiveCandidatesMs[nextIndex] / 1000))
+        maxActiveCandidateIndex = nextIndex
+        maxActiveAttemptMs = 0
+        actStep = .none
+        activationRequested = true
+        afterDelay(0.2) { [weak self] in self?.disconnect() }
+        return true
+    }
+
+    private func markMaxActiveAccepted() {
+        guard maxActiveAttemptMs > 0 else { return }
+        // Save it now. The sensor accepted the value, even if the activate command fails later.
+        adoptActivatedMaxActive(maxActiveAttemptMs, "activation-accept")
+    }
+
+    private func writeDestructionTime() {
+        // retainTime is a short DURATION, not a date. Writing a date made the sensor drop the link.
+        let retainMs = materials.retainTimeMs > 0 ? materials.retainTimeMs : OttaiConstants.defaultRetainTimeMs
+        let payload = longToBytesLE(retainMs / 1000) + [0x04]
+        if !writeChar(OttaiConstants.charDestructive, payload) {
+            failActivation("destruction characteristic is unavailable")
+        }
+    }
+
+    private func writeActivateCmd() {
+        guard let cmd = OttaiCrypto.encryptActivateCmd([OttaiConstants.activateCmd], sessionKeyHex: sessionKeyHex) else {
+            failActivation("activation command encryption failed"); return
+        }
+        if !writeChar(OttaiConstants.charCommand, cmd) {
+            failActivation("activation command characteristic is unavailable")
+        }
+    }
+
+    private func markActivationCommandSent() {
+        activationCommandSentAtMs = nowMs()
+        maxActiveCandidatesMs = []
+        maxActiveCandidateIndex = 0
+        OttaiRegistry.setActivationAttempted(sensorId, true)
+        if materials.activeTimeMs <= 0 { setProvisionalActiveTime(activationCommandSentAtMs, "activation-command") }
+        reportSensorSessionIfNeeded()
+        trace("activation command sent; sensor accepted activation writes", log: log, category: ConstantsLog.categoryCGMOttai, type: .info)
+        // Check that the activation worked. Send nothing else in the meantime (only one
+        // Bluetooth operation at a time).
+        activationConfirmAttempt = 0
+        afterDelay(Self.postActivationConfirmDelay) { [weak self] in self?.activationConfirmTick() }
+    }
+
+    private func activationConfirmTick() {
+        if commandStatus == 3 { return }
+        if activationConfirmAttempt >= Self.postActivationConfirmMaxAttempts {
+            trace("activation confirmation read never landed after %{public}d attempts; awaiting the next poll or reconnect", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, activationConfirmAttempt)
+            return
+        }
+        activationConfirmAttempt += 1
+        readChar(OttaiConstants.charCommand)
+        afterDelay(Self.postActivationConfirmRetry) { [weak self] in self?.activationConfirmTick() }
+    }
+
+    private func adoptActivatedMaxActive(_ ms: Int64, _ source: String) {
+        if ms <= 0 || ms == activatedMaxActiveMs { return }
+        activatedMaxActiveMs = ms
+        OttaiRegistry.saveAcceptedMaxActive(sensorId, ms)
+        trace("activated lifetime = %{public}dd source=%{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, Int(ms / 86_400_000), source)
+    }
+
+    private func failActivation(_ reason: String) {
+        trace("activation failed: %{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, reason)
+        actStep = .none
+        pendingActivation = false
+        maxActiveCandidatesMs = []
+        maxActiveCandidateIndex = 0
+    }
+
+    // MARK: - Bluetooth helpers
+
+    private func readLiveGlucose(_ reason: String) {
+        guard !sessionKeyHex.isEmpty else { return }
+        trace("read live glucose reason=%{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, reason)
+        liveReadInFlight = true
+        readChar(OttaiConstants.charGlucoseLive)
+    }
+
+    private func readChar(_ characteristic: String) {
+        guard let ch = char(characteristic) else {
+            trace("read skipped: characteristic %{public}@ not discovered", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, String(characteristic.prefix(8)))
+            return
+        }
+        readValueForCharacteristic(for: ch)
+    }
+
+    @discardableResult
+    private func writeChar(_ characteristic: String, _ value: [UInt8]) -> Bool {
+        guard let ch = char(characteristic) else {
+            trace("write skipped: characteristic %{public}@ not discovered", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, String(characteristic.prefix(8)))
+            return false
+        }
+        return writeDataToPeripheral(data: Data(value), characteristicToWriteTo: ch, type: .withResponse)
+    }
+
+    override func prepareForRelease() {
+        workQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.livePollTimer?.cancel()
+            self.livePollTimer = nil
+            self.clearPendingHistoryRange()
+        }
+        super.prepareForRelease()
+    }
+
+    // MARK: - small helpers
+
+    private func nowMs() -> Int64 { Int64(Date().timeIntervalSince1970 * 1000) }
+    private func shortLE(_ v: Int) -> [UInt8] { [UInt8(v & 0xFF), UInt8((v >> 8) & 0xFF)] }
+    private func longToBytesLE(_ v: Int64) -> [UInt8] {
+        var out = [UInt8](repeating: 0, count: 8)
+        for i in 0 ..< 8 { out[i] = UInt8((v >> (i * 8)) & 0xFF) }
+        return out
+    }
+}
+
+private extension CBUUID {
+    /// The full 128-bit UUID as lower-case text, so short (16-bit) and long forms compare equal.
+    var full128: String {
+        let s = uuidString.lowercased()
+        switch s.count {
+        case 4: return "0000\(s)-0000-1000-8000-00805f9b34fb"
+        case 8: return "\(s)-0000-1000-8000-00805f9b34fb"
+        default: return s
+        }
+    }
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/CGMOttaiTransmitter.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/CGMOttaiTransmitter.swift
@@ -278,12 +278,16 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
     var sensorCommandStatus: Int { commandStatus }
 
     /// Same as `requestForceActivation()` in JugglucoNG: the user's Activate button is
-    /// always a "force" request. It also runs on a sensor that is already active or has
-    /// ended, so the user can try to start it again (for example to extend the lifetime).
-    /// The warning is shown by the settings screen before this is called.
+    /// always a "force" request. It also runs on a sensor that is already active, so the
+    /// user can try to extend its lifetime (the settings screen warns first). A sensor that
+    /// has ended is refused: the sensor rejected every such restart in the logs we have.
     func startSensor(sensorCode: String?, startDate: Date) {
         workQueue.async { [weak self] in
             guard let self = self else { return }
+            if self.commandStatus >= 4 {
+                trace("activation refused — the sensor has ended (cmd=%{public}d) and cannot be started again", log: self.log, category: ConstantsLog.categoryCGMOttai, type: .error, self.commandStatus)
+                return
+            }
             if self.effectiveActiveTimeMs() > 0 || self.activationCommandSentAtMs > 0 {
                 trace("FORCE activation (bypassing already-started guard)", log: self.log, category: ConstantsLog.categoryCGMOttai, type: .info)
             }
@@ -739,22 +743,11 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
             if previous != 3 { startStreamingAfterCommandStatus() }
             return
         }
-        // 4 or more = the sensor has ended. Normally we do not try to restart it: we just read
-        // the live buffer once, to learn the last dataNo, and fetch the history up to it. But
-        // the same "invalid handle" quirk that sometimes rejects a maxActiveTime write during a
-        // normal activation can also flip an already-activated sensor back to "ended" (seen live:
-        // a sensor activated cleanly, then a repeated activation request failed the same write
-        // and the sensor reported ended 44 seconds later). While we are still inside the
-        // lifetime we told the sensor to run for, one recovery attempt is worth it before we
-        // give up on it as genuinely finished.
+        // 4 or more = the sensor has ended. We do not try to restart it: the sensor refused
+        // every restart in the logs we have (the lifetime write always fails). We only read
+        // the live buffer once, to learn the last dataNo, and fetch the history up to it. No
+        // glucose is shown from this read. The user needs a new sensor.
         livePollTimer?.cancel(); livePollTimer = nil
-        if OttaiConstants.shouldAttemptEndedSensorRecovery(commandStatus: status, activeTimeMs: warmupAnchorMs(), nowMs: nowMs()),
-           actStep == .none, !pendingActivation {
-            trace("sensor ended cmd=%{public}d but still within its lifetime — attempting recovery", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, status)
-            activationRequested = false
-            afterDelay(0.25) { [weak self] in self?.requestActivationWithRediscovery() }
-            return
-        }
         trace("sensor ended cmd=%{public}d; no lifetime write will be attempted automatically", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, status)
         afterDelay(0.5) { [weak self] in
             guard let self = self, self.commandStatus >= 4 else { return }

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/CGMOttaiTransmitter.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/CGMOttaiTransmitter.swift
@@ -28,8 +28,10 @@
 //  Different on purpose (xDrip has no Room database):
 //    - the first readings after connect are collected and given to xDrip ONCE,
 //      newest first, so its 5-minute filter can fill the chart from empty
-//    - the first backfill is a fixed 24 h window (not a database diff), and
-//      there is no list of missing windows saved between sessions
+//    - after a start, the first backfill asks only for the records after the last
+//      one xDrip already has (a saved "delivered" mark; the Kotlin uses
+//      previousDataNo the same way). Only a sensor we know nothing about gets the
+//      last 24 h. Missing windows are not saved between sessions
 //    - NFC wake, connection priority and the outage probe do not exist on iOS
 //
 //  Threads: everything in this class runs on `workQueue` (one at a time).
@@ -144,6 +146,13 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
     // MARK: - state that stays across reconnects
 
     private var lastDataNo = 0
+    /// The last dataNo that xDrip has stored, with no older records still on the way.
+    /// Saved, so the next start asks the sensor only for what came after it. It stays
+    /// behind `lastDataNo` while a gap fill is planned or history blocks are still coming.
+    private var deliveredDataNo = 0
+    /// True from the moment a gap fill after a live reading is planned until it has been
+    /// sent (or found unnecessary). See `noteDelivered(upTo:)`.
+    private var historyGapPending = false
     // The record size (8 or 9 bytes) learned from this sensor. 0 until a big enough
     // packet has shown it. A small live packet (one record) cannot tell the two sizes
     // apart, so it must not choose. See OttaiParser.decisiveRecordSize.
@@ -218,6 +227,7 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
 
         // load the saved state (restoreFromPersistence in the Kotlin)
         self.lastDataNo = OttaiRegistry.loadLastDataNo(canonical)
+        self.deliveredDataNo = OttaiRegistry.loadDeliveredDataNo(canonical)
         self.learnedRecordSize = OttaiRegistry.loadRecordSize(canonical)
         self.activatedMaxActiveMs = OttaiRegistry.loadAcceptedMaxActive(canonical)
         if materials.activeTimeMs > 0 {
@@ -328,6 +338,7 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
         expectedRediscoveryCount = 0
         liveReadInFlight = false
         lastVerifyFailed = false
+        historyGapPending = false
         livePollTimer?.cancel()
         livePollTimer = nil
         clearPendingHistoryRange()
@@ -784,9 +795,10 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
             readLiveGlucose("initial-history-probe")
             return
         }
-        initialHistoryRequested = true
-        let start = max(0, lastDataNo - Self.initialBackfillRecords)
-        _ = requestHistoryRange("initial", start: start, count: lastDataNo - start)
+        // Without a live reading we only know the last record we saw. Ask for the part
+        // of it xDrip never got; the live path asks for anything newer later.
+        guard let range = Self.startupBackfillRange(liveDataNo: lastDataNo + 1, lastDataNo: lastDataNo, deliveredDataNo: deliveredDataNo) else { return }
+        if requestHistoryRange("initial", start: range.start, count: range.count) { initialHistoryRequested = true }
     }
 
     // MARK: - live and history packets
@@ -858,10 +870,15 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
             let liveDataNo = lastDataNo
             let previousForHistory = previousDataNoForHistory(previousDataNo, liveDataNo)
             if !initialFlushDone && !initialHistoryRequested && liveDataNo > 0 {
-                initialHistoryRequested = true
-                let start = max(0, liveDataNo - Self.initialBackfillRecords)
-                _ = requestHistoryRange("room-backfill", start: start, count: liveDataNo - start)
+                // First live reading after a start: ask only for what xDrip is missing.
+                if let range = Self.startupBackfillRange(liveDataNo: liveDataNo, lastDataNo: previousForHistory, deliveredDataNo: deliveredDataNo) {
+                    if requestHistoryRange("room-backfill", start: range.start, count: range.count) { initialHistoryRequested = true }
+                } else {
+                    initialHistoryRequested = true
+                    trace("skip history reason=room-backfill previous=%{public}d delivered=%{public}d live=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, previousForHistory, deliveredDataNo, liveDataNo)
+                }
             } else if previousForHistory < 0 || liveDataNo - previousForHistory - 1 > 0 {
+                historyGapPending = true
                 afterDelay(1.5) { [weak self] in self?.requestHistoryAfterLive(previousForHistory, liveDataNo) }
             }
         } else {
@@ -889,6 +906,7 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
             trace("ended live buffer has no records", log: log, category: ConstantsLog.categoryCGMOttai, type: .info)
             return
         }
+        let previousDataNo = lastDataNo
         noteSeenDataNo(latest.dataNo)
         // Only a confirmed activation time may date this backfill. A guessed time
         // would give wrong dates.
@@ -898,11 +916,14 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
         trace("ended live buffer indexed dataNo=%{public}d; glucose suppressed", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, latest.dataNo)
         afterDelay(4.5) { [weak self] in
             guard let self = self, self.commandStatus >= 4, self.phase == .streaming, !self.sessionKeyHex.isEmpty else { return }
-            let end = self.lastDataNo + 1
-            guard end > 0, !self.initialHistoryRequested else { return }
-            self.initialHistoryRequested = true
-            let start = max(0, end - Self.initialBackfillRecords)
-            _ = self.requestHistoryRange("ended-backfill", start: start, count: end - start)
+            guard !self.initialHistoryRequested else { return }
+            // Include the last record itself: an ended sensor sends no live reading that would bring it.
+            guard let range = Self.startupBackfillRange(liveDataNo: self.lastDataNo + 1, lastDataNo: previousDataNo, deliveredDataNo: self.deliveredDataNo) else {
+                self.initialHistoryRequested = true
+                trace("skip history reason=ended-backfill previous=%{public}d delivered=%{public}d last=%{public}d", log: self.log, category: ConstantsLog.categoryCGMOttai, type: .info, previousDataNo, self.deliveredDataNo, self.lastDataNo)
+                return
+            }
+            if self.requestHistoryRange("ended-backfill", start: range.start, count: range.count) { self.initialHistoryRequested = true }
         }
     }
 
@@ -969,7 +990,7 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
         }
         rememberAcceptedReading(r, mmol: mmol, sampleMs: sampleMs)
         if advancesDataNo { noteSeenDataNo(r.record.dataNo) }
-        trace("BG dataNo=%{public}d mmol=%{public}.2f mgdl=%{public}.0f raw=%{public}d T=%{public}.1f", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, r.record.dataNo, Double(mmol), mgdl, r.record.rawCurrent, r.record.temperatureC)
+        trace("BG dataNo=%{public}d mmol=%{public}@ mgdl=%{public}@ raw=%{public}d T=%{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, r.record.dataNo, String(format: "%.2f", Double(mmol)), String(format: "%.0f", mgdl), r.record.rawCurrent, String(format: "%.1f", r.record.temperatureC))
         // Like the Kotlin: history is always kept. A live reading is kept only when
         // it is fresh and newer than the last one. An old record that comes from the
         // live characteristic is never shown as the current value.
@@ -985,7 +1006,7 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
 
     private func rejectReading(_ r: OttaiReading, mmol: Float, live: Bool, reason: String) -> (dataNo: Int, glucose: GlucoseData)? {
         rememberRejectedReading(r, mmol: mmol)
-        trace("%{public}@ BG rejected reason=%{public}@ dataNo=%{public}d mmol=%{public}.2f raw=%{public}d T=%{public}.1f", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, live ? "live" : "history", reason, r.record.dataNo, Double(mmol), r.record.rawCurrent, r.record.temperatureC)
+        trace("%{public}@ BG rejected reason=%{public}@ dataNo=%{public}d mmol=%{public}@ raw=%{public}d T=%{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, live ? "live" : "history", reason, r.record.dataNo, String(format: "%.2f", Double(mmol)), r.record.rawCurrent, String(format: "%.1f", r.record.temperatureC))
         return nil
     }
 
@@ -1039,6 +1060,10 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
         trace("reset ahead lastDataNo previous=%{public}d acceptedLive=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, lastDataNo, acceptedDataNo)
         lastDataNo = acceptedDataNo - 1
         OttaiRegistry.saveLastDataNo(sensorId, lastDataNo)
+        if deliveredDataNo > lastDataNo {
+            deliveredDataNo = 0
+            OttaiRegistry.saveDeliveredDataNo(sensorId, 0)
+        }
     }
 
     /// The highest dataNo we accept. Only a real activation time (from the cloud
@@ -1300,7 +1325,7 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
             let gen = flushGeneration
             workQueue.asyncAfter(deadline: .now() + 5.0) { [weak self] in self?.flushInitialBufferIfIdle(gen) }
         } else {
-            deliver(emitted.map { $0.glucose }.sorted { $0.timeStamp > $1.timeStamp })
+            deliver(emitted.map { $0.glucose }.sorted { $0.timeStamp > $1.timeStamp }, upTo: emitted.map { $0.dataNo }.max() ?? 0)
         }
     }
 
@@ -1308,20 +1333,35 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
         guard !initialFlushDone, flushGeneration == generation else { return }
         initialFlushDone = true
         let arr = Array(initialBuffer.values).sorted { $0.timeStamp > $1.timeStamp }
+        let newestDataNo = initialBuffer.keys.max() ?? 0
         initialBuffer.removeAll()
         guard !arr.isEmpty else { return }
         trace("flushing initial backfill count=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, arr.count)
-        deliver(arr)
+        deliver(arr, upTo: newestDataNo)
     }
 
-    private func deliver(_ readings: [GlucoseData]) {
+    /// Gives the readings to xDrip on the main queue. `newestDataNo` is the highest
+    /// dataNo in the batch. Once xDrip has stored the batch, it can become the saved
+    /// "delivered" mark (see `noteDelivered(upTo:)`).
+    private func deliver(_ readings: [GlucoseData], upTo newestDataNo: Int) {
         guard !readings.isEmpty else { return }
         let sensorAge = sensorAgeTimeInterval()
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             var arr = readings
             self.cgmTransmitterDelegate?.cgmTransmitterInfoReceived(glucoseData: &arr, transmitterBatteryInfo: nil, sensorAge: sensorAge)
+            self.workQueue.async { [weak self] in self?.noteDelivered(upTo: newestDataNo) }
         }
+    }
+
+    /// Moves the saved "delivered" mark forward. Not while older records are still on
+    /// the way (a gap fill is planned or history blocks are still coming): the next
+    /// start would then not see the hole.
+    private func noteDelivered(upTo dataNo: Int) {
+        guard dataNo > deliveredDataNo else { return }
+        guard !historyGapPending, activeHistoryEndExclusive <= 0, pendingHistoryReason == nil else { return }
+        deliveredDataNo = dataNo
+        OttaiRegistry.saveDeliveredDataNo(sensorId, dataNo)
     }
 
     // MARK: - cgm-info packets
@@ -1377,6 +1417,24 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
 
     // MARK: - history requests, block chain and watchdog
 
+    /// What to ask the sensor for right after a start. `liveDataNo` is the record that
+    /// just came in (the range ends before it). `lastDataNo` is the last record we saw
+    /// before it (0 or less = nothing known). `deliveredDataNo` is the saved mark of what
+    /// xDrip already has. Nil when nothing is missing. The Kotlin uses previousDataNo the
+    /// same way; the delivered mark also covers readings that were still in the start
+    /// buffer when the app died. A sensor we know nothing about gets the last 24 h. That
+    /// is also the most one start ever asks for.
+    static func startupBackfillRange(liveDataNo: Int, lastDataNo: Int, deliveredDataNo: Int) -> (start: Int, count: Int)? {
+        guard liveDataNo > 0 else { return nil }
+        let oldest = max(0, liveDataNo - initialBackfillRecords)
+        guard lastDataNo > 0 else { return (oldest, liveDataNo - oldest) }
+        var basis = lastDataNo
+        if deliveredDataNo > 0 && deliveredDataNo < basis { basis = deliveredDataNo }
+        let start = max(basis + 1, oldest)
+        let count = liveDataNo - start
+        return count > 0 ? (start, count) : nil
+    }
+
     @discardableResult
     private func requestRecentHistory(_ reason: String) -> Bool {
         let endExclusive = lastDataNo
@@ -1386,6 +1444,7 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
     }
 
     private func requestHistoryAfterLive(_ previousDataNo: Int, _ liveDataNo: Int) {
+        historyGapPending = false
         guard liveDataNo > 0 else { return }
         let missingBeforeLive = liveDataNo - previousDataNo - 1
         if previousDataNo >= 0 && missingBeforeLive <= 0 { return }

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/CGMOttaiTransmitter.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/CGMOttaiTransmitter.swift
@@ -716,7 +716,13 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
         if status < 0 { return }
         if OttaiConstants.commandNeedsActivation(status) {
             livePollTimer?.cancel(); livePollTimer = nil
-            if OttaiConstants.shouldStartActivation(commandStatus: status, explicitlyRequested: activationRequested),
+            // activationRequested is only in memory. If this object is destroyed and created
+            // again during a retry (the app came to the foreground, or a reconnect came in
+            // between), the flag is lost while the user's request is not finished. The saved
+            // flag "activation was requested for this sensor" survives that, so a new object
+            // still finishes the job instead of waiting for activation forever.
+            let explicitlyRequested = activationRequested || OttaiRegistry.loadActivationAttempted(sensorId)
+            if OttaiConstants.shouldStartActivation(commandStatus: status, explicitlyRequested: explicitlyRequested),
                actStep == .none, !pendingActivation {
                 activationRequested = false
                 trace("sensor command status=%{public}d and user requested activation; starting activation sequence", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, status)
@@ -733,10 +739,22 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
             if previous != 3 { startStreamingAfterCommandStatus() }
             return
         }
-        // 4 or more = the sensor has ended. We do not try to restart it. We read the
-        // live buffer once, only to learn the last dataNo, and then fetch the history
-        // up to it. No glucose is published from this read.
+        // 4 or more = the sensor has ended. Normally we do not try to restart it: we just read
+        // the live buffer once, to learn the last dataNo, and fetch the history up to it. But
+        // the same "invalid handle" quirk that sometimes rejects a maxActiveTime write during a
+        // normal activation can also flip an already-activated sensor back to "ended" (seen live:
+        // a sensor activated cleanly, then a repeated activation request failed the same write
+        // and the sensor reported ended 44 seconds later). While we are still inside the
+        // lifetime we told the sensor to run for, one recovery attempt is worth it before we
+        // give up on it as genuinely finished.
         livePollTimer?.cancel(); livePollTimer = nil
+        if OttaiConstants.shouldAttemptEndedSensorRecovery(commandStatus: status, activeTimeMs: warmupAnchorMs(), nowMs: nowMs()),
+           actStep == .none, !pendingActivation {
+            trace("sensor ended cmd=%{public}d but still within its lifetime — attempting recovery", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, status)
+            activationRequested = false
+            afterDelay(0.25) { [weak self] in self?.requestActivationWithRediscovery() }
+            return
+        }
         trace("sensor ended cmd=%{public}d; no lifetime write will be attempted automatically", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, status)
         afterDelay(0.5) { [weak self] in
             guard let self = self, self.commandStatus >= 4 else { return }

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/CGMOttaiTransmitter.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/CGMOttaiTransmitter.swift
@@ -144,6 +144,12 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
     // MARK: - state that stays across reconnects
 
     private var lastDataNo = 0
+    // The record size (8 or 9 bytes) learned from this sensor. 0 until a big enough
+    // packet has shown it. A small live packet (one record) cannot tell the two sizes
+    // apart, so it must not choose. See OttaiParser.decisiveRecordSize.
+    private var learnedRecordSize = 0
+    // Log only once while packets keep disagreeing with the learned size.
+    private var recordSizeDisagreementLogged = false
     private var lastGlucoseAtMs: Int64 = 0
     private var lastLiveFrameAtMs: Int64 = 0
     private var lastLiveNotifyAtMs: Int64 = 0
@@ -212,6 +218,7 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
 
         // load the saved state (restoreFromPersistence in the Kotlin)
         self.lastDataNo = OttaiRegistry.loadLastDataNo(canonical)
+        self.learnedRecordSize = OttaiRegistry.loadRecordSize(canonical)
         self.activatedMaxActiveMs = OttaiRegistry.loadAcceptedMaxActive(canonical)
         if materials.activeTimeMs > 0 {
             OttaiRegistry.saveProvisionalActiveTime(canonical, 0)
@@ -785,7 +792,8 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
             trace("%{public}@ decrypt failed len=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, kind, cipher.count)
             return
         }
-        let records = OttaiParser.frameRecords(payload, deviceVersion: materials.deviceVersion)
+        learnRecordSize(payload)
+        let records = OttaiParser.frameRecords(payload, deviceVersion: materials.deviceVersion, learned: heldRecordSize())
         if records.isEmpty {
             trace("%{public}@ no records payloadLen=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, kind, payload.count)
             if live {
@@ -864,7 +872,7 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
     /// the live buffer and fetch history up to it. No glucose is published.
     private func handleEndedLiveBuffer(_ cipher: [UInt8]) {
         guard let payload = OttaiCrypto.decryptPayload(cipher, sessionKeyHex: sessionKeyHex) else { return }
-        let latest = OttaiParser.frameRecords(payload, deviceVersion: materials.deviceVersion)
+        let latest = OttaiParser.frameRecords(payload, deviceVersion: materials.deviceVersion, learned: heldRecordSize())
             .map(OttaiParser.parseRecord).max { $0.dataNo < $1.dataNo }
         guard let latest = latest else {
             trace("ended live buffer has no records", log: log, category: ConstantsLog.categoryCGMOttai, type: .info)
@@ -885,6 +893,35 @@ final class CGMOttaiTransmitter: BluetoothTransmitter, CGMTransmitter {
             let start = max(0, end - Self.initialBackfillRecords)
             _ = self.requestHistoryRange("ended-backfill", start: start, count: end - start)
         }
+    }
+
+    /// The learned layout to frame with, or nil while nothing has proved one.
+    private func heldRecordSize() -> Int? { learnedRecordSize > 0 ? learnedRecordSize : nil }
+
+    /// Learn the record size from a packet that is big enough to prove it. If a packet
+    /// would choose a different size, log it once, with the counts for both sizes, so the
+    /// log shows why. Only once, so a strange sensor cannot fill the log.
+    private func learnRecordSize(_ payload: [UInt8]) {
+        if let decisive = OttaiParser.decisiveRecordSize(payload, deviceVersion: materials.deviceVersion) {
+            recordSizeDisagreementLogged = false
+            if decisive != learnedRecordSize {
+                let previous = learnedRecordSize
+                learnedRecordSize = decisive
+                OttaiRegistry.saveRecordSize(sensorId, decisive)
+                trace("record size learned=%{public}d previous=%{public}d len=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, decisive, previous, payload.count)
+            }
+            return
+        }
+        guard learnedRecordSize > 0 else { return }
+        let wouldChoose = OttaiParser.chooseRecordSize(payload, deviceVersion: materials.deviceVersion)
+        if wouldChoose == learnedRecordSize {
+            recordSizeDisagreementLogged = false
+            return
+        }
+        if recordSizeDisagreementLogged { return }
+        recordSizeDisagreementLogged = true
+        let (nine, eight) = OttaiParser.recordSizeEvidence(payload)
+        trace("record size held=%{public}d payloadWould=%{public}d nine=%{public}d eight=%{public}d len=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, learnedRecordSize, wouldChoose, nine, eight, payload.count)
     }
 
     // MARK: - one reading and all its checks (same order as the Kotlin)

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiBleAuth.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiBleAuth.swift
@@ -1,0 +1,181 @@
+//
+//  OttaiBleAuth.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — the math for the Bluetooth login ("Auth V2").
+//  It uses secp256r1 ECDH key exchange, SHA-256 signatures, and a small rule to
+//  pick the session key out of the shared secret.
+//
+//  This is a Swift copy of OttaiBleAuth.kt from JugglucoNG. No Bluetooth here.
+//
+
+import Foundation
+import CryptoKit
+
+enum OttaiBleAuth {
+
+    /// Size of one number on the P-256 curve, in bytes.
+    static let fieldLen = 32
+
+    // MARK: - key pair
+
+    /// A new P-256 key pair for one login.
+    struct KeyPair {
+        let privateKey: P256.KeyAgreement.PrivateKey
+        /// X of our public key, 32 bytes, big-endian.
+        let pubX: [UInt8]
+        /// Y of our public key, 32 bytes, big-endian.
+        let pubY: [UInt8]
+    }
+
+    /// Make a new secp256r1 key pair.
+    static func generateKeyPair() -> KeyPair {
+        let priv = P256.KeyAgreement.PrivateKey()
+        let raw = [UInt8](priv.publicKey.rawRepresentation) // 64 bytes: X(32) || Y(32)
+        let x = Array(raw[0 ..< 32])
+        let y = Array(raw[32 ..< 64])
+        return KeyPair(privateKey: priv, pubX: x, pubY: y)
+    }
+
+    // MARK: - little-endian helpers
+
+    /// Read a 32-bit number from the first 4 bytes, little-endian.
+    static func bytesToIntLE(_ b: [UInt8]) -> Int32 {
+        precondition(b.count >= 4, "need >=4 bytes")
+        return Int32(bitPattern:
+            UInt32(b[0]) |
+            (UInt32(b[1]) << 8) |
+            (UInt32(b[2]) << 16) |
+            (UInt32(b[3]) << 24))
+    }
+
+    /// Write a 32-bit number as 4 bytes, little-endian.
+    static func intToBytesLE(_ i: Int32) -> [UInt8] {
+        let u = UInt32(bitPattern: i)
+        return [
+            UInt8(u & 0xFF),
+            UInt8((u >> 8) & 0xFF),
+            UInt8((u >> 16) & 0xFF),
+            UInt8((u >> 24) & 0xFF),
+        ]
+    }
+
+    /// Make the 3-byte "app time" from the sensor's time bytes.
+    /// Read the bytes as one big-endian number, add 1, and keep bits 24..8.
+    static func appTime3(_ deviceTimeBytes: [UInt8]) -> [UInt8] {
+        // big-endian parse of the raw bytes, +1
+        var value: UInt64 = 0
+        for b in deviceTimeBytes { value = (value << 8) | UInt64(b) }
+        value = value &+ 1
+        return [
+            UInt8((value >> 24) & 0xFF),
+            UInt8((value >> 16) & 0xFF),
+            UInt8((value >> 8) & 0xFF),
+        ]
+    }
+
+    /// The value we write to characteristic 1756ef6e:
+    /// `index(1 byte) || time3(3 bytes) || pubX || pubY`.
+    static func appAuthParameter(selectedIndex: Int, time3: [UInt8], pubX: [UInt8], pubY: [UInt8]) -> [UInt8] {
+        [UInt8(selectedIndex & 0xFF)] + time3 + pubX + pubY
+    }
+
+    // MARK: - signatures
+
+    /// Signature = SHA256( authKey || mac || pubX || pubY || time3 ).
+    /// We write ours to characteristic 785022c6, and we check the sensor's with it too.
+    static func authSign(authKey: [UInt8], mac: [UInt8], pubX: [UInt8], pubY: [UInt8], time3: [UInt8]) -> [UInt8] {
+        var hasher = SHA256()
+        hasher.update(data: Data(authKey))
+        hasher.update(data: Data(mac))
+        hasher.update(data: Data(pubX))
+        hasher.update(data: Data(pubY))
+        hasher.update(data: Data(time3))
+        return Array(hasher.finalize())
+    }
+
+    /// Same as authSign, but the key and the mac are hex text.
+    static func authSignHex(authKeyHex: String, macHex: String, pubX: [UInt8], pubY: [UInt8], time3: [UInt8]) -> [UInt8] {
+        authSign(authKey: OttaiCrypto.hexToBytes(authKeyHex),
+                 mac: OttaiCrypto.hexToBytes(macHex),
+                 pubX: pubX, pubY: pubY, time3: time3)
+    }
+
+    /// Check the signature the sensor sent (characteristic 785022c6).
+    static func verifyDeviceSign(
+        deviceSign: [UInt8],
+        authKeyHex: String,
+        macHex: String,
+        devPubX: [UInt8],
+        devPubY: [UInt8],
+        devTime: [UInt8]
+    ) -> Bool {
+        let expect = authSign(
+            authKey: OttaiCrypto.hexToBytes(authKeyHex),
+            mac: OttaiCrypto.hexToBytes(macHex),
+            pubX: devPubX, pubY: devPubY, time3: devTime
+        )
+        return expect == deviceSign
+    }
+
+    // MARK: - ECDH session key
+
+    /// Make the session key. We combine our private key with the sensor's public
+    /// key (ECDH), turn the shared X into hex, and pick characters from it.
+    /// Returns nil if the sensor key is bad or the result is too short.
+    static func deriveSessionKey(devPubXHex: String, devPubYHex: String, ourPrivate: P256.KeyAgreement.PrivateKey) -> String? {
+        let x = OttaiCrypto.hexToBytes(devPubXHex)
+        let y = OttaiCrypto.hexToBytes(devPubYHex)
+        return deriveSessionKey(devPubX: x, devPubY: y, ourPrivate: ourPrivate)
+    }
+
+    static func deriveSessionKey(devPubX: [UInt8], devPubY: [UInt8], ourPrivate: P256.KeyAgreement.PrivateKey) -> String? {
+        let xField = fixedFieldBytes(devPubX, fieldLen: fieldLen)
+        let yField = fixedFieldBytes(devPubY, fieldLen: fieldLen)
+        // A public key without the 0x04 prefix is just X(32) || Y(32).
+        guard let devPub = try? P256.KeyAgreement.PublicKey(rawRepresentation: Data(xField + yField)) else {
+            return nil
+        }
+        guard let shared = try? ourPrivate.sharedSecretFromKeyAgreement(with: devPub) else {
+            return nil
+        }
+        // The shared secret is the full 32-byte X, with leading zeros kept.
+        let sharedBytes = shared.withUnsafeBytes { [UInt8]($0) }
+        let sharedHex = OttaiCrypto.bytesToHex(fixedFieldBytes(sharedBytes, fieldLen: fieldLen))
+        return sessionKeyPick(sharedHex)
+    }
+
+    /// Make the value exactly [fieldLen] bytes: add zeros at the front, never cut.
+    static func fixedFieldBytes(_ value: [UInt8], fieldLen: Int) -> [UInt8] {
+        if value.count == fieldLen { return value }
+        var out = [UInt8](repeating: 0, count: fieldLen)
+        if value.count < fieldLen {
+            for i in 0 ..< value.count { out[fieldLen - value.count + i] = value[i] }
+        } else {
+            // too long means an extra sign byte at the front: keep the last bytes
+            for i in 0 ..< fieldLen { out[i] = value[value.count - fieldLen + i] }
+        }
+        return out
+    }
+
+    /// Pick the session key characters from the shared secret hex.
+    /// Start at position 2, take one character, then move +1, +3, +1, +3 ...
+    /// (positions 2,3,6,7,10,11,...). The result must be at least 32 characters.
+    static func sessionKeyPick(_ sharedHex: String) -> String? {
+        if sharedHex.isEmpty { return nil }
+        let chars = Array(sharedHex)
+        var out = String()
+        var pos = 2
+        var toggle = 1
+        var i = 2
+        while i < chars.count {
+            if pos < chars.count {
+                out.append(chars[pos])
+                pos += (toggle != 0) ? 1 : 3
+                toggle ^= 1
+            }
+            i += 1
+        }
+        return out.count >= 32 ? out : nil
+    }
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiCloudClient.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiCloudClient.swift
@@ -1,0 +1,772 @@
+//
+//  OttaiCloudClient.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — talks to the cloud (login, check and bind a sensor,
+//  cgmAuth, unbind, decrypt the sensor keys). Works with all three servers:
+//  China (api.ottai.com, phone + SMS), Global (seas.ottai.com), Syai
+//  (api.syai.com), and also the website API for email login and sign-up.
+//
+//  This is a Swift copy of OttaiCloudClient.kt from JugglucoNG. The HTTP calls
+//  wait for the answer, so call them from a background queue, never from the
+//  main thread.
+//
+
+import CryptoKit
+import Foundation
+
+enum OttaiCloudClient {
+
+    // The secret used to sign requests. The old endpoints and cgmAuth use MD5.
+    private static let seed = "dy7234hbnrnfh7q89eru8ybfn899"
+    private static let watchAppName = "ottai-watch"
+    private static let watchPkg = "com.ottai.tag.watch"
+    private static let phoneAppName = "ottai"
+    private static let phonePkg = "com.ottai.tag"
+    private static let timeoutMs = 30_000
+    private static let temporaryUnbindDelayMs: UInt32 = 2_000
+
+    // Error codes from the server that the caller must handle.
+    static let bizAlreadyBinding = "AppUser_AlreadyBinding"
+    static let bizOutOfProduceTime = "AppDevice_OutOfProduceTime"
+    static let bizUpgradeVersion = "AppDevice_Upgrade_Version"
+    static let bizEndUsing = "AppDevice_EndUsing"
+
+    struct CloudFailure { let text: String; var code: String = "" }
+
+    /// Why the last call failed (no secrets in it). Nil after a call that worked.
+    static var lastFailure: CloudFailure?
+    static var lastError: String { lastFailure?.text ?? "" }
+
+    struct LoginResult {
+        let userId: String
+        let accessToken: String
+        let glucoseSecretKey: String
+        var ok: Bool { !accessToken.isEmpty && !glucoseSecretKey.isEmpty }
+    }
+
+    struct DeviceResp {
+        var mac: String
+        var keyA: String
+        var method: String
+        var coefficient: String
+        var produceTime: Int64
+        var methodUpdateTime: Int64
+        var coeffUpdateTime: Int64
+        var activeTime: Int64
+        var activeExpireTime: Int64  // sensor lifetime in ms
+        var preheatPeriodTime: Int64
+        var retainTime: Int64        // "destruction" time in ms
+        var deviceVersion: String
+        var deviceId: Int
+    }
+
+    struct DeviceValidation {
+        let device: DeviceResp
+        /// New China sensors answer the V3 check with info only. keyA comes later from bindV3.
+        let requiresV3Bind: Bool
+    }
+
+    struct DeviceSummary {
+        let mac: String
+        let serialNo: String
+        let deviceType: String
+        let deviceVersion: String
+        let bindTime: Int64
+        let unbindTime: Int64
+        var isActive: Bool { unbindTime <= 0 }
+    }
+
+    struct V3AuthMaterial {
+        let authHost: String
+        let authFlag: String
+        let keyB: String
+        let cf: String
+        var ok: Bool { !authHost.isEmpty && !authFlag.isEmpty }
+    }
+
+    // MARK: - identity / signature
+
+    private struct ApiIdentity {
+        let appName: String
+        let packageName: String
+        func deviceId(_ value: String) -> String { "\(appName):a:\(value)" }
+    }
+
+    private static func sessionIdentity(_ profile: OttaiRegistry.SessionProfile) -> ApiIdentity {
+        profile == .cnPhone ? ApiIdentity(appName: phoneAppName, packageName: phonePkg)
+                            : ApiIdentity(appName: watchAppName, packageName: watchPkg)
+    }
+
+    private static func md5Hex(_ s: String) -> String {
+        // The cloud signs with MD5. CryptoKit returns a digest sequence; keep the previous
+        // lowercase hex string format.
+        Insecure.MD5.hash(data: Data(s.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func signForProfile(_ profile: OttaiRegistry.SessionProfile, deviceId: String, ts: Int64, _ args: String...) -> String {
+        let identity = sessionIdentity(profile)
+        return md5Hex(identity.appName + identity.deviceId(deviceId) + String(ts) + args.joined() + seed)
+    }
+
+    static func cgmAuthVerifySign(_ profile: OttaiRegistry.SessionProfile, deviceId: String, timestampMillis: Int64, mac: String, paramStr: String, shaInfo: String) -> String {
+        let identity = sessionIdentity(profile)
+        return md5Hex(identity.appName + identity.deviceId(deviceId) + mac.uppercased() + paramStr.uppercased() + shaInfo.uppercased() + String(timestampMillis) + seed)
+    }
+
+    private static func activeProfile(_ apiBase: String) -> OttaiRegistry.SessionProfile {
+        apiBase == OttaiConstants.apiBase ? OttaiRegistry.loadSessionProfile() : .watch
+    }
+
+    private static func requestDeviceId(_ profile: OttaiRegistry.SessionProfile) -> String {
+        profile == .cnPhone ? OttaiRegistry.loadCnHeaderDeviceId() : OttaiRegistry.loadOrCreateDeviceId()
+    }
+
+    private static func headers(ts: Int64, apiBase: String, authorizationOverride: String? = nil, profileOverride: OttaiRegistry.SessionProfile? = nil) -> [String: String] {
+        let token = authorizationOverride ?? OttaiRegistry.loadAccessToken()
+        let profile = profileOverride ?? activeProfile(apiBase)
+        let deviceId = requestDeviceId(profile)
+        if profile == .cnPhone {
+            var h = cnPhoneHeaders(deviceId: deviceId, accessToken: token, timestamp: ts, traceId: UUID().uuidString)
+            if token.isEmpty { h.removeValue(forKey: "Authorization") }
+            return h
+        }
+        let identity = sessionIdentity(.watch)
+        let offsetSec = TimeZone.current.secondsFromGMT()
+        var h: [String: String] = [
+            "appName": identity.appName,
+            "versionName": "1.1.0",
+            "versionCode": "244301",
+            "packageName": identity.packageName,
+            "ua": "Android_Watch_Ottai_Arc",
+            "timezone": String(offsetSec),
+            "timeZoneName": TimeZone.current.identifier,
+            "language": Locale.current.language.languageCode?.identifier ?? "en",
+            "traceId": "trace_testtest",
+            "timestamp": String(ts),
+            "country": "zh_CN",
+            "deviceId": identity.deviceId(deviceId),
+        ]
+        // The China server only accepts China IPs. Send a fake one, but ONLY to that server.
+        if apiBase == OttaiConstants.apiBase {
+            h["X-Forwarded-For"] = OttaiConstants.cnForwardIp
+            h["X-Real-IP"] = OttaiConstants.cnForwardIp
+            h["CF-Connecting-IP"] = OttaiConstants.cnForwardIp
+            h["True-Client-IP"] = OttaiConstants.cnForwardIp
+        }
+        if !token.isEmpty { h["Authorization"] = token }
+        return h
+    }
+
+    private static func cnPhoneHeaders(deviceId: String, accessToken: String, timestamp: Int64, traceId: String) -> [String: String] {
+        let identity = sessionIdentity(.cnPhone)
+        return [
+            "User-Agent": "Dart/3.8 (dart:io)",
+            "ua": "Android",
+            "deviceId": identity.deviceId(deviceId),
+            "applicationType": "ottai_main",
+            "appName": identity.appName,
+            "versionCode": "263121",
+            "country": "CN",
+            "language": "zh",
+            "timezone": "28800",
+            "packageName": identity.packageName,
+            "productModel": "MB",
+            "unit": "mmol_L",
+            "timeZoneName": "Asia/Shanghai",
+            "deviceModel": "SM-A205FN",
+            "versionName": "1.55.0",
+            "X-Forwarded-For": OttaiConstants.cnForwardIp,
+            "X-Real-IP": OttaiConstants.cnForwardIp,
+            "CF-Connecting-IP": OttaiConstants.cnForwardIp,
+            "True-Client-IP": OttaiConstants.cnForwardIp,
+            "timestamp": String(timestamp),
+            "traceId": traceId,
+            "Authorization": accessToken,
+        ]
+    }
+
+    private static func now() -> Int64 { Int64(Date().timeIntervalSince1970 * 1000) }
+    private static func base() -> String { OttaiRegistry.loadApiBase() }
+
+    private static func normalizePhone(_ raw: String) -> String {
+        var d = raw.filter { $0.isNumber }
+        if d.count == 13 && d.hasPrefix("86") { d = String(d.dropFirst(2)) }
+        if d.count == 14 && d.hasPrefix("0086") { d = String(d.dropFirst(4)) }
+        return d
+    }
+
+    // MARK: - login
+
+    static func getApiToken(apiBase: String = base(), authorizationOverride: String? = nil, profileOverride: OttaiRegistry.SessionProfile? = nil) -> String? {
+        let ts = now()
+        let profile = profileOverride ?? activeProfile(apiBase)
+        let deviceId = requestDeviceId(profile)
+        let sig = signForProfile(profile, deviceId: deviceId, ts: ts)
+        let resp = httpGet(apiBase + OttaiConstants.epApiToken, ["signature": sig], headers(ts: ts, apiBase: apiBase, authorizationOverride: authorizationOverride, profileOverride: profile))
+        return str(resp, "data").nilIfEmpty
+    }
+
+    static func requestSmsCode(phone: String, phoneCode: String = "86") -> String? {
+        let profile = OttaiRegistry.SessionProfile.cnPhone
+        guard let apiToken = getApiToken(apiBase: OttaiConstants.apiBase, authorizationOverride: "", profileOverride: profile) else {
+            lastFailure = CloudFailure(text: "apiToken failed"); return nil
+        }
+        let ts = now()
+        let deviceId = requestDeviceId(profile)
+        let ph = normalizePhone(phone)
+        let body: [String: Any] = [
+            "phoneCode": phoneCode, "phone": ph, "apiToken": apiToken, "smsType": 1,
+            "signature": signForProfile(profile, deviceId: deviceId, ts: ts, ph, apiToken),
+        ]
+        let resp = httpPostJson(OttaiConstants.apiBase + OttaiConstants.epSmsCode, json(body), headers(ts: ts, apiBase: OttaiConstants.apiBase, authorizationOverride: "", profileOverride: profile))
+        return str(resp, "data").nilIfEmpty
+    }
+
+    static func smsLogin(phone: String, code: String, requestId: String, phoneCode: String = "86") -> LoginResult? {
+        let profile = OttaiRegistry.SessionProfile.cnPhone
+        let ts = now()
+        let deviceId = requestDeviceId(profile)
+        let ph = normalizePhone(phone)
+        let body: [String: Any] = [
+            "phoneCode": phoneCode, "phone": ph, "validCode": code, "requestId": requestId,
+            "signature": signForProfile(profile, deviceId: deviceId, ts: ts, requestId, ph, code),
+        ]
+        guard let resp = httpPostJson(OttaiConstants.apiBase + OttaiConstants.epSmsLogin, json(body), headers(ts: ts, apiBase: OttaiConstants.apiBase, authorizationOverride: "", profileOverride: profile)),
+              let data = dataObject(resp) else { return nil }
+        let result = LoginResult(userId: str(data, "userId"), accessToken: str(data, "accessToken"), glucoseSecretKey: str(data, "glucoseSecretKey"))
+        if result.ok {
+            OttaiRegistry.saveApiBase(OttaiConstants.apiBase)
+            OttaiRegistry.saveSessionProfile(profile)
+            OttaiRegistry.saveAccessToken(result.accessToken)
+            OttaiRegistry.saveGlucoseSecretKey(result.glucoseSecretKey)
+            OttaiRegistry.saveUserId(result.userId)
+        }
+        return result
+    }
+
+    /// Login with user name and password for Global / Syai (no SMS). Only one try.
+    static func passwordLogin(account: String, password: String, base baseUrl: String = OttaiConstants.apiBaseGlobal, authorizationOverride: String? = nil) -> LoginResult? {
+        let acct = account.trimmingCharacters(in: .whitespaces)
+        if acct.isEmpty || password.isEmpty { lastFailure = CloudFailure(text: "account/password required"); return nil }
+        guard let apiToken = getApiToken(apiBase: baseUrl, authorizationOverride: authorizationOverride) else {
+            lastFailure = CloudFailure(text: "apiToken failed"); return nil
+        }
+        let ts = now()
+        let deviceId = requestDeviceId(.watch)
+        let body: [String: Any] = [
+            "account": acct, "username": acct, "userName": acct, "password": password, "apiToken": apiToken,
+            "signature": signForProfile(.watch, deviceId: deviceId, ts: ts, apiToken, acct, password),
+        ]
+        guard let resp = httpPostJson(baseUrl + OttaiConstants.epAccountLogin, json(body), headers(ts: ts, apiBase: baseUrl, authorizationOverride: authorizationOverride)),
+              let data = dataObject(resp) else { return nil }
+        let result = LoginResult(userId: str(data, "userId"), accessToken: str(data, "accessToken"), glucoseSecretKey: str(data, "glucoseSecretKey"))
+        if result.ok {
+            OttaiRegistry.saveApiBase(baseUrl)
+            OttaiRegistry.saveSessionProfile(.watch)
+            OttaiRegistry.saveAccessToken(result.accessToken)
+            OttaiRegistry.saveGlucoseSecretKey(result.glucoseSecretKey)
+            OttaiRegistry.saveUserId(result.userId)
+            return result
+        }
+        return nil
+    }
+
+    static func logout() {
+        let ts = now()
+        _ = httpPostJson(base() + OttaiConstants.epLogout, "{}", headers(ts: ts, apiBase: base()))
+        OttaiRegistry.saveAccessToken(nil)
+        OttaiRegistry.saveGlucoseSecretKey(nil)
+        OttaiRegistry.saveUserId(nil)
+        OttaiRegistry.saveAccountLogin(nil)
+        OttaiRegistry.saveSessionProfile(nil)
+        OttaiRegistry.saveApiBase(OttaiConstants.apiBase)
+        OttaiRegistry.saveCloudUploadStatus(nil)
+    }
+
+    /// The account profile (`/user/getUser`) of the signed-in session, or nil.
+    /// Used to find the customerId for the upload. Do not call this on the main thread.
+    static func fetchUserProfile() -> [String: Any]? {
+        let token = OttaiRegistry.loadAccessToken()
+        if token.isEmpty { return nil }
+        return mobileGetUser(base(), accessToken: token)
+    }
+
+    // MARK: - device validate / bind
+
+    static func validateByMac(mac: String) -> DeviceResp? {
+        guard let v = validateForSetup(mac: mac), !v.device.keyA.isEmpty else { return nil }
+        return v.device
+    }
+
+    static func validateForSetup(mac: String) -> DeviceValidation? {
+        let canonical = OttaiConstants.canonicalSensorId(mac)
+        if canonical.isEmpty { return nil }
+        let apiBase = base()
+        let ts = now()
+        let profile = activeProfile(apiBase)
+        let deviceId = requestDeviceId(profile)
+        let resp = httpGet(apiBase + OttaiConstants.epValidateByMac,
+                           ["mac": canonical, "signature": signForProfile(profile, deviceId: deviceId, ts: ts, canonical)],
+                           headers(ts: ts, apiBase: apiBase, profileOverride: profile))
+        if let resp = resp, let device = parseDeviceResp(resp) {
+            return DeviceValidation(device: device, requiresV3Bind: false)
+        }
+        if apiBase != OttaiConstants.apiBase || profile != .cnPhone ||
+            !(lastFailure?.code.caseInsensitiveEquals(bizUpgradeVersion) ?? false) {
+            return nil
+        }
+        let v3Ts = now()
+        let body: [String: Any] = ["mac": canonical, "signature": signForProfile(profile, deviceId: deviceId, ts: v3Ts, canonical)]
+        guard let v3 = httpPostJson(apiBase + OttaiConstants.epValidateByMacV3, json(body), headers(ts: v3Ts, apiBase: apiBase, profileOverride: profile)),
+              let device = parseDeviceResp(v3, requireKeyA: false) else { return nil }
+        OttaiRegistry.saveLastValidatedDeviceVersion(sensorId: canonical, version: device.deviceVersion)
+        return DeviceValidation(device: device, requiresV3Bind: true)
+    }
+
+    enum BindContract { case legacy, v3 }
+
+    static func bindRequestBody(mac: String, deviceVersion: String, userId: String?, activeTime: Int64, contract: BindContract) -> [String: Any] {
+        var body: [String: Any] = ["mac": mac, "deviceType": "cgm", "deviceVersion": deviceVersion, "activeTime": activeTime]
+        if let userId = userId, !userId.isEmpty { body["userId"] = userId }
+        if contract == .v3 { body["newBindType"] = 2 }
+        return body
+    }
+
+    static func bind(mac: String, deviceVersion: String, userId: String) -> DeviceResp? {
+        bind(mac: mac, deviceVersion: deviceVersion, userId: userId, contract: .legacy)
+    }
+
+    static func bindV3(mac: String, deviceVersion: String) -> DeviceResp? {
+        bind(mac: mac, deviceVersion: deviceVersion, userId: OttaiRegistry.loadUserId(), contract: .v3)
+    }
+
+    private static func bind(mac: String, deviceVersion: String, userId: String?, contract: BindContract) -> DeviceResp? {
+        let canonical = OttaiConstants.canonicalSensorId(mac)
+        if canonical.isEmpty || deviceVersion.isEmpty { lastFailure = CloudFailure(text: "bind requires mac and deviceVersion"); return nil }
+        if contract == .v3 && (userId?.isEmpty ?? true) { lastFailure = CloudFailure(text: "bindV3 requires a signed-in session (userId)"); return nil }
+        let ts = now()
+        let body = bindRequestBody(mac: canonical, deviceVersion: deviceVersion.trimmingCharacters(in: .whitespaces), userId: userId,
+                                   activeTime: contract == .v3 ? ts / 1000 : ts, contract: contract)
+        let endpoint = contract == .v3 ? OttaiConstants.epBindV3 : OttaiConstants.epBind
+        guard let resp = httpPostJson(base() + endpoint, json(body), headers(ts: ts, apiBase: base())) else { return nil }
+        return parseDeviceResp(resp)
+    }
+
+    static let syaiMaterialBindDeviceVersion = "E1.1.4(V1.7.S2530.1)"
+    static let globalMaterialBindDeviceVersion = "vE1.2.3(V1.7.SH2542.1)"
+
+    static func materialBindDeviceVersion(apiBase: String, selectedDeviceVersion: String?, failureCode: String?) -> String? {
+        if let sel = selectedDeviceVersion?.trimmingCharacters(in: .whitespaces), !sel.isEmpty { return sel }
+        if !(failureCode?.caseInsensitiveEquals(bizOutOfProduceTime) ?? false) { return nil }
+        switch apiBase {
+        case OttaiConstants.apiBaseSyai: return syaiMaterialBindDeviceVersion
+        case OttaiConstants.apiBaseGlobal: return globalMaterialBindDeviceVersion
+        default: return nil
+        }
+    }
+
+    static func materialBindDeviceVersion(selectedDeviceVersion: String?, failureCode: String?) -> String? {
+        materialBindDeviceVersion(apiBase: base(), selectedDeviceVersion: selectedDeviceVersion, failureCode: failureCode)
+    }
+
+    static func bindForMaterials(mac: String, deviceVersion: String, historicalActiveTimeMs: Int64 = 0) -> DeviceResp? {
+        let canonical = OttaiConstants.canonicalSensorId(mac)
+        let userId = OttaiRegistry.loadUserId()
+        guard let resp = bind(mac: canonical, deviceVersion: deviceVersion.trimmingCharacters(in: .whitespaces), userId: userId, contract: .legacy) else { return nil }
+        let bindFailure = lastFailure
+        usleep(temporaryUnbindDelayMs * 1000)
+        _ = unbind(mac: canonical, headerOverride: nil)
+        lastFailure = bindFailure
+        return sanitizeTemporaryBindResponse(resp, historicalActiveTimeMs: historicalActiveTimeMs)
+    }
+
+    static func sanitizeTemporaryBindResponse(_ response: DeviceResp, historicalActiveTimeMs: Int64) -> DeviceResp {
+        var r = response
+        r.activeTime = historicalActiveTimeMs > 0 ? historicalActiveTimeMs : 0
+        return r
+    }
+
+    // MARK: - cgmAuth (V3 Active_Auth)
+
+    static func cgmAuthVerify(mac: String, authDevHex: String, authFlagHex: String) -> V3AuthMaterial? {
+        let canonical = OttaiConstants.canonicalSensorId(mac)
+        if canonical.isEmpty { lastFailure = CloudFailure(text: "verify requires mac"); return nil }
+        let apiBase = base()
+        let profile = activeProfile(apiBase)
+        let deviceId = requestDeviceId(profile)
+        let ts = now()
+        let paramStr = authDevHex.uppercased()
+        let shaInfo = authFlagHex.uppercased()
+        let sign = cgmAuthVerifySign(profile, deviceId: deviceId, timestampMillis: ts, mac: canonical, paramStr: paramStr, shaInfo: shaInfo)
+        let body: [String: Any] = ["mac": canonical, "paramStr": paramStr, "shaInfo": shaInfo, "sign": sign, "timestamp": String(ts)]
+        guard let resp = httpPostJson(apiBase + OttaiConstants.epCgmAuthVerify, json(body), headers(ts: ts, apiBase: apiBase, profileOverride: profile), timeoutMs: 60_000) else { return nil }
+        let data = dataObject(resp)
+        let mat = V3AuthMaterial(authHost: str(data, "auth"), authFlag: str(data, "shaInfo"), keyB: str(data, "kb"), cf: str(data, "cf"))
+        return mat.ok ? mat : nil
+    }
+
+    // MARK: - unbind / list
+
+    static func unbind(mac: String) -> Bool { unbind(mac: mac, headerOverride: nil) }
+
+    private static func unbind(mac: String, headerOverride: ((Int64) -> [String: String])?) -> Bool {
+        let canonical = OttaiConstants.canonicalSensorId(mac)
+        if canonical.isEmpty { return false }
+        let ts = now()
+        let body: [String: Any] = ["mac": canonical, "deviceType": "cgm", "unbindType": 0]
+        let requestHeaders = headerOverride?(ts) ?? headers(ts: ts, apiBase: base())
+        guard let resp = httpPutJson(base() + OttaiConstants.epUnbind, json(body), requestHeaders) else { return false }
+        let bizCode = anyToString(resp["code"])
+        return bizCode.isEmpty || bizCode == "200" || bizCode.caseInsensitiveEquals("OK") || bizCode.caseInsensitiveEquals(bizEndUsing)
+    }
+
+    static func getBindDevice() -> DeviceResp? {
+        let ts = now()
+        guard let resp = httpGet(base() + OttaiConstants.epGetBindDevice, [:], headers(ts: ts, apiBase: base())) else { return nil }
+        return parseDeviceResp(resp)
+    }
+
+    static func listDevices(pageSize: Int = 80, pageNumber: Int = 1) -> [DeviceSummary] {
+        let ts = now()
+        guard let resp = httpGet(base() + OttaiConstants.epDeviceList,
+                                 ["pageSize": String(pageSize), "pageNumber": String(pageNumber)],
+                                 headers(ts: ts, apiBase: base())),
+              let data = dataObject(resp) else { return [] }
+        let items = (data["items"] as? [[String: Any]]) ?? (data["list"] as? [[String: Any]]) ?? (data["records"] as? [[String: Any]]) ?? []
+        return items.compactMap { o in
+            let mac = str(o, "mac")
+            if mac.isEmpty { return nil }
+            var version = str(o, "deviceVersion")
+            if version.isEmpty { version = str(o["cgmDeviceRespVO"] as? [String: Any], "deviceVersion") }
+            return DeviceSummary(mac: mac, serialNo: str(o, "serialNo"), deviceType: str(o, "deviceType"),
+                                 deviceVersion: version, bindTime: longLoose(o, "bindTime"), unbindTime: longLoose(o, "unbindTime"))
+        }
+    }
+
+    // MARK: - parse + decrypt
+
+    private static func parseDeviceResp(_ resp: [String: Any], requireKeyA: Bool = true) -> DeviceResp? {
+        guard let data = dataObject(resp) else { return nil }
+        let vo = (data["cgmDeviceRespVO"] as? [String: Any]) ?? data
+        let mvo = (data["cgmDeviceMethodVO"] as? [String: Any]) ?? vo
+        let keyA = str(vo, "keyA")
+        if requireKeyA && keyA.isEmpty { return nil }
+        func pick(_ key: String) -> String { let m = str(mvo, key); return m.isEmpty ? str(vo, key) : m }
+        func pickTime(_ key: String) -> Int64 { let m = longLoose(mvo, key); return m != 0 ? m : longLoose(vo, key) }
+        return DeviceResp(
+            mac: str(vo, "mac"), keyA: keyA, method: pick("method"), coefficient: pick("coefficient"),
+            produceTime: longLoose(vo, "produceTime"), methodUpdateTime: pickTime("methodUpdateTime"), coeffUpdateTime: pickTime("coeffUpdateTime"),
+            activeTime: longLoose(vo, "activeTime"), activeExpireTime: longLoose(vo, "activeExpireTime"),
+            preheatPeriodTime: longLoose(vo, "preheatPeriodTime"), retainTime: longLoose(vo, "retainTime"),
+            deviceVersion: str(vo, "deviceVersion"), deviceId: Int(longLoose(vo, "id"))
+        )
+    }
+
+    /// Decrypt the sensor keys from the cloud answer with the account secret key.
+    static func toMaterials(mac: String, resp: DeviceResp) -> OttaiRegistry.DeviceMaterials? {
+        let secret = OttaiRegistry.loadGlucoseSecretKey()
+        if secret.isEmpty { return nil }
+        let canonical = OttaiConstants.canonicalSensorId(mac)
+        guard let keyAPlain = OttaiCrypto.decryptKeyA(base64KeyA: resp.keyA, glucoseSecretKey: secret, produceTime: String(resp.produceTime), mac: canonical) else { return nil }
+        if OttaiCrypto.parseAuthKeys(keyAPlain) == nil { return nil }
+        let methodPlain = resp.method.isEmpty ? "" : (OttaiCrypto.decryptMethod(base64Method: resp.method, glucoseSecretKey: secret, methodUpdateTime: String(resp.methodUpdateTime), mac: canonical) ?? "")
+        let coeffPlain = resp.coefficient.isEmpty ? "" : (OttaiCrypto.decryptCoefficient(base64Coeff: resp.coefficient, glucoseSecretKey: secret, coeffUpdateTime: String(resp.coeffUpdateTime), mac: canonical) ?? "")
+        return OttaiRegistry.DeviceMaterials(
+            keyAHex: keyAPlain,
+            method: OttaiMethodDefaults.resolve(method: methodPlain, coefficient: coeffPlain),
+            coefficient: coeffPlain,
+            activeTimeMs: normalizeOttaiActiveTimeMs(resp.activeTime),
+            deviceVersion: resp.deviceVersion,
+            deviceId: resp.deviceId,
+            activeExpireTimeMs: resp.activeExpireTime,
+            retainTimeMs: resp.retainTime,
+            preheatPeriodMs: resp.preheatPeriodTime
+        )
+    }
+
+    // MARK: - get and save the keys of one sensor (same as fetchOttaiMaterials in JugglucoNG)
+
+    /// After login, get the keys for [cloudId] and save them, so the Bluetooth part
+    /// can log in. It tries, in this order: keys already saved -> check by mac ->
+    /// the sensor bound to the account -> a short bind and unbind (for an old
+    /// Syai / Global sensor). Returns true if good keys were saved. Do not call
+    /// this on the main thread.
+    static func fetchAndSaveMaterials(cloudId: String) -> Bool {
+        let canonical = OttaiConstants.canonicalSensorId(cloudId)
+        if canonical.isEmpty { return false }
+        if OttaiRegistry.loadMaterials(sensorId: canonical).authKeys != nil { return true }
+
+        var firstFailure: CloudFailure?
+        func remember() { if firstFailure == nil { firstFailure = lastFailure } }
+
+        if let v = validateForSetup(mac: canonical), !v.device.keyA.isEmpty,
+           let m = toMaterials(mac: canonical, resp: v.device), m.authKeys != nil {
+            return OttaiRegistry.saveMaterials(sensorId: canonical, m)
+        }
+        remember()
+
+        if let resp = getBindDevice(),
+           OttaiConstants.matchesCanonicalOrKnownNativeAlias(OttaiConstants.canonicalSensorId(resp.mac), canonical),
+           let m = toMaterials(mac: OttaiConstants.canonicalSensorId(resp.mac), resp: resp), m.authKeys != nil {
+            return OttaiRegistry.saveMaterials(sensorId: canonical, m)
+        }
+        remember()
+
+        if let version = materialBindDeviceVersion(selectedDeviceVersion: nil, failureCode: firstFailure?.code),
+           let resp = bindForMaterials(mac: canonical, deviceVersion: version),
+           let m = toMaterials(mac: canonical, resp: resp), m.authKeys != nil {
+            return OttaiRegistry.saveMaterials(sensorId: canonical, m)
+        }
+        if lastFailure == nil { lastFailure = firstFailure }
+        return false
+    }
+
+    // MARK: - website API (email login and sign-up)
+
+    private static let webApp = "ottai-seas"
+    private static let webDeviceId = "8"
+    private static let webAesKey = "miH5ngQ7z4NZU3JgZFq87Gg6v1Y7YJm9"
+    private static let webFingerprint = "0123456789abcdef0123456789abcdef01234567"
+    private static let webAppSyai = "cgm"
+    private static let webFingerprintSyai = "90507337afdab98e443d3ec8fcccb672"
+
+    private static func isSyaiWeb(_ webBase: String) -> Bool { webBase.contains("syai") }
+    private static func webAppFor(_ webBase: String) -> String { isSyaiWeb(webBase) ? webAppSyai : webApp }
+    private static func webSign(_ parts: String...) -> String { md5Hex(parts.joined() + seed) }
+
+    private static func webHeaders(_ webBase: String, ts: Int64) -> [String: String] {
+        if isSyaiWeb(webBase) {
+            return ["appName": webAppSyai, "timestamp": String(ts), "deviceFingerprinting": webFingerprintSyai,
+                    "country": "US", "region": "Americas", "ua": "Android", "versionCode": "5",
+                    "traceId": "trace_\(ts)", "language": "en", "timezone": "-18000"]
+        }
+        return ["appName": webApp, "timestamp": String(ts), "deviceId": webDeviceId, "deviceFingerprinting": webFingerprint,
+                "region": "Europe", "ua": "web", "versionCode": "253201", "traceId": "trace_\(ts)",
+                "language": "en", "timezone": "0", "X-Canary-Mode": "OFF", "country": "RU"]
+    }
+
+    private static func webEncrypt(_ plainJson: String) -> String {
+        guard let out = OttaiCrypto.aesECB(.encrypt, key: Array(webAesKey.utf8), data: Array(plainJson.utf8), pkcs7Padded: true) else { return "" }
+        return Data(out).base64EncodedString()
+    }
+
+    private static func getWebApiToken(_ webBase: String) -> String? {
+        for attempt in 0 ..< 2 {
+            let ts = now()
+            let resp = httpGet("\(webBase)/user/apiToken", ["signature": webSign(webAppFor(webBase), String(ts))], webHeaders(webBase, ts: ts))
+            if let tok = str(resp, "data").nilIfEmpty { return tok }
+            if attempt == 0 { usleep(900_000) }
+        }
+        return nil
+    }
+
+    private static func webPostRetry(_ webBase: String, _ path: String, buildBody: (_ apiToken: String, _ ts: Int64) -> [String: Any]) -> [String: Any]? {
+        for attempt in 0 ..< 5 {
+            guard let apiToken = getWebApiToken(webBase) else { lastFailure = CloudFailure(text: "apiToken failed"); return nil }
+            let ts = now()
+            guard let resp = httpPostJson("\(webBase)\(path)", json(buildBody(apiToken, ts)), webHeaders(webBase, ts: ts)) else { return nil }
+            if !anyToString(resp["code"]).caseInsensitiveEquals("User_SignatureInvalid") { return resp }
+            if attempt < 4 { usleep(500_000) }
+        }
+        return nil
+    }
+
+    static func mailLogin(email: String, password: String, webBase: String = OttaiConstants.webBaseOttai) -> LoginResult? {
+        let em = email.trimmingCharacters(in: .whitespaces)
+        if em.isEmpty || password.isEmpty { lastFailure = CloudFailure(text: "email/password required"); return nil }
+        let resp: [String: Any]?
+        if isSyaiWeb(webBase) {
+            let encInfo = webEncrypt(json(["email": em, "password": password]))
+            resp = webPostRetry(webBase, "/user/mail/login") { apiToken, ts in
+                ["encryptInfo": encInfo, "email": em, "apiToken": apiToken, "signature": webSign(webAppSyai, String(ts), apiToken, em, password)]
+            }
+        } else {
+            let encInfo = webEncrypt(json(["username": em, "password": password]))
+            resp = webPostRetry(webBase, "/user/login/thirdLoginByPassword") { apiToken, ts in
+                ["uuid": UUID().uuidString.replacingOccurrences(of: "-", with: ""), "encryptInfo": encInfo, "apiToken": apiToken, "source": 5,
+                 "signature": webSign(webApp, webDeviceId, String(ts), apiToken, em, password)]
+            }
+        }
+        guard let resp = resp else { return nil }
+        let mobileBase = webBaseToMobile(webBase)
+        let webToken = str(dataObject(resp), "accessToken")
+        if !webToken.isEmpty {
+            let profile = isSyaiWeb(webBase) ? mobileGetUser(mobileBase, accessToken: webToken) : webGetUser(webBase, accessToken: webToken)
+            if let userName = str(profile, "userName").nilIfEmpty {
+                if let r = passwordLogin(account: userName, password: password, base: mobileBase, authorizationOverride: webToken), r.ok { return r }
+            }
+        }
+        if isSyaiWeb(webBase) {
+            if lastError.isEmpty { lastFailure = CloudFailure(text: "Syai mobile login upgrade failed") }
+            return nil
+        }
+        return persistWebLogin(resp, mobileBase: mobileBase, webBase: webBase)
+    }
+
+    static func sendMail(email: String, type: String = "SIGN_UP", webBase: String = OttaiConstants.webBaseOttai) -> String? {
+        let em = email.trimmingCharacters(in: .whitespaces)
+        guard let resp = webPostRetry(webBase, "/user/mail/sendMail", buildBody: { apiToken, ts in
+            ["type": type, "isSend": 1, "email": em, "apiToken": apiToken, "signature": webSign(webAppFor(webBase), String(ts), em, apiToken)]
+        }) else { return nil }
+        if !anyToString(resp["code"]).caseInsensitiveEquals("OK") { return nil }
+        return str(dataObject(resp), "key").nilIfEmpty
+    }
+
+    static func signUp(email: String, password: String, profileName: String, requestId: String, validCode: String, webBase: String = OttaiConstants.webBaseOttai) -> LoginResult? {
+        let em = email.trimmingCharacters(in: .whitespaces)
+        if isSyaiWeb(webBase) { return syaiSignUp(em: em, password: password, requestId: requestId, validCode: validCode, webBase: webBase) }
+        let encInfo = webEncrypt(json(["email": em, "password": password, "profileName": profileName]))
+        guard let resp = webPostRetry(webBase, "/user/mail/signUp", buildBody: { apiToken, ts in
+            ["apiToken": apiToken, "encryptInfo": encInfo, "requestId": requestId, "validCode": validCode,
+             "recommendFlag": false, "country": "RU", "language": "en", "signature": webSign(webApp, String(ts), requestId, em, validCode)]
+        }) else { return nil }
+        return persistWebLogin(resp, mobileBase: webBaseToMobile(webBase), webBase: webBase)
+    }
+
+    private static func syaiSignUp(em: String, password: String, requestId: String, validCode: String, webBase: String) -> LoginResult? {
+        guard let verify = webPostRetry(webBase, "/user/mail/verifyMail", buildBody: { _, ts in
+            ["type": "SIGN_UP", "validCode": validCode, "requestId": requestId, "email": em, "signature": webSign(webAppSyai, String(ts), requestId, em, validCode)]
+        }), anyToString(verify["code"]).caseInsensitiveEquals("OK") else { return nil }
+        let encInfo = webEncrypt(json(["email": em, "password": password]))
+        guard let resp = webPostRetry(webBase, "/user/mail/signUp", buildBody: { _, ts in
+            ["encryptInfo": encInfo, "requestId": requestId, "signature": webSign(webAppSyai, String(ts), requestId, em)]
+        }) else { return nil }
+        return persistWebLogin(resp, mobileBase: webBaseToMobile(webBase), webBase: webBase)
+    }
+
+    static func webBaseToMobile(_ webBase: String) -> String {
+        webBase.contains("syai") ? OttaiConstants.apiBaseSyai : OttaiConstants.apiBaseGlobal
+    }
+
+    private static func persistWebLogin(_ resp: [String: Any], mobileBase: String, webBase: String) -> LoginResult? {
+        guard let data = dataObject(resp) else { return nil }
+        let accessToken = str(data, "accessToken")
+        var glucoseSecretKey = str(data, "glucoseSecretKey")
+        if !accessToken.isEmpty && glucoseSecretKey.isEmpty {
+            glucoseSecretKey = str(webGetUser(webBase, accessToken: accessToken), "glucoseSecretKey")
+        }
+        let result = LoginResult(userId: str(data, "userId"), accessToken: accessToken, glucoseSecretKey: glucoseSecretKey)
+        if !result.accessToken.isEmpty {
+            OttaiRegistry.saveApiBase(mobileBase)
+            OttaiRegistry.saveSessionProfile(.watch)
+            OttaiRegistry.saveAccessToken(result.accessToken)
+            if !result.glucoseSecretKey.isEmpty { OttaiRegistry.saveGlucoseSecretKey(result.glucoseSecretKey) }
+            OttaiRegistry.saveUserId(result.userId)
+        }
+        return result
+    }
+
+    private static func webGetUser(_ webBase: String, accessToken: String) -> [String: Any]? {
+        let ts = now()
+        var headers = webHeaders(webBase, ts: ts)
+        if isSyaiWeb(webBase) { headers["deviceId"] = webDeviceId }
+        headers["Authorization"] = "Bearer \(accessToken)"
+        guard let resp = httpGet("\(webBase)/user/getUser", [:], headers) else { return nil }
+        return dataObject(resp)
+    }
+
+    private static func mobileGetUser(_ mobileBase: String, accessToken: String) -> [String: Any]? {
+        let ts = now()
+        guard let resp = httpGet(mobileBase + OttaiConstants.epGetUser, [:], headers(ts: ts, apiBase: mobileBase, authorizationOverride: accessToken)) else { return nil }
+        return dataObject(resp)
+    }
+
+    // MARK: - HTTP
+
+    private static func httpGet(_ base: String, _ query: [String: String], _ headers: [String: String]) -> [String: Any]? {
+        let qs = query.map { "\(enc($0.key))=\(enc($0.value))" }.joined(separator: "&")
+        let url = qs.isEmpty ? base : "\(base)?\(qs)"
+        return request("GET", url: url, body: nil, headers: headers)
+    }
+
+    private static func httpPostJson(_ url: String, _ body: String, _ headers: [String: String], timeoutMs: Int = timeoutMs) -> [String: Any]? {
+        var h = headers; h["Content-Type"] = "application/json;charset=UTF-8"
+        return request("POST", url: url, body: body, headers: h, timeoutMs: timeoutMs)
+    }
+
+    private static func httpPutJson(_ url: String, _ body: String, _ headers: [String: String]) -> [String: Any]? {
+        var h = headers; h["Content-Type"] = "application/json;charset=UTF-8"
+        return request("PUT", url: url, body: body, headers: h)
+    }
+
+    private static func request(_ method: String, url: String, body: String?, headers: [String: String], timeoutMs: Int = timeoutMs) -> [String: Any]? {
+        guard let u = URL(string: url) else { lastFailure = CloudFailure(text: "bad url"); return nil }
+        var req = URLRequest(url: u)
+        req.httpMethod = method
+        req.timeoutInterval = TimeInterval(timeoutMs) / 1000.0
+        for (k, v) in headers { req.setValue(v, forHTTPHeaderField: k) }
+        if let body = body { req.httpBody = body.data(using: .utf8) }
+
+        let sem = DispatchSemaphore(value: 0)
+        var outData: Data?
+        var outCode = -1
+        var outErr: Error?
+        URLSession.shared.dataTask(with: req) { data, response, error in
+            outData = data
+            outErr = error
+            if let http = response as? HTTPURLResponse { outCode = http.statusCode }
+            sem.signal()
+        }.resume()
+        _ = sem.wait(timeout: .now() + .milliseconds(timeoutMs + 5_000))
+
+        if let error = outErr { lastFailure = CloudFailure(text: "network: \(error.localizedDescription)"); return nil }
+        let text = outData.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+        let jsonObj = text.isEmpty ? nil : (try? JSONSerialization.jsonObject(with: Data(text.utf8))) as? [String: Any]
+        let bizCode = anyToString(jsonObj?["code"])
+        let bizMsg = anyToString(jsonObj?["message"]).nilIfEmpty ?? anyToString(jsonObj?["msg"]).nilIfEmpty ?? anyToString(jsonObj?["detailMessage"])
+        let bizOk = bizCode.isEmpty || bizCode == "200" || bizCode.caseInsensitiveEquals("OK")
+        if !(200 ... 299).contains(outCode) || !bizOk {
+            lastFailure = CloudFailure(text: "http=\(outCode) biz=\(bizCode) \(String(bizMsg.prefix(120)))".trimmingCharacters(in: .whitespaces), code: bizCode)
+        } else {
+            lastFailure = nil
+        }
+        return jsonObj
+    }
+
+    // MARK: - JSON helpers
+
+    private static func json(_ obj: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: obj, options: []) else { return "{}" }
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+
+    private static func dataObject(_ resp: [String: Any]?) -> [String: Any]? {
+        (resp?["data"] as? [String: Any]) ?? (resp?["result"] as? [String: Any])
+    }
+
+    private static func str(_ dict: [String: Any]?, _ key: String) -> String {
+        anyToString(dict?[key])
+    }
+
+    private static func longLoose(_ dict: [String: Any]?, _ key: String) -> Int64 {
+        guard let v = dict?[key] else { return 0 }
+        if let n = v as? NSNumber { return n.int64Value }
+        if let s = v as? String { return Int64(s) ?? 0 }
+        return 0
+    }
+
+    private static func anyToString(_ any: Any?) -> String {
+        guard let any = any else { return "" }
+        if let s = any as? String { return s == "null" ? "" : s }
+        if let n = any as? NSNumber { return n.stringValue }
+        return ""
+    }
+
+    private static func enc(_ s: String) -> String {
+        s.addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? s
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+    func caseInsensitiveEquals(_ other: String) -> Bool { caseInsensitiveCompare(other) == .orderedSame }
+}
+
+private extension CharacterSet {
+    static let urlQueryValueAllowed: CharacterSet = {
+        var cs = CharacterSet.urlQueryAllowed
+        cs.remove(charactersIn: "&=?+")
+        return cs
+    }()
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiCloudUploader.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiCloudUploader.swift
@@ -1,0 +1,341 @@
+//
+//  OttaiCloudUploader.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — sends the readings xDrip accepted to the Syai
+//  cloud, so the Syai Tag app, the Syai website and its followers show the
+//  same values as xDrip.
+//
+
+import Foundation
+import os
+
+final class OttaiCloudUploader {
+
+    /// One reading, with the raw fields the Syai server wants.
+    struct Sample {
+        let dataNo: Int
+        let runtimeSec: Int
+        let voltage: Int
+        let rawCurrent: Int
+        let temperatureC: Double
+        /// Glucose in mmol/L (the sensor formula result).
+        let mmol: Double
+        /// The time of the reading, ms since 1970.
+        let sampleMs: Int64
+        /// When the app received the packet, ms since 1970.
+        let receivedAtMs: Int64
+        /// The 12-byte record (00 00 ‖ dataNo ‖ 8 bytes) — sent as "origin".
+        let originBytes: [UInt8]
+        let live: Bool
+    }
+
+    // MARK: - constants (values seen in the Syai Tag app requests)
+
+    private static let appName = "Syai Tag"
+    private static let packageName = "com.syai.tag"
+    private static let versionName = "1.23.0"
+    private static let versionCode = "261933"
+    private static let userAgent = "Dart/3.10 (dart:io)"
+    /// The hardware model of this phone, e.g. "iPhone16,1".
+    static let deviceModel: String = {
+        var sys = utsname()
+        uname(&sys)
+        let machine = withUnsafeBytes(of: &sys.machine) { buf in
+            String(decoding: buf.prefix(while: { $0 != 0 }), as: UTF8.self)
+        }
+        return machine.isEmpty ? "iPhone" : machine
+    }()
+    private static let unit = "mmol_L"
+    /// The Syai Tag app sends 1 for a reading from the sensor. Other values are unknown,
+    /// so live and history readings are both sent as 1.
+    private static let dataTypeSensor = 1
+    private static let glucoseStatusNormal = 0
+
+    private static let flushDelay: TimeInterval = 3.0
+    private static let maxBatch = 200
+    /// More than this and the oldest readings are dropped (about 3 days of 1-minute readings).
+    private static let maxPending = 4000
+    private static let firstRetryDelay: TimeInterval = 60
+    private static let maxRetryDelay: TimeInterval = 15 * 60
+    private static let requestTimeout: TimeInterval = 30
+
+    // MARK: - state
+
+    private let log = OSLog(subsystem: ConstantsLog.subSystem, category: ConstantsLog.categoryCGMOttai)
+    private let sensorId: String
+    private let queue = DispatchQueue(label: "OttaiCloudUploader.work")
+    private let session: URLSession
+
+    private var pending: [Sample] = []
+    private var uploadedDataNos = Set<Int>()
+    private var flushWork: DispatchWorkItem?
+    private var inFlight = false
+    private var retryDelay: TimeInterval = OttaiCloudUploader.firstRetryDelay
+    /// The customerId of the signed-in account, found once per app run.
+    private var cachedCustomerId: String?
+
+    init(sensorId: String) {
+        self.sensorId = sensorId
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = Self.requestTimeout
+        config.waitsForConnectivity = false
+        self.session = URLSession(configuration: config)
+    }
+
+    // MARK: - is the upload possible?
+
+    /// Why the upload cannot run right now, or nil when it can.
+    static func unavailableReason() -> String? {
+        if !OttaiRegistry.loadCloudUploadEnabled() { return "Upload is off" }
+        if OttaiRegistry.loadApiBase() != OttaiConstants.apiBaseSyai { return "Upload needs the Syai region" }
+        if OttaiRegistry.loadAccessToken().isEmpty { return "Not signed in" }
+        return nil
+    }
+
+    // MARK: - enqueue
+
+    /// Add one accepted reading. Nothing happens when the upload is off.
+    func enqueue(reading: OttaiReading, mmol: Double, sampleMs: Int64, receivedAtMs: Int64, live: Bool) {
+        guard OttaiRegistry.loadCloudUploadEnabled() else { return }
+        let sample = Sample(
+            dataNo: reading.record.dataNo,
+            runtimeSec: reading.record.runtimeSec,
+            voltage: reading.record.voltage,
+            rawCurrent: reading.record.rawCurrent,
+            temperatureC: reading.record.temperatureC,
+            mmol: mmol,
+            sampleMs: sampleMs,
+            receivedAtMs: receivedAtMs,
+            originBytes: reading.record.recordBytes,
+            live: live
+        )
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            if self.uploadedDataNos.contains(sample.dataNo) { return }
+            if let i = self.pending.firstIndex(where: { $0.dataNo == sample.dataNo }) {
+                self.pending[i] = sample
+            } else {
+                self.pending.append(sample)
+                if self.pending.count > Self.maxPending {
+                    self.pending.removeFirst(self.pending.count - Self.maxPending)
+                }
+            }
+            // Only wait the short delay when no retry is already scheduled.
+            if !self.inFlight && self.flushWork == nil {
+                self.scheduleFlush(after: Self.flushDelay)
+            }
+        }
+    }
+
+    // MARK: - flush
+
+    private func scheduleFlush(after delay: TimeInterval) {
+        flushWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            self.flushWork = nil
+            self.flush()
+        }
+        flushWork = work
+        queue.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    private func flush() {
+        guard !inFlight, !pending.isEmpty else { return }
+
+        if let reason = Self.unavailableReason() {
+            trace("cloud upload skipped: %{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, reason)
+            if !OttaiRegistry.loadCloudUploadEnabled() { pending.removeAll() }
+            Self.setStatus(reason)
+            scheduleRetry()
+            return
+        }
+
+        let materials = OttaiRegistry.loadMaterials(sensorId: sensorId)
+        guard materials.deviceId > 0 else {
+            trace("cloud upload skipped: no cloud device id for sensor %{public}@", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, sensorId)
+            Self.setStatus("No cloud device id for this sensor — fetch the sensor from the cloud")
+            pending.removeAll()
+            return
+        }
+
+        let customerId = resolveCustomerId()
+        let batch = Array(pending.prefix(Self.maxBatch))
+        guard let request = buildRequest(batch: batch, materials: materials, customerId: customerId) else {
+            Self.setStatus("Could not build the upload request")
+            return
+        }
+
+        inFlight = true
+        trace("cloud upload: posting %{public}d readings (dataNo %{public}d…%{public}d) deviceId=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info,
+              batch.count, batch.map { $0.dataNo }.min() ?? 0, batch.map { $0.dataNo }.max() ?? 0, materials.deviceId)
+        session.dataTask(with: request) { [weak self] data, response, error in
+            self?.queue.async { self?.handleResponse(batch: batch, data: data, response: response, error: error) }
+        }.resume()
+    }
+
+    private func handleResponse(batch: [Sample], data: Data?, response: URLResponse?, error: Error?) {
+        inFlight = false
+        let httpCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        let text = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+        let jsonObj = text.isEmpty ? nil : (try? JSONSerialization.jsonObject(with: Data(text.utf8))) as? [String: Any]
+        let bizCode = Self.anyToString(jsonObj?["code"])
+        let bizMsg = [Self.anyToString(jsonObj?["message"]), Self.anyToString(jsonObj?["msg"]), Self.anyToString(jsonObj?["detailMessage"])]
+            .first { !$0.isEmpty } ?? ""
+        let bizOk = bizCode.isEmpty || bizCode == "200" || bizCode.caseInsensitiveCompare("OK") == .orderedSame
+
+        if let error = error {
+            fail("network: \(error.localizedDescription)")
+            return
+        }
+        guard (200 ... 299).contains(httpCode), bizOk else {
+            fail("http=\(httpCode) biz=\(bizCode) \(String(bizMsg.prefix(120)))".trimmingCharacters(in: .whitespaces))
+            return
+        }
+
+        let sent = Set(batch.map { $0.dataNo })
+        uploadedDataNos.formUnion(sent)
+        pending.removeAll { sent.contains($0.dataNo) }
+        retryDelay = Self.firstRetryDelay
+        let stamp = DateFormatter.localizedString(from: Date(), dateStyle: .none, timeStyle: .short)
+        Self.setStatus("\(batch.count) reading(s) uploaded at \(stamp)")
+        trace("cloud upload: ok count=%{public}d pending=%{public}d", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, batch.count, pending.count)
+        if !pending.isEmpty { scheduleFlush(after: 0.5) }
+    }
+
+    private func fail(_ reason: String) {
+        trace("cloud upload failed: %{public}@ (pending=%{public}d, retry in %{public}ds)", log: log, category: ConstantsLog.categoryCGMOttai, type: .error, reason, pending.count, Int(retryDelay))
+        Self.setStatus("Failed: \(reason)")
+        scheduleRetry()
+    }
+
+    private func scheduleRetry() {
+        scheduleFlush(after: retryDelay)
+        retryDelay = min(retryDelay * 2, Self.maxRetryDelay)
+    }
+
+    // MARK: - customer id
+
+    /// The customerId header. Always the signed-in account: read once from the account
+    /// profile, or the user id when the profile has none. It can not be typed in, so an
+    /// upload can never go to another account.
+    private func resolveCustomerId() -> String {
+        if let cached = cachedCustomerId { return cached }
+        let resolved: String
+        if let profile = OttaiCloudClient.fetchUserProfile(), let found = Self.findCustomerId(in: profile) {
+            trace("cloud upload: customerId %{public}@ found in the account profile", log: log, category: ConstantsLog.categoryCGMOttai, type: .info, found)
+            resolved = found
+        } else {
+            trace("cloud upload: no customerId in the account profile, using the user id", log: log, category: ConstantsLog.categoryCGMOttai, type: .info)
+            resolved = OttaiRegistry.loadUserId()
+        }
+        cachedCustomerId = resolved
+        return resolved
+    }
+
+    static func findCustomerId(in dict: [String: Any]) -> String? {
+        for (key, value) in dict {
+            let k = key.lowercased()
+            if k == "customerid" || k == "customer_id" || k == "customerno" {
+                let s = anyToString(value)
+                if !s.isEmpty { return s }
+            }
+        }
+        for (_, value) in dict {
+            if let sub = value as? [String: Any], let found = findCustomerId(in: sub) { return found }
+        }
+        return nil
+    }
+
+    // MARK: - request
+
+    private func buildRequest(batch: [Sample], materials: OttaiRegistry.DeviceMaterials, customerId: String) -> URLRequest? {
+        guard let url = URL(string: OttaiConstants.apiBaseSyai + OttaiConstants.epCollectGlucoseV2) else { return nil }
+        let body: [String: Any] = [
+            "deviceId": materials.deviceId,
+            "embeddedSoftVersion": Self.embeddedSoftVersion(materials.deviceVersion),
+            "dataList": batch.map(Self.dataListEntry),
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: body, options: []) else { return nil }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.httpBody = data
+        for (k, v) in Self.headers(customerId: customerId) { req.setValue(v, forHTTPHeaderField: k) }
+        return req
+    }
+
+    static func dataListEntry(_ s: Sample) -> [String: Any] {
+        let mmol = (s.mmol * 10).rounded() / 10
+        return [
+            "runSec": s.runtimeSec,
+            "voltage": s.voltage,
+            "timeAppReceive": s.receivedAtMs,
+            "frontIdx": s.dataNo,
+            "glucose": mmol,
+            "cgmGlucose": mmol,
+            "adjGlucose": mmol,
+            "current": s.rawCurrent,
+            "time": s.sampleMs,
+            "glucoseStatus": glucoseStatusNormal,
+            "alignId": NSNull(),
+            "temperature": (s.temperatureC * 10).rounded() / 10,
+            "origin": s.originBytes.map { Int($0) },
+            "dataType": dataTypeSensor,
+        ]
+    }
+
+    /// The cloud stores the version as "E1.1.4(V1.7.S2530.1)". The app sends the
+    /// part in the brackets — the sensor firmware. Old versions have no brackets.
+    static func embeddedSoftVersion(_ deviceVersion: String) -> String {
+        let v = deviceVersion.trimmingCharacters(in: .whitespaces)
+        if let open = v.firstIndex(of: "("), let close = v.lastIndex(of: ")"), open < close {
+            let inner = v[v.index(after: open) ..< close].trimmingCharacters(in: .whitespaces)
+            if !inner.isEmpty { return inner }
+        }
+        return v
+    }
+
+    static func headers(customerId: String, now: Date = Date()) -> [String: String] {
+        let ts = Int64(now.timeIntervalSince1970 * 1000)
+        let tz = TimeZone.current
+        let locale = Locale.current
+        let country = locale.region?.identifier ?? "GB"
+        let language = locale.language.languageCode?.identifier ?? "en"
+        var h: [String: String] = [
+            "user-agent": userAgent,
+            "ua": "android",
+            "deviceid": "\(appName):a:n:\(OttaiRegistry.loadOrCreateCloudUploadDeviceUuid())",
+            "authorization": OttaiRegistry.loadAccessToken(),
+            "appname": appName,
+            "content-type": "application/json",
+            "timestamp": String(ts),
+            "versioncode": versionCode,
+            "country": country,
+            "traceid": UUID().uuidString.lowercased(),
+            "language": language,
+            "timezone": String(tz.secondsFromGMT(for: now)),
+            "region": country,
+            "packagename": packageName,
+            "unit": unit,
+            "timezonename": tz.abbreviation(for: now) ?? tz.identifier,
+            "devicemodel": deviceModel,
+            "versionname": versionName,
+        ]
+        if !customerId.isEmpty { h["customerid"] = customerId }
+        return h
+    }
+
+    // MARK: - helpers
+
+    private static func setStatus(_ text: String) {
+        OttaiRegistry.saveCloudUploadStatus(text)
+    }
+
+    private static func anyToString(_ any: Any?) -> String {
+        guard let any = any else { return "" }
+        if let s = any as? String { return s == "null" ? "" : s }
+        if let n = any as? NSNumber { return n.stringValue }
+        return ""
+    }
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiConstants.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiConstants.swift
@@ -1,0 +1,270 @@
+//
+//  OttaiConstants.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — Bluetooth UUIDs, cloud addresses, sensor id helpers
+//  and lifetime rules. This is a Swift copy of OttaiConstants.kt from JugglucoNG
+//  (without the Android preference keys).
+//
+//  The cloud "mac" is a 12-character hex id. The server and the Bluetooth login
+//  use it. It is not always the same as the Bluetooth address of the sensor.
+//
+//  Only Foundation is used here, so this file can be tested without Bluetooth.
+//
+
+import Foundation
+
+enum OttaiConstants {
+
+    static let tag = "Ottai"
+    static let defaultDisplayName = "Ottai CGM"
+    static let provisionalSensorPrefix = "OTTAI-"
+    static let maxNativeSensorIdChars = 16
+
+    // MARK: - Bluetooth services and characteristics (UUID text)
+
+    static let serviceDeviceInfo = "0000180a-0000-1000-8000-00805f9b34fb"
+    static let charSoftwareVersion = "00002a28-0000-1000-8000-00805f9b34fb"
+    static let charCurrentTime = "00002a2b-0000-1000-8000-00805f9b34fb"
+    static let charMaxActiveTime = "b8fd9848-0ccd-423f-bd34-2419aa7ea004"
+    static let charCgmInfoNotify = "cb627922-4e79-42e3-b107-a10e816f6caa"
+
+    static let serviceCgm = "0000181f-0000-1000-8000-00805f9b34fb"
+    static let charGlucoseLive = "00002aa7-0000-1000-8000-00805f9b34fb"
+    static let charHistoryRequest = "ccecb015-6750-41fd-ba78-3fb77d350574"
+    static let charGlucoseHistory = "69e4f45f-a180-422c-83c0-324146402112"
+    static let charCommand = "d78d0706-c775-448d-8a78-01215e7c2e11"
+
+    static let serviceAuth = "e06e1d43-1319-4ebf-94b0-5b0e5313b1f4"
+    static let charAuthDeviceParam = "86805092-92b5-4d8c-9d73-0785ff6f9147"
+    static let charAuthAppParam = "1756ef6e-884b-4eb0-b646-f04ab18408f9"
+    static let charAuthSign = "785022c6-08c0-48af-ad17-684bb889aa83"
+
+    /// Used only during activation.
+    static let serviceDestructive = "84c5b711-655a-460d-89ca-337dbc981857"
+    static let charDestructive = "6aa799b6-b374-4148-8f36-6d440c0ec203"
+
+    static let cccd = "00002902-0000-1000-8000-00805f9b34fb"
+
+    /// The "activate" command byte. It is padded with zeros and encrypted before it is sent.
+    static let activateCmd: UInt8 = 0x03
+
+    // MARK: - Cloud
+
+    static let apiBase = "https://api.ottai.com"          // China app (phone + SMS account)
+    static let apiBaseGlobal = "https://seas.ottai.com"   // Ottai global app (user name + password)
+    static let apiBaseSyai = "https://api.syai.com"       // Syai global app
+    static let apiBaseSyaiLegacy = "https://ru.syai.com"
+    static let webBaseOttai = "https://www.ottai.com/api/cgm/web"
+    static let webBaseSyai = "https://www.syai.com/api/cgm/web"
+    static let prefix = "/cgm/app/server"
+
+    static let epApiToken = "\(prefix)/user/apiToken"
+    static let epSmsCode = "\(prefix)/user/smsCode"
+    static let epSmsLogin = "\(prefix)/user/smsLogin"
+    static let epAccountLogin = "\(prefix)/user/accountLogin"
+    static let epLogout = "\(prefix)/user/logout"
+    static let epGetUser = "\(prefix)/user/getUser"
+    static let epValidateByMac = "\(prefix)/device/validateDeviceByMacV2"
+    static let epValidateByMacV3 = "\(prefix)/device/validateDeviceByMacV3"
+    static let epBind = "\(prefix)/deviceBind/composite/bind"
+    static let epBindV3 = "\(prefix)/deviceBind/composite/bindV3"
+    static let epCgmAuthVerify = "\(prefix)/cgmAuth/verify"
+    static let epUnbind = "\(prefix)/deviceBind/unBindDevice"
+    static let epGetBindDevice = "\(prefix)/deviceBind/getBindDevice"
+    static let epDeviceList = "\(prefix)/deviceBind/list"
+    static let epDownloadGlucose = "\(prefix)/search/downloadGlucose"
+    /// Upload of readings, as the Syai Tag app does it (no `prefix`). Syai server only.
+    static let epCollectGlucoseV2 = "/cgm/data/collect/collect/glucose/v2"
+
+    static let headerAppName = "ottai"
+    static let headerPackage = "com.ottai.tag"
+    static let headerAppType = "ottai_main"
+    /// A fake China IP. The China server only answers requests that look like they come from China.
+    static let cnForwardIp = "114.114.114.114"
+
+    // MARK: - Sensor id helpers
+
+    private static let macColonRegex = try! NSRegularExpression(
+        pattern: "^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$", options: [.caseInsensitive])
+    private static let macPlainRegex = try! NSRegularExpression(
+        pattern: "^[0-9A-F]{12}$", options: [.caseInsensitive])
+
+    private static func fullMatch(_ regex: NSRegularExpression, _ s: String) -> Bool {
+        let range = NSRange(s.startIndex..., in: s)
+        return regex.firstMatch(in: s, options: [], range: range) != nil
+    }
+
+    static func isProvisionalSensorId(_ name: String?) -> Bool {
+        guard let name = name?.trimmingCharacters(in: .whitespaces) else { return false }
+        return name.lowercased().hasPrefix(provisionalSensorPrefix.lowercased())
+    }
+
+    /// The cloud id in its standard form: 12 upper-case hex characters, no colons.
+    static func canonicalSensorId(_ sensorId: String?) -> String {
+        let trimmed = sensorId?.trimmingCharacters(in: .whitespaces) ?? ""
+        if trimmed.isEmpty { return "" }
+        if fullMatch(macColonRegex, trimmed) { return trimmed.uppercased().replacingOccurrences(of: ":", with: "") }
+        if fullMatch(macPlainRegex, trimmed) { return trimmed.uppercased() }
+        return trimmed
+    }
+
+    /// Add colons to a 12-hex id. Only use this when you know it is a Bluetooth address.
+    static func macWithColons(_ canonical: String) -> String {
+        let c = canonicalSensorId(canonical)
+        if !fullMatch(macPlainRegex, c) { return c }
+        return stride(from: 0, to: c.count, by: 2).map { i -> String in
+            let start = c.index(c.startIndex, offsetBy: i)
+            let end = c.index(start, offsetBy: 2)
+            return String(c[start ..< end])
+        }.joined(separator: ":")
+    }
+
+    /// Make a Bluetooth address upper-case with colons. A plain 12-hex text is only
+    /// accepted when the caller says so.
+    static func normalizeBleAddress(_ address: String?, allowPlain: Bool = false) -> String? {
+        let t = address?.trimmingCharacters(in: .whitespaces) ?? ""
+        if t.isEmpty { return nil }
+        if fullMatch(macColonRegex, t) { return t.uppercased() }
+        if allowPlain && fullMatch(macPlainRegex, t) {
+            return macWithColons(t.uppercased())
+        }
+        return nil
+    }
+
+    static func looksLikeBleAddress(_ address: String?) -> Bool {
+        normalizeBleAddress(address, allowPlain: true) != nil
+    }
+
+    static func looksLikeMac(_ s: String?) -> Bool {
+        let t = s?.trimmingCharacters(in: .whitespaces) ?? ""
+        return fullMatch(macColonRegex, t) || fullMatch(macPlainRegex, t)
+    }
+
+    static func matchesCanonicalOrKnownNativeAlias(_ a: String?, _ b: String?) -> Bool {
+        let ca = canonicalSensorId(a)
+        let cb = canonicalSensorId(b)
+        if ca.isEmpty || cb.isEmpty { return false }
+        return ca.caseInsensitiveCompare(cb) == .orderedSame
+    }
+
+    /// Find the 12-hex sensor id in a QR / barcode text.
+    ///
+    /// The box label is a GS1 code. The id is the (21) serial number, NOT the (01)
+    /// product number at the start. We score every 12-hex run: right after "21"
+    /// (+8), has a letter A-F (+4), stands alone (+2). The best one wins. If nothing
+    /// scores, the first 12-hex run is used.
+    static func extractMacFromQr(_ qr: String?) -> String? {
+        guard let qr = qr, !qr.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+        let raw = Array(qr.uppercased())
+        // A MAC with colons wins at once.
+        let rawStr = String(raw)
+        let colonRange = NSRange(rawStr.startIndex..., in: rawStr)
+        if let m = try? NSRegularExpression(pattern: "(?:[0-9A-F]{2}:){5}[0-9A-F]{2}")
+            .firstMatch(in: rawStr, options: [], range: colonRange),
+           let r = Range(m.range, in: rawStr) {
+            return canonicalSensorId(String(rawStr[r]))
+        }
+        func isHex(_ c: Character) -> Bool {
+            ("0" ... "9").contains(c) || ("A" ... "F").contains(c)
+        }
+        var best: String?
+        var bestScore = -1
+        var i = 0
+        while i + 12 <= raw.count {
+            if (i ..< i + 12).allSatisfy({ isHex(raw[$0]) }) {
+                let sub = String(raw[i ..< i + 12])
+                let afterAi21 = i >= 2 && raw[i - 1] == "1" && raw[i - 2] == "2"
+                let standalone = (i == 0 || !isHex(raw[i - 1])) && (i + 12 == raw.count || !isHex(raw[i + 12]))
+                let hasLetter = sub.contains { ("A" ... "F").contains($0) }
+                let score = (afterAi21 ? 8 : 0) + (hasLetter ? 4 : 0) + (standalone ? 2 : 0)
+                if score > bestScore { bestScore = score; best = sub }
+            }
+            i += 1
+        }
+        return best
+    }
+
+    // MARK: - Lifetime
+
+    /// The sensor lifetime the cloud reports for the tested Chinese M8.
+    static let defaultRatedLifetimeDays: Int64 = 15
+
+    static let defaultRetainTimeMs: Int64 = 172_800_000
+    static let defaultActiveExpireMs: Int64 = defaultRatedLifetimeDays * 24 * 3600 * 1000
+
+    private static let minActiveExpireMs: Int64 = 10 * 24 * 3600 * 1000
+    private static let maxActiveExpireMs: Int64 = 45 * 24 * 3600 * 1000
+
+    /// The longest lifetime we ask for during activation.
+    static let extendedLifetimeDays: Int64 = 30
+    static let extendedLifetimeMs: Int64 = extendedLifetimeDays * 24 * 3600 * 1000
+
+    /// Keep the value only if it is between 10 and 45 days. Else return 0.
+    static func sanitizeActiveExpireMs(_ value: Int64) -> Int64 {
+        (value >= minActiveExpireMs && value <= maxActiveExpireMs) ? value : 0
+    }
+
+    /// The lifetimes to try during activation, longest first.
+    static func activationMaxActiveCandidatesMs(cloudActiveExpireMs: Int64) -> [Int64] {
+        let cloudMs = sanitizeActiveExpireMs(cloudActiveExpireMs) > 0
+            ? sanitizeActiveExpireMs(cloudActiveExpireMs)
+            : defaultActiveExpireMs
+        var candidates: [Int64] = []
+        if cloudMs > extendedLifetimeMs { candidates.append(cloudMs) }
+        var days = extendedLifetimeDays
+        while days >= 15 {
+            candidates.append(days * 24 * 3600 * 1000)
+            days -= 1
+        }
+        candidates.append(cloudMs)
+        // remove doubles, keep the order
+        var seen = Set<Int64>()
+        return candidates.filter { seen.insert($0).inserted }
+    }
+
+    static func expectedLifetimeMs(cloudActiveExpireMs: Int64, acceptedMaxActiveMs: Int64) -> Int64 {
+        if sanitizeActiveExpireMs(acceptedMaxActiveMs) > 0 { return sanitizeActiveExpireMs(acceptedMaxActiveMs) }
+        if sanitizeActiveExpireMs(cloudActiveExpireMs) > 0 { return sanitizeActiveExpireMs(cloudActiveExpireMs) }
+        return defaultActiveExpireMs
+    }
+
+    static func shouldAttemptEndedSensorRecovery(commandStatus: Int, activeTimeMs: Int64, nowMs: Int64) -> Bool {
+        commandStatus == 4 && activeTimeMs > 0 && nowMs >= activeTimeMs && nowMs < activeTimeMs + extendedLifetimeMs
+    }
+
+    /// The sensor's command byte is the truth. 0, 1 or 2 means "not activated yet".
+    static func commandNeedsActivation(_ commandStatus: Int) -> Bool {
+        commandStatus >= 0 && commandStatus <= 2
+    }
+
+    /// Activation cannot be undone, so the user must ask for it.
+    static func shouldStartActivation(commandStatus: Int, explicitlyRequested: Bool) -> Bool {
+        explicitlyRequested && commandNeedsActivation(commandStatus)
+    }
+
+    /// China Ottai and Syai sensors must be woken with NFC around activation.
+    static func requiresNfcActivationWake(apiBase: String) -> Bool {
+        apiBase == OttaiConstants.apiBase || apiBase == apiBaseSyai
+    }
+
+    // MARK: - Warmup
+
+    static let defaultReadingIntervalMinutes = 1
+    static let defaultWarmupSeconds = 3200
+    static let defaultPreheatPeriodMs: Int64 = 3_600_000
+
+    /// For this time after activation, readings are decoded but not used.
+    /// The official app waits 60 minutes. Real sensors settle in about 10 minutes,
+    /// so we use 10 minutes.
+    static let warmupSuppressMs: Int64 = 600_000
+
+    /// True if the sample is inside the warmup window. Pass 0 as the start to turn
+    /// the check off.
+    static func isWithinWarmup(activationStartMs: Int64, sampleMs: Int64) -> Bool {
+        activationStartMs > 0 && sampleMs > 0 && sampleMs < activationStartMs + warmupSuppressMs
+    }
+
+    /// After the lifetime is over, wait this long without samples before calling the sensor expired.
+    static let expiredStaleGraceMs: Int64 = 6 * 3600 * 1000
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiConstants.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiConstants.swift
@@ -229,9 +229,6 @@ enum OttaiConstants {
         return defaultActiveExpireMs
     }
 
-    static func shouldAttemptEndedSensorRecovery(commandStatus: Int, activeTimeMs: Int64, nowMs: Int64) -> Bool {
-        commandStatus == 4 && activeTimeMs > 0 && nowMs >= activeTimeMs && nowMs < activeTimeMs + extendedLifetimeMs
-    }
 
     /// The sensor's command byte is the truth. 0, 1 or 2 means "not activated yet".
     static func commandNeedsActivation(_ commandStatus: Int) -> Bool {

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiCrypto.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiCrypto.swift
@@ -1,0 +1,261 @@
+//
+//  OttaiCrypto.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — encryption helpers.
+//
+//  This is a Swift copy of OttaiCrypto.kt from JugglucoNG.
+//
+//  The account has a secret key called `glucoseSecretKey`. The cloud sends three
+//  encrypted fields for each sensor:
+//    - keyA        -> six 16-byte keys for the Bluetooth login (192 hex chars)
+//    - method      -> the glucose formula (see OttaiFormula)
+//    - coefficient -> the numbers used by that formula
+//
+//  Each field has its own AES key:
+//    fieldKey = glucoseSecretKey + last 10 chars of <time> + last 6 chars of <mac>
+//  The cipher is AES in ECB mode with PKCS5 padding. There is no IV.
+//
+//  Bluetooth data uses AES ECB with "zero byte padding". We do the same thing with
+//  AES ECB "no padding" and add the zero bytes ourselves.
+//
+//  No network, no Bluetooth here. AES comes from CommonCrypto, which is the only
+//  system API that offers ECB (CryptoKit deliberately does not).
+//
+
+import CommonCrypto
+import Foundation
+
+enum OttaiCrypto {
+
+    /// Six 16-byte Bluetooth login keys come out of one decrypted keyA.
+    static let authKeyCount = 6
+    static let authKeyBytes = 16
+    static let authKeyHexLen = authKeyCount * authKeyBytes * 2 // 192
+
+    // MARK: - cloud secret chain
+
+    /// The last [n] characters of [s].
+    static func takeLast(_ n: Int, _ s: String) -> String {
+        if n <= 0 { return "" }
+        if s.count <= n { return s }
+        return String(s.suffix(n))
+    }
+
+    /// Build the AES key text for one cloud field.
+    ///
+    /// - Parameters:
+    ///   - glucoseSecretKey: the account secret from login (never log it)
+    ///   - fieldTimestamp: produceTime, methodUpdateTime or coeffUpdateTime
+    ///   - mac: the sensor MAC. Only the last 6 characters are used, as in the app.
+    static func deriveFieldKey(glucoseSecretKey: String, fieldTimestamp: String, mac: String) -> String {
+        glucoseSecretKey + takeLast(10, fieldTimestamp) + takeLast(6, mac)
+    }
+
+    static func deriveFieldKey(glucoseSecretKey: String, fieldTimestamp: Int64, mac: String) -> String {
+        deriveFieldKey(glucoseSecretKey: glucoseSecretKey, fieldTimestamp: String(fieldTimestamp), mac: mac)
+    }
+
+    /// Decrypt one base64 cloud field with AES ECB PKCS5.
+    /// - Returns: the text, or nil if anything fails.
+    static func decryptCloudField(base64Cipher: String, fieldKey: String) -> String? {
+        guard let cipherBytes = base64Decode(base64Cipher) else { return nil }
+        guard let plain = aesECB(.decrypt, key: Array(fieldKey.utf8), data: cipherBytes, pkcs7Padded: true) else { return nil }
+        return String(bytes: plain, encoding: .utf8)
+    }
+
+    /// Encrypt text with AES ECB PKCS5 and return base64. Only used in tests.
+    static func encryptCloudField(plaintext: String, fieldKey: String) -> String? {
+        guard let out = aesECB(.encrypt, key: Array(fieldKey.utf8), data: Array(plaintext.utf8), pkcs7Padded: true) else { return nil }
+        return Data(out).base64EncodedString()
+    }
+
+    /// Decrypt keyA. The time is produceTime.
+    static func decryptKeyA(base64KeyA: String, glucoseSecretKey: String, produceTime: String, mac: String) -> String? {
+        decryptCloudField(base64Cipher: base64KeyA,
+                          fieldKey: deriveFieldKey(glucoseSecretKey: glucoseSecretKey, fieldTimestamp: produceTime, mac: mac))
+    }
+
+    /// Decrypt the method. The time is methodUpdateTime.
+    static func decryptMethod(base64Method: String, glucoseSecretKey: String, methodUpdateTime: String, mac: String) -> String? {
+        decryptCloudField(base64Cipher: base64Method,
+                          fieldKey: deriveFieldKey(glucoseSecretKey: glucoseSecretKey, fieldTimestamp: methodUpdateTime, mac: mac))
+    }
+
+    /// Decrypt the coefficients. The time is coeffUpdateTime.
+    static func decryptCoefficient(base64Coeff: String, glucoseSecretKey: String, coeffUpdateTime: String, mac: String) -> String? {
+        decryptCloudField(base64Cipher: base64Coeff,
+                          fieldKey: deriveFieldKey(glucoseSecretKey: glucoseSecretKey, fieldTimestamp: coeffUpdateTime, mac: mac))
+    }
+
+    /// Split a decrypted keyA (192 hex chars) into six 16-byte keys.
+    /// Returns nil if the text is not exactly 192 hex chars.
+    static func parseAuthKeys(_ keyAHexPlain: String) -> [[UInt8]]? {
+        let hex = keyAHexPlain.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hex.count != authKeyHexLen { return nil }
+        if !hex.allSatisfy({ $0.isHexChar }) { return nil }
+        let chars = Array(hex)
+        var out: [[UInt8]] = []
+        for i in 0 ..< authKeyCount {
+            let sub = String(chars[(i * 32) ..< (i * 32 + 32)])
+            out.append(hexToBytes(sub))
+        }
+        return out
+    }
+
+    // MARK: - Bluetooth data (session key)
+    //
+    // The app uses AES ECB with zero byte padding and the session key as bytes.
+    // Encrypt: add zero bytes up to a multiple of 16. Decrypt: if the length is
+    // even and the last 8 bytes are all zero, drop those 8 bytes.
+
+    /// Decrypt a live or history packet with the session key (hex text).
+    static func decryptPayload(_ cipher: [UInt8], sessionKeyHex: String) -> [UInt8]? {
+        guard let key = try? hexToBytesStrict(sessionKeyHex) else { return nil }
+        if cipher.isEmpty || cipher.count % 16 != 0 { return nil }
+        guard let plain = aesECB(.decrypt, key: key, data: cipher, pkcs7Padded: false) else { return nil }
+        return trimTrailingZeroBlock(plain)
+    }
+
+    static func decryptPayload(_ cipher: Data, sessionKeyHex: String) -> [UInt8]? {
+        decryptPayload([UInt8](cipher), sessionKeyHex: sessionKeyHex)
+    }
+
+    /// Drop the last 8 bytes only when the length is even and they are all zero.
+    private static func trimTrailingZeroBlock(_ data: [UInt8]) -> [UInt8] {
+        if data.count >= 8 && data.count % 2 == 0 {
+            var allZero = true
+            for i in (data.count - 8) ..< data.count where data[i] != 0 {
+                allZero = false
+                break
+            }
+            if allZero { return Array(data[0 ..< (data.count - 8)]) }
+        }
+        return data
+    }
+
+    /// Build the "activate" command: pad [cmd] with zeros to 16 bytes, then encrypt
+    /// with the session key.
+    static func encryptActivateCmd(_ cmd: [UInt8], sessionKeyHex: String) -> [UInt8]? {
+        guard let key = try? hexToBytesStrict(sessionKeyHex) else { return nil }
+        return aesECB(.encrypt, key: key, data: zeroPad16(cmd), pkcs7Padded: false)
+    }
+
+    /// Encrypt any bytes with zero padding and the session key.
+    static func encryptPayload(_ plain: [UInt8], sessionKeyHex: String) -> [UInt8]? {
+        guard let key = try? hexToBytesStrict(sessionKeyHex) else { return nil }
+        return aesECB(.encrypt, key: key, data: zeroPad16(plain), pkcs7Padded: false)
+    }
+
+    private static func zeroPad16(_ data: [UInt8]) -> [UInt8] {
+        if data.isEmpty { return [UInt8](repeating: 0, count: 16) }
+        let rem = data.count % 16
+        if rem == 0 { return data }
+        return data + [UInt8](repeating: 0, count: 16 - rem)
+    }
+
+    // MARK: - AES ECB
+
+    enum AESOperation {
+        case encrypt
+        case decrypt
+
+        var ccOperation: CCOperation {
+            CCOperation(self == .encrypt ? kCCEncrypt : kCCDecrypt)
+        }
+    }
+
+    /// AES in ECB mode, with or without PKCS7 padding. There is no IV.
+    ///
+    /// - Returns: the result, or nil when the key length is not an AES key length, when unpadded
+    ///   data is not a whole number of blocks, or when CommonCrypto reports a failure.
+    static func aesECB(_ operation: AESOperation, key: [UInt8], data: [UInt8], pkcs7Padded: Bool) -> [UInt8]? {
+        guard key.count == kCCKeySizeAES128 || key.count == kCCKeySizeAES192 || key.count == kCCKeySizeAES256 else { return nil }
+        guard pkcs7Padded || (!data.isEmpty && data.count % kCCBlockSizeAES128 == 0) else { return nil }
+        if data.isEmpty && operation == .decrypt { return [] }
+
+        var options = CCOptions(kCCOptionECBMode)
+        if pkcs7Padded { options |= CCOptions(kCCOptionPKCS7Padding) }
+
+        var out = [UInt8](repeating: 0, count: data.count + kCCBlockSizeAES128)
+        let outCapacity = out.count
+        var outLength = 0
+
+        let status = out.withUnsafeMutableBytes { outBytes in
+            key.withUnsafeBytes { keyBytes in
+                data.withUnsafeBytes { dataBytes in
+                    CCCrypt(
+                        operation.ccOperation,
+                        CCAlgorithm(kCCAlgorithmAES),
+                        options,
+                        keyBytes.baseAddress, key.count,
+                        nil,
+                        dataBytes.baseAddress, data.count,
+                        outBytes.baseAddress, outCapacity,
+                        &outLength
+                    )
+                }
+            }
+        }
+
+        guard status == CCCryptorStatus(kCCSuccess) else { return nil }
+        return Array(out[0 ..< outLength])
+    }
+
+    // MARK: - hex
+
+    static func hexToBytes(_ hex: String) -> [UInt8] {
+        (try? hexToBytesStrict(hex)) ?? []
+    }
+
+    /// Same as hexToBytes, but throws on bad text. Used for the session key.
+    static func hexToBytesStrict(_ hex: String) throws -> [UInt8] {
+        let chars = Array(hex)
+        guard chars.count % 2 == 0 else { throw OttaiCryptoError.oddHexLength }
+        var out = [UInt8]()
+        out.reserveCapacity(chars.count / 2)
+        var i = 0
+        while i < chars.count {
+            guard let hi = chars[i].hexDigitValue, let lo = chars[i + 1].hexDigitValue else {
+                throw OttaiCryptoError.badHexChar
+            }
+            out.append(UInt8((hi << 4) | lo))
+            i += 2
+        }
+        return out
+    }
+
+    static func bytesToHex(_ bytes: [UInt8]) -> String {
+        var s = String()
+        s.reserveCapacity(bytes.count * 2)
+        for b in bytes {
+            s.append(hexDigits[Int(b >> 4)])
+            s.append(hexDigits[Int(b & 0x0F)])
+        }
+        return s
+    }
+
+    static func bytesToHex(_ data: Data) -> String { bytesToHex([UInt8](data)) }
+
+    private static let hexDigits = Array("0123456789abcdef")
+
+    // MARK: - base64
+
+    static func base64Decode(_ s: String) -> [UInt8]? {
+        let clean = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        if clean.isEmpty { return [] }
+        guard let data = Data(base64Encoded: clean) else { return nil }
+        return [UInt8](data)
+    }
+
+    enum OttaiCryptoError: Error {
+        case oddHexLength
+        case badHexChar
+    }
+}
+
+private extension Character {
+    var isHexChar: Bool {
+        ("0" ... "9").contains(self) || ("a" ... "f").contains(self) || ("A" ... "F").contains(self)
+    }
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiFormula.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiFormula.swift
@@ -1,0 +1,146 @@
+//
+//  OttaiFormula.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — runs the glucose formula from the cloud.
+//
+//  This is a Swift copy of OttaiFormula.kt from JugglucoNG. The cloud sends a
+//  `method` (a small program in reverse Polish notation) and `coefficient`
+//  (numbers). We put the values in and run it to get the glucose in mmol/L.
+//
+//  Method format: groups are separated by `;`. Tokens in a group are separated by
+//  spaces. A token is an operator, a number, or a name that we replace first:
+//    C{i}  coefficient number i
+//    V{i}  V0..V5 = current, temperature, runtime, dataNo, runtime/3600 (int), voltage
+//    B{i}  byte i of the 12-byte record, read as a signed number
+//    R{i}  the result of group i (an earlier group)
+//  The result of the LAST group is the glucose. Values under 0.1 become 0.0.
+//
+
+import Foundation
+
+enum OttaiFormula {
+
+    /// The 29 operators. Same order as in the official app.
+    private static let operators: Set<String> = [
+        "AD", "SB", "ML", "DV", "NG", "AB", "SQ", "PW", "BW", "BE", "GT", "GE",
+        "LT", "LE", "RD", "LN", "MX", "MI", "SN", "CS", "TN", "AS", "AC", "AT",
+        "BA", "BO", "BN", "BX", "MD",
+    ]
+
+    /// Run the [methodText] for one record.
+    ///
+    /// - Parameters:
+    ///   - coefficients: the decrypted numbers (C0..Cn)
+    ///   - v: V0..V5: [current, temperature, runtime, dataNo, runtime/3600(int), voltage]
+    ///   - recordBytes: the 12-byte record; B{i} uses the SIGNED byte value
+    /// - Returns: the glucose value (last group result; under 0.1 becomes 0.0)
+    static func evaluate(methodText: String, coefficients: [Double], v: [Double], recordBytes: [UInt8]) -> Double {
+        if methodText.trimmingCharacters(in: .whitespaces).isEmpty { return 0.0 }
+        let groups = methodText.split(separator: ";", omittingEmptySubsequences: false).map(String.init)
+        var groupResults: [Double] = []
+
+        for group in groups {
+            let rawTokens = group.split(separator: " ").map(String.init).filter { !$0.isEmpty }
+            if rawTokens.isEmpty { continue }
+            let tokens = rawTokens.map { substitute($0, coefficients: coefficients, v: v, recordBytes: recordBytes, priorResults: groupResults) }
+            groupResults.append(evalGroup(tokens))
+        }
+
+        guard var adjust = groupResults.last else { return 0.0 }
+        if adjust < 0.1 { adjust = 0.0 }
+        return adjust
+    }
+
+    private static func substitute(_ token: String, coefficients: [Double], v: [Double], recordBytes: [UInt8], priorResults: [Double]) -> String {
+        if token.count >= 2 {
+            let first = token.first!
+            let idxStr = String(token.dropFirst())
+            if let idx = Int(idxStr), idx >= 0 {
+                switch first {
+                case "C": if idx < coefficients.count { return String(coefficients[idx]) }
+                case "V": if idx < v.count { return String(v[idx]) }
+                case "B": if idx < recordBytes.count { return String(Int(Int8(bitPattern: recordBytes[idx]))) } // signed
+                case "R": if idx < priorResults.count { return String(priorResults[idx]) }
+                default: break
+                }
+            }
+        }
+        return token
+    }
+
+    /// Run one group as a stack machine. `sp` starts at -1. A number is pushed
+    /// (sp goes up). An operator reads from the stack and writes its result. The
+    /// group result is stack[0].
+    private static func evalGroup(_ tokens: [String]) -> Double {
+        if tokens.isEmpty { return 0.0 }
+        var stack = [Double](repeating: 0.0, count: tokens.count)
+        var sp = -1
+        for tok in tokens {
+            let op = tok.uppercased()
+            if operators.contains(op) {
+                var r = 1.0 // default value in the original app
+                switch op {
+                case "AD": sp -= 1; r = stack[sp + 1] + stack[sp]
+                case "SB": sp -= 1; r = stack[sp] - stack[sp + 1]
+                case "ML": sp -= 1; r = stack[sp + 1] * stack[sp]
+                case "DV": sp -= 1; r = stack[sp] / stack[sp + 1]
+                case "NG": r = -stack[sp]
+                case "AB": r = abs(stack[sp])
+                case "SQ": r = sqrt(stack[sp])
+                case "PW": sp -= 1; r = pow(stack[sp], stack[sp + 1])
+                case "BW":
+                    sp -= 3
+                    r = (stack[sp + 1] >= stack[sp] || stack[sp] >= stack[sp + 2]) ? 0.0
+                        : (stack[sp + 3] != 1.0 ? stack[sp] : 1.0)
+                case "BE":
+                    sp -= 3
+                    r = (stack[sp + 1] <= stack[sp] && stack[sp] <= stack[sp + 2] && stack[sp + 3] != 1.0)
+                        ? stack[sp] : 1.0
+                case "GT": sp -= 2; r = stack[sp] > stack[sp + 1] ? stack[sp + 2] : 0.0
+                case "GE": sp -= 2; r = stack[sp] >= stack[sp + 1] ? stack[sp + 2] : 0.0
+                case "LT": sp -= 2; r = stack[sp] < stack[sp + 1] ? stack[sp + 2] : 0.0
+                case "LE": sp -= 2; r = stack[sp] <= stack[sp + 1] ? stack[sp + 2] : 0.0
+                case "RD":
+                    sp -= 1
+                    let decimals = Int(stack[sp + 1])
+                    r = Double(String(format: "%.\(max(0, decimals))f", stack[sp])) ?? stack[sp]
+                case "LN": r = log(stack[sp])
+                case "MX": sp -= 1; r = max(stack[sp], stack[sp + 1])
+                case "MI": sp -= 1; r = min(stack[sp], stack[sp + 1])
+                case "SN": r = sin(stack[sp])
+                case "CS": r = cos(stack[sp])
+                case "TN": r = tan(stack[sp])
+                case "AS": r = asin(stack[sp])
+                case "AC": r = acos(stack[sp])
+                case "AT": r = atan(stack[sp])
+                case "BA": sp -= 1; r = Double(Int(stack[sp]) & Int(stack[sp + 1]))
+                case "BO": sp -= 1; r = Double(Int(stack[sp]) | Int(stack[sp + 1]))
+                case "BN": r = Double(~Int(stack[sp]))
+                case "BX": sp -= 1; r = Double(Int(stack[sp]) ^ Int(stack[sp + 1]))
+                case "MD": sp -= 1; r = Double(Int(stack[sp]) % Int(stack[sp + 1]))
+                default: break
+                }
+                if sp < 0 { sp = 0 } // protect against a bad formula
+                stack[sp] = r
+            } else {
+                sp += 1
+                if sp >= stack.count { return stack.isEmpty ? 0.0 : stack[0] }
+                stack[sp] = Double(tok) ?? 0.0
+            }
+        }
+        return stack.isEmpty ? 0.0 : stack[0]
+    }
+
+    /// Build the V0..V5 list from one record.
+    static func buildVariables(rawCurrent: Int, temperature: Double, runtimeSec: Int, dataNo: Int, voltage: Int) -> [Double] {
+        [
+            Double(rawCurrent),
+            temperature,
+            Double(runtimeSec),
+            Double(dataNo),
+            Double(runtimeSec / 3600), // whole number division, like the original
+            Double(voltage),
+        ]
+    }
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiMethodDefaults.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiMethodDefaults.swift
@@ -1,0 +1,47 @@
+//
+//  OttaiMethodDefaults.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — the default formula for the common 14-coefficient
+//  sensors. This is a Swift copy of OttaiMethodDefaults.kt from JugglucoNG.
+//
+//  The official app keeps the formula it got before. When the cloud later sends
+//  only coefficients and no formula, the app keeps using the saved one. V1.5 and
+//  V1.7 sensors seen so far all use these 14 numbers and this formula.
+//
+
+import Foundation
+
+enum OttaiMethodDefaults {
+
+    static let standard14CoeffMethod: String =
+        "V1 C0 ad C1 ml C2 ad;" +
+        "V0 R0 2 pw dv;" +
+        "C3 0 ml C4 R1 2 pw ml ad C5 R1 ml ad C6 ad;" +
+        "C7 R2 2 pw ml C8 R2 ml ad C9 ad;" +
+        "C10 V2 86400 dv C11 ml sb V2 C12 1 le ml V2 C12 1 gt C13 ml ad;" +
+        "R3 R4 ml 1 rd"
+
+    /// Use the given formula. If it is empty and the coefficients look like the
+    /// common 14-number set, use the default formula.
+    static func resolve(method: String, coefficient: String) -> String {
+        let explicit = method.trimmingCharacters(in: .whitespaces)
+        if !explicit.isEmpty { return explicit }
+        return matchesStandard14CoefficientProfile(coefficient) ? standard14CoeffMethod : ""
+    }
+
+    static func matchesStandard14CoefficientProfile(_ coefficient: String) -> Bool {
+        let parts = coefficient.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        var values: [Double] = []
+        for part in parts {
+            guard let d = Double(part) else { return false }
+            values.append(d)
+        }
+        if values.count != 14 { return false }
+        if values.contains(where: { !$0.isFinite }) { return false }
+        let splitAgeSeconds = values[12]
+        let lateWearMask = values[13]
+        return splitAgeSeconds >= 86_400.0 && splitAgeSeconds <= 604_800.0 &&
+            lateWearMask >= 0.0 && lateWearMask <= 2.0
+    }
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiOutputFilter.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiOutputFilter.swift
@@ -1,0 +1,51 @@
+//
+//  OttaiOutputFilter.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — the last check before a reading is used.
+//  This is a Swift copy of OttaiOutputFilter.kt from JugglucoNG.
+//
+//  The parser and the formula do not filter anything. This file throws away
+//  impossible values and single-sample spikes seen on real sensors.
+//
+
+import Foundation
+
+enum OttaiOutputFilter {
+
+    static let minRawCurrent = 1000
+    static let maxTemperatureC = 45.0
+    /// A sensor on the body is never this cold. Without a lower limit, a broken
+    /// packet with a low temperature would pass.
+    static let minTemperatureC = 15.0
+    static let maxGlucoseMmol: Float = 40.0
+
+    /// A one-minute jump this big, together with a big jump in the raw current,
+    /// is treated as noise.
+    static let singleSampleDeltaMmol: Float = 1.5
+    static let rawExcursionRatio: Float = 0.18
+
+    /// Returns a reason text if the record must be thrown away, or nil if it is fine.
+    static func hardRejectReason(record: OttaiRecord, mmol: Float) -> String? {
+        if !mmol.isFinite || mmol <= 0 { return "glucose=\(mmol)" }
+        if mmol > maxGlucoseMmol { return "glucose=\(mmol)" }
+        if record.rawCurrent < minRawCurrent { return "raw=\(record.rawCurrent)" }
+        if !record.temperatureC.isFinite ||
+            record.temperatureC > maxTemperatureC ||
+            record.temperatureC < minTemperatureC {
+            return "temp=\(record.temperatureC)"
+        }
+        return nil
+    }
+
+    /// True if this sample is a single-sample spike compared to the last good sample.
+    static func isOneMinuteRawExcursion(candidateMmol: Float, candidateRaw: Int, baselineMmol: Float, baselineRaw: Int) -> Bool {
+        if !candidateMmol.isFinite || !baselineMmol.isFinite { return false }
+        if candidateMmol <= 0 || baselineMmol <= 0 { return false }
+        if candidateRaw <= 0 || baselineRaw <= 0 { return false }
+
+        let glucoseDelta = abs(candidateMmol - baselineMmol)
+        let rawDeltaRatio = Float(abs(candidateRaw - baselineRaw)) / Float(baselineRaw)
+        return glucoseDelta >= singleSampleDeltaMmol && rawDeltaRatio >= rawExcursionRatio
+    }
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiParser.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiParser.swift
@@ -1,0 +1,231 @@
+//
+//  OttaiParser.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — reads the live and history packets from the sensor.
+//
+//  This is a Swift copy of OttaiParser.kt from JugglucoNG.
+//
+//  A decrypted packet looks like this:
+//    bytes 0..3   status (not used)
+//    bytes 4..5   the dataNo of the first record (little-endian)
+//    bytes 6..7   marker / count (little-endian)
+//    bytes 8..N   the records, 8 or 9 bytes each
+//  We turn every record into a 12-byte record for the parser:
+//    {0x00,0x00} || dataNo (little-endian) || the 8 record bytes
+//  Fields of the 12-byte record:
+//    [2..3]   dataNo (little-endian)
+//    [4]      voltage
+//    [5..7]   runtime = (b5<<16) | (b7<<8) | b6   (this mixed order is correct)
+//    [8..9]   raw current (little-endian)
+//    [10..11] temperature*100 (little-endian) -> /100.0
+//
+//  Live mode uses only the LAST record. History mode uses all records.
+//
+
+import Foundation
+
+struct OttaiRecord {
+    let dataNo: Int
+    let voltage: Int
+    let runtimeSec: Int
+    let rawCurrent: Int
+    let temperatureC: Double
+    /// The 12-byte record (00 00 ‖ dataNo ‖ 8 bytes).
+    let recordBytes: [UInt8]
+}
+
+struct OttaiReading {
+    let record: OttaiRecord
+    /// The formula result. 0.0 means too low or invalid.
+    let adjustGlucose: Double
+    /// activeTimeMs + runtimeSec*1000. 0 if the activation time is unknown.
+    let monitorTimeMs: Int64
+    /// False when the record fails the sanity check.
+    let valid: Bool
+}
+
+enum OttaiParser {
+
+    static let headerSize = 8
+    static let bleRecordSize = 8
+    /// Some V1.7 sensors use 9-byte records with a different layout.
+    static let bleRecordSizeE12 = 9
+    static let parserRecordSize = 12
+    static let invalidDataNo = 65535
+
+    /// Firmware families where we know the record size for sure.
+    private static let confirmedEFamilies: [String: Int] = [
+        "1.2": bleRecordSizeE12, // E1.2.3(V1.7.SH2542.1) — 9-byte
+    ]
+
+    /// The E-number at the start of a version text: `E1.1.4(...)`, `vE1.2.3(...)`.
+    private static let eNumberRegex = try! NSRegularExpression(
+        pattern: "(?:^|[^0-9A-Za-z])v?e(\\d+)\\.(\\d+)",
+        options: [.caseInsensitive]
+    )
+
+    /// Choose the record size for a packet.
+    ///
+    /// The version text is not enough: a Syai sensor and a CN V3 sensor can both
+    /// say E1.1.4(V1.7.S2530.1) but use different layouts. So we only trust the
+    /// version for known families. For the rest we try both sizes and count how
+    /// many records look valid (current >= 1000, temperature <= 45). The wrong size
+    /// gives nonsense like 505 °C, so it loses.
+    static func chooseRecordSize(_ payload: [UInt8], deviceVersion: String) -> Int {
+        if let confirmed = confirmedRecordSize(deviceVersion) { return confirmed }
+        let nine = vendorValidCount(payload, recSize: bleRecordSizeE12, curLo: 0, tempLo: 7)
+        let eight = vendorValidCount(payload, recSize: bleRecordSize, curLo: 4, tempLo: 6)
+        return nine > eight ? bleRecordSizeE12 : bleRecordSize
+    }
+
+    /// Record size for firmware we know; nil if unknown.
+    private static func confirmedRecordSize(_ deviceVersion: String) -> Int? {
+        let range = NSRange(deviceVersion.startIndex..., in: deviceVersion)
+        if let m = eNumberRegex.firstMatch(in: deviceVersion, options: [], range: range),
+           let r1 = Range(m.range(at: 1), in: deviceVersion),
+           let r2 = Range(m.range(at: 2), in: deviceVersion) {
+            let key = "\(deviceVersion[r1]).\(deviceVersion[r2])"
+            if let size = confirmedEFamilies[key] { return size }
+        }
+        // Old version texts without an E-number. V1.5 is always 8 bytes.
+        // V1.7 is not clear, so it is not listed here and we guess from the data.
+        if deviceVersion.range(of: "V1.5", options: .caseInsensitive) != nil { return bleRecordSize }
+        return nil
+    }
+
+    /// Count the records that pass the simple validity check for this record size.
+    private static func vendorValidCount(_ payload: [UInt8], recSize: Int, curLo: Int, tempLo: Int) -> Int {
+        let count = (payload.count - headerSize) / recSize
+        if count <= 0 { return 0 }
+        var valid = 0
+        for i in 0 ..< count {
+            let src = headerSize + i * recSize
+            if src + tempLo + 1 >= payload.count { break }
+            let current = le16(payload[src + curLo], payload[src + curLo + 1])
+            let temperature = Double(le16(payload[src + tempLo], payload[src + tempLo + 1])) / 100.0
+            if current >= 1000 && temperature <= 45.0 { valid += 1 }
+        }
+        return valid
+    }
+
+    private static func le16(_ lo: UInt8, _ hi: UInt8) -> Int {
+        Int(lo) | (Int(hi) << 8)
+    }
+
+    /// The dataNo of the first record (bytes 4..5).
+    static func frontDataNo(_ payload: [UInt8]) -> Int {
+        if payload.count < 6 { return 0 }
+        return le16(payload[4], payload[5])
+    }
+
+    /// Split a decrypted packet into 12-byte records. Extra bytes at the end are
+    /// ignored. Returns an empty list if there are no records.
+    static func frameRecords(_ payload: [UInt8], deviceVersion: String = "") -> [[UInt8]] {
+        if payload.count <= headerSize { return [] }
+        let front = frontDataNo(payload)
+        let bleSize = chooseRecordSize(payload, deviceVersion: deviceVersion)
+        let nineByte = bleSize == bleRecordSizeE12
+        let bodyLen = payload.count - headerSize
+        let count = bodyLen / bleSize
+        if count <= 0 { return [] }
+        var out: [[UInt8]] = []
+        out.reserveCapacity(count)
+        for i in 0 ..< count {
+            let src = headerSize + i * bleSize
+            // 9-byte packets fill the end with zero records. Skip them, so the live
+            // path gets the real last record.
+            if nineByte && (0 ..< bleSize).allSatisfy({ payload[src + $0] == 0 }) { continue }
+            let dataNo = (front + i) & 0xFFFF
+            var rec = [UInt8](repeating: 0, count: parserRecordSize)
+            rec[2] = UInt8(dataNo & 0xFF)
+            rec[3] = UInt8((dataNo >> 8) & 0xFF)
+            if nineByte {
+                // Move the 9-byte fields into the 12-byte layout, so the parser and the
+                // formula stay the same. The 16-bit runtime counter wraps around, so we
+                // take runtime from dataNo (= minutes since activation) instead.
+                let runtime = dataNo * 60
+                rec[4] = payload[src + 6]                        // voltage
+                rec[5] = UInt8((runtime >> 16) & 0xFF)           // runtime (b5<<16)
+                rec[6] = UInt8(runtime & 0xFF)                   // runtime (| b6)
+                rec[7] = UInt8((runtime >> 8) & 0xFF)            // runtime (| b7<<8)
+                rec[8] = payload[src + 0]                        // current LE lo
+                rec[9] = payload[src + 1]                        // current LE hi
+                rec[10] = payload[src + 7]                       // temp*100 LE lo
+                rec[11] = payload[src + 8]                       // temp*100 LE hi
+            } else {
+                for j in 0 ..< bleRecordSize { rec[4 + j] = payload[src + j] }
+            }
+            out.append(rec)
+        }
+        return out
+    }
+
+    /// Read the fields of a 12-byte record.
+    static func parseRecord(_ rec: [UInt8]) -> OttaiRecord {
+        precondition(rec.count >= parserRecordSize, "record too short")
+        let dataNo = le16(rec[2], rec[3])
+        let voltage = Int(rec[4])
+        let b5 = Int(rec[5])
+        let b6 = Int(rec[6])
+        let b7 = Int(rec[7])
+        let runtime = (b5 << 16) | (b7 << 8) | b6
+        let rawCurrent = le16(rec[8], rec[9])
+        let temperature = Double(le16(rec[10], rec[11])) / 100.0
+        return OttaiRecord(dataNo: dataNo, voltage: voltage, runtimeSec: runtime,
+                           rawCurrent: rawCurrent, temperatureC: temperature, recordBytes: rec)
+    }
+
+    /// Sanity check from the official app: dataNo must not be 65535, and after
+    /// dataNo 60 the dataNo and runtime/60 must not differ by more than 120.
+    static func isRecordSane(_ rec: OttaiRecord) -> Bool {
+        if rec.dataNo == invalidDataNo { return false }
+        if rec.dataNo >= 60 && abs(rec.dataNo - (rec.runtimeSec / 60)) > 120 { return false }
+        return true
+    }
+
+    /// True for an "average" record: runtime >= warmup, dataNo >= 5, dataNo is a multiple of 5.
+    static func isAverageTick(_ rec: OttaiRecord, warmupSec: Int = 3200) -> Bool {
+        rec.runtimeSec >= warmupSec && rec.dataNo >= 5 && rec.dataNo % 5 == 0
+    }
+
+    // MARK: - full parse (decrypt → records → formula)
+
+    /// Live: decrypt, take the last record, run the formula.
+    static func parseLive(cipher: [UInt8], sessionKeyHex: String, method: String, coefficients: [Double], activeTimeMs: Int64) -> OttaiReading? {
+        guard let payload = OttaiCrypto.decryptPayload(cipher, sessionKeyHex: sessionKeyHex) else { return nil }
+        let records = frameRecords(payload)
+        guard let last = records.last else { return nil }
+        return toReading(last, method: method, coefficients: coefficients, activeTimeMs: activeTimeMs)
+    }
+
+    /// History: decrypt, take all records, run the formula on each.
+    static func parseHistory(cipher: [UInt8], sessionKeyHex: String, method: String, coefficients: [Double], activeTimeMs: Int64) -> [OttaiReading] {
+        guard let payload = OttaiCrypto.decryptPayload(cipher, sessionKeyHex: sessionKeyHex) else { return [] }
+        return frameRecords(payload).map { toReading($0, method: method, coefficients: coefficients, activeTimeMs: activeTimeMs) }
+    }
+
+    /// Make a reading from one 12-byte record (no decryption here).
+    static func toReading(_ rec12: [UInt8], method: String, coefficients: [Double], activeTimeMs: Int64) -> OttaiReading {
+        let record = parseRecord(rec12)
+        let adjust: Double
+        if method.trimmingCharacters(in: .whitespaces).isEmpty {
+            adjust = 0.0
+        } else {
+            adjust = OttaiFormula.evaluate(
+                methodText: method,
+                coefficients: coefficients,
+                v: OttaiFormula.buildVariables(
+                    rawCurrent: record.rawCurrent,
+                    temperature: record.temperatureC,
+                    runtimeSec: record.runtimeSec,
+                    dataNo: record.dataNo,
+                    voltage: record.voltage
+                ),
+                recordBytes: rec12
+            )
+        }
+        let monitorMs = activeTimeMs > 0 ? activeTimeMs + Int64(record.runtimeSec) * 1000 : 0
+        return OttaiReading(record: record, adjustGlucose: adjust, monitorTimeMs: monitorMs, valid: isRecordSane(record))
+    }
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiParser.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiParser.swift
@@ -72,11 +72,51 @@ enum OttaiParser {
     /// version for known families. For the rest we try both sizes and count how
     /// many records look valid (current >= 1000, temperature <= 45). The wrong size
     /// gives nonsense like 505 °C, so it loses.
-    static func chooseRecordSize(_ payload: [UInt8], deviceVersion: String) -> Int {
+    ///
+    /// A live packet is 24 bytes: a header, one 9-byte record and 7 bytes of padding.
+    /// The same 24 bytes also fit a header and two 8-byte records. Two records win over
+    /// one, so a live packet is always read as 8-byte. Then the second "record" is only
+    /// padding and gets rejected, and the live path (which uses only the last record)
+    /// never sees the real one. The reading for that minute is lost. So a packet this
+    /// small must not choose the size. Pass `learned` once `decisiveRecordSize` has
+    /// found it for this sensor.
+    static func chooseRecordSize(_ payload: [UInt8], deviceVersion: String, learned: Int? = nil) -> Int {
         if let confirmed = confirmedRecordSize(deviceVersion) { return confirmed }
-        let nine = vendorValidCount(payload, recSize: bleRecordSizeE12, curLo: 0, tempLo: 7)
-        let eight = vendorValidCount(payload, recSize: bleRecordSize, curLo: 4, tempLo: 6)
+        if let learned = learned, learned == bleRecordSize || learned == bleRecordSizeE12 { return learned }
+        let (nine, eight) = recordSizeEvidence(payload)
         return nine > eight ? bleRecordSizeE12 : bleRecordSize
+    }
+
+    /// How many valid records the packet has when read as 9-byte and as 8-byte records,
+    /// in that order. One function, so the choice, the proof test and the log all use
+    /// the same numbers.
+    static func recordSizeEvidence(_ payload: [UInt8]) -> (nine: Int, eight: Int) {
+        (
+            vendorValidCount(payload, recSize: bleRecordSizeE12, curLo: 0, tempLo: 7),
+            vendorValidCount(payload, recSize: bleRecordSize, curLo: 4, tempLo: 6)
+        )
+    }
+
+    /// How many valid records the winner needs before we trust it. A 24-byte live
+    /// packet has at most two, which is not enough. A history page or a polled live
+    /// read has nine or more.
+    private static let minDecisiveRecords = 3
+    /// How many more records the winner needs than the loser. One extra record can
+    /// come from padding by chance.
+    private static let decisiveMargin = 2
+
+    /// The record size this packet proves, or nil if it proves nothing.
+    ///
+    /// A known device version proves it without reading the packet. Otherwise the
+    /// winner needs at least `minDecisiveRecords` valid records and a lead of
+    /// `decisiveMargin`. A live packet can never do that; a history page or a
+    /// nine-record live read always does.
+    static func decisiveRecordSize(_ payload: [UInt8], deviceVersion: String) -> Int? {
+        if let confirmed = confirmedRecordSize(deviceVersion) { return confirmed }
+        let (nine, eight) = recordSizeEvidence(payload)
+        if nine >= minDecisiveRecords && nine - eight >= decisiveMargin { return bleRecordSizeE12 }
+        if eight >= minDecisiveRecords && eight - nine >= decisiveMargin { return bleRecordSize }
+        return nil
     }
 
     /// Record size for firmware we know; nil if unknown.
@@ -121,10 +161,10 @@ enum OttaiParser {
 
     /// Split a decrypted packet into 12-byte records. Extra bytes at the end are
     /// ignored. Returns an empty list if there are no records.
-    static func frameRecords(_ payload: [UInt8], deviceVersion: String = "") -> [[UInt8]] {
+    static func frameRecords(_ payload: [UInt8], deviceVersion: String = "", learned: Int? = nil) -> [[UInt8]] {
         if payload.count <= headerSize { return [] }
         let front = frontDataNo(payload)
-        let bleSize = chooseRecordSize(payload, deviceVersion: deviceVersion)
+        let bleSize = chooseRecordSize(payload, deviceVersion: deviceVersion, learned: learned)
         let nineByte = bleSize == bleRecordSizeE12
         let bodyLen = payload.count - headerSize
         let count = bodyLen / bleSize

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiPhoneNumber.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiPhoneNumber.swift
@@ -1,0 +1,53 @@
+//
+//  OttaiPhoneNumber.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — checks a phone number for the China SMS login.
+//  This is a Swift copy of OttaiPhoneNumber.kt from JugglucoNG.
+//
+
+import Foundation
+
+enum OttaiSmsCountry: CaseIterable {
+    case mainlandChina
+    case hongKong
+
+    var phoneCode: String {
+        switch self {
+        case .mainlandChina: return "86"
+        case .hongKong: return "852"
+        }
+    }
+
+    var prefix: String {
+        switch self {
+        case .mainlandChina: return "+86"
+        case .hongKong: return "+852"
+        }
+    }
+
+    var subscriberDigits: Int {
+        switch self {
+        case .mainlandChina: return 11
+        case .hongKong: return 8
+        }
+    }
+
+    private var pattern: String {
+        switch self {
+        case .mainlandChina: return "^1[3-9]\\d{9}$"
+        case .hongKong: return "^[4-9]\\d{7}$"
+        }
+    }
+
+    func accepts(_ raw: String) -> Bool {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
+        let range = NSRange(raw.startIndex..., in: raw)
+        return regex.firstMatch(in: raw, options: [], range: range) != nil
+    }
+}
+
+/// Returns the digits if they are a valid number for the country, else nil.
+func normalizeOttaiPhone(_ raw: String, country: OttaiSmsCountry) -> String? {
+    country.accepts(raw) ? raw : nil
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiRegistry.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiRegistry.swift
@@ -1,0 +1,372 @@
+//
+//  OttaiRegistry.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — saves the account login and the sensor keys.
+//
+//  This is a Swift copy of OttaiRegistry.kt from JugglucoNG. It uses UserDefaults
+//  instead of Android preferences. It stores the account session (tokens, secret
+//  key, region) and the decrypted keys of each sensor, so the Bluetooth part can
+//  log in, stream and activate without the server.
+//
+
+import Foundation
+
+/// Old cloud answers use milliseconds. The China V3 bind answer uses seconds.
+/// We always store milliseconds.
+func normalizeOttaiActiveTimeMs(_ value: Int64) -> Int64 {
+    (value >= 1 && value <= 9_999_999_999) ? value * 1000 : value
+}
+
+enum OttaiRegistry {
+
+    enum SessionProfile: String {
+        case watch = "WATCH"
+        case cnPhone = "CN_PHONE"
+    }
+
+    // MARK: - UserDefaults keys (same names as in the Kotlin code)
+
+    private enum K {
+        static let accessToken = "ottai_access_token"
+        static let glucoseSecret = "ottai_glucose_secret_key"
+        static let userId = "ottai_user_id"
+        static let accountLogin = "ottai_account_login"
+        static let apiBase = "ottai_api_base"
+        static let sessionProfile = "ottai_session_profile"
+        static let selfDeviceId = "ottai_self_device_id"
+        static let cnCommonDeviceId = "ottai_cn_common_device_id"
+        static let sensorsSet = "ottai_sensors"
+        // xDrip only: upload of readings to the Syai cloud (see OttaiCloudUploader)
+        static let cloudUploadEnabled = "ottai_cloud_upload_enabled"
+        static let cloudUploadDeviceUuid = "ottai_cloud_upload_device_uuid"
+        static let cloudUploadStatus = "ottai_cloud_upload_status"
+        static let draftSensorsSet = "ottai_draft_sensors"
+
+        static let keyAPrefix = "ottai_keya_"
+        static let methodPrefix = "ottai_method_"
+        static let coeffPrefix = "ottai_coeff_"
+        static let activeTimePrefix = "ottai_active_time_"
+        static let provisionalActiveTimePrefix = "ottai_provisional_active_time_"
+        static let activeExpirePrefix = "ottai_active_expire_"
+        static let acceptedMaxActivePrefix = "ottai_accepted_max_active_"
+        static let preheatPeriodPrefix = "ottai_preheat_period_"
+        static let retainTimePrefix = "ottai_retain_time_"
+        static let deviceVersionPrefix = "ottai_device_version_"
+        static let lastDataNoPrefix = "ottai_last_datano_"
+        static let continuityBaselinePrefix = "ottai_continuity_baseline_"
+        static let deviceIdPrefix = "ottai_device_id_"
+        static let activationAttemptedPrefix = "ottai_act_tried_"
+        static let v3BootstrapPendingPrefix = "ottai_v3_bootstrap_pending_"
+        static func validatedVersion(_ id: String) -> String { "ottai_v3_validated_version_\(id)" }
+    }
+
+    private static let cnDeviceIdLength = 32
+    private static let cnDeviceIdAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    private static let cnGeneratedPrefix = "g:"
+
+    private static var d: UserDefaults { UserDefaults.standard }
+
+    // MARK: - decrypted per-sensor materials
+
+    struct DeviceMaterials {
+        var keyAHex: String = ""
+        var method: String = ""
+        var coefficient: String = ""
+        var activeTimeMs: Int64 = 0
+        var deviceVersion: String = ""
+        var deviceId: Int = 0
+        var activeExpireTimeMs: Int64 = 0
+        var retainTimeMs: Int64 = 0
+        var preheatPeriodMs: Int64 = 0
+
+        var authKeys: [[UInt8]]? { OttaiCrypto.parseAuthKeys(keyAHex) }
+
+        var coefficients: [Double] {
+            coefficient.split(separator: ",").compactMap { Double($0.trimmingCharacters(in: .whitespaces)) }
+        }
+
+        var hasAll: Bool {
+            !keyAHex.isEmpty && !method.isEmpty && activeTimeMs > 0
+        }
+    }
+
+    struct SensorRecord {
+        let sensorId: String   // the cloud id; the server and the Bluetooth login use it
+        let address: String    // Bluetooth address with colons; may be empty
+        let displayName: String
+
+        func matchesId(_ id: String?) -> Bool {
+            OttaiConstants.matchesCanonicalOrKnownNativeAlias(sensorId, id)
+        }
+    }
+
+    // MARK: - session accessors
+
+    static func loadAccessToken() -> String { d.string(forKey: K.accessToken) ?? "" }
+    static func saveAccessToken(_ v: String?) { setOrRemove(K.accessToken, v) }
+
+    static func loadGlucoseSecretKey() -> String { d.string(forKey: K.glucoseSecret) ?? "" }
+    static func saveGlucoseSecretKey(_ v: String?) { setOrRemove(K.glucoseSecret, v) }
+
+    static func loadUserId() -> String { d.string(forKey: K.userId) ?? "" }
+    static func saveUserId(_ v: String?) { setOrRemove(K.userId, v) }
+
+    static func loadAccountLogin() -> String { d.string(forKey: K.accountLogin) ?? "" }
+    static func saveAccountLogin(_ v: String?) { setOrRemove(K.accountLogin, v) }
+
+    static func loadApiBase() -> String {
+        let stored = d.string(forKey: K.apiBase)
+        let normalized = normalizeApiBase(stored)
+        if let stored = stored, !stored.isEmpty, stored != normalized {
+            d.set(normalized, forKey: K.apiBase)
+        }
+        return normalized
+    }
+
+    static func normalizeApiBase(_ stored: String?) -> String {
+        switch stored?.trimmingCharacters(in: .whitespaces) {
+        case nil, "": return OttaiConstants.apiBase
+        case OttaiConstants.apiBaseSyaiLegacy: return OttaiConstants.apiBaseSyai
+        case let s?: return s
+        }
+    }
+
+    static func saveApiBase(_ v: String) { d.set(v, forKey: K.apiBase) }
+
+    static func loadSessionProfile() -> SessionProfile {
+        SessionProfile(rawValue: d.string(forKey: K.sessionProfile) ?? "") ?? .watch
+    }
+
+    static func saveSessionProfile(_ profile: SessionProfile?) {
+        setOrRemove(K.sessionProfile, profile?.rawValue)
+    }
+
+    // MARK: - upload to the Syai cloud (xDrip only)
+
+    static func loadCloudUploadEnabled() -> Bool { d.bool(forKey: K.cloudUploadEnabled) }
+    static func saveCloudUploadEnabled(_ v: Bool) { d.set(v, forKey: K.cloudUploadEnabled) }
+
+    /// A short text for the settings screen: what the last upload did.
+    static func loadCloudUploadStatus() -> String { d.string(forKey: K.cloudUploadStatus) ?? "" }
+    static func saveCloudUploadStatus(_ v: String?) { setOrRemove(K.cloudUploadStatus, v) }
+
+    /// The uuid in the deviceId header of the upload ("Syai Tag:a:n:<uuid>"). Made once, kept forever.
+    static func loadOrCreateCloudUploadDeviceUuid() -> String {
+        if let existing = d.string(forKey: K.cloudUploadDeviceUuid), !existing.isEmpty { return existing }
+        let generated = UUID().uuidString.lowercased()
+        d.set(generated, forKey: K.cloudUploadDeviceUuid)
+        return generated
+    }
+
+    static func saveLastValidatedDeviceVersion(sensorId: String, version: String) {
+        let v = version.trimmingCharacters(in: .whitespaces)
+        if sensorId.isEmpty || v.isEmpty { return }
+        d.set(v, forKey: K.validatedVersion(sensorId))
+    }
+
+    static func loadLastValidatedDeviceVersion(sensorId: String) -> String? {
+        let v = d.string(forKey: K.validatedVersion(sensorId))?.trimmingCharacters(in: .whitespaces)
+        return (v?.isEmpty ?? true) ? nil : v
+    }
+
+    /// A fixed id for this phone. It goes into the cloud signature and the deviceId header.
+    static func loadOrCreateDeviceId() -> String {
+        if let existing = d.string(forKey: K.selfDeviceId), !existing.isEmpty { return existing }
+        let generated = String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(16))
+        d.set(generated, forKey: K.selfDeviceId)
+        return generated
+    }
+
+    /// The device id for the China app headers. iOS has no ANDROID_ID, so we
+    /// always make a random one in the `g:<32 chars>` form.
+    static func loadCnHeaderDeviceId() -> String {
+        if let existing = d.string(forKey: K.cnCommonDeviceId), !existing.isEmpty { return existing }
+        var s = cnGeneratedPrefix
+        let alphabet = Array(cnDeviceIdAlphabet)
+        for _ in 0 ..< cnDeviceIdLength {
+            s.append(alphabet[Int.random(in: 0 ..< alphabet.count)])
+        }
+        d.set(s, forKey: K.cnCommonDeviceId)
+        return s
+    }
+
+    // MARK: - bootstrap / activation flags
+
+    static func isV3CredentialBootstrapPending(_ id: String) -> Bool {
+        d.bool(forKey: K.v3BootstrapPendingPrefix + OttaiConstants.canonicalSensorId(id))
+    }
+
+    static func setV3CredentialBootstrapPending(_ id: String, _ pending: Bool) {
+        d.set(pending, forKey: K.v3BootstrapPendingPrefix + OttaiConstants.canonicalSensorId(id))
+    }
+
+    static func loadActivationAttempted(_ id: String) -> Bool {
+        d.bool(forKey: K.activationAttemptedPrefix + OttaiConstants.canonicalSensorId(id))
+    }
+
+    static func setActivationAttempted(_ id: String, _ v: Bool) {
+        d.set(v, forKey: K.activationAttemptedPrefix + OttaiConstants.canonicalSensorId(id))
+    }
+
+    // MARK: - materials
+
+    static func saveMaterials(sensorId: String, _ m: DeviceMaterials) -> Bool {
+        let id = canonical(sensorId)
+        if id.isEmpty { return false }
+        let existing = loadMaterials(sensorId: id)
+        let coefficient = m.coefficient.isEmpty ? existing.coefficient : m.coefficient
+        let method = OttaiMethodDefaults.resolve(method: m.method.isEmpty ? existing.method : m.method, coefficient: coefficient)
+        let activeExpireTimeMs = OttaiConstants.sanitizeActiveExpireMs(m.activeExpireTimeMs)
+        d.set(m.keyAHex, forKey: K.keyAPrefix + id)
+        d.set(method, forKey: K.methodPrefix + id)
+        d.set(coefficient, forKey: K.coeffPrefix + id)
+        d.set(NSNumber(value: normalizeOttaiActiveTimeMs(m.activeTimeMs)), forKey: K.activeTimePrefix + id)
+        if activeExpireTimeMs > 0 {
+            d.set(NSNumber(value: activeExpireTimeMs), forKey: K.activeExpirePrefix + id)
+        } else {
+            d.removeObject(forKey: K.activeExpirePrefix + id)
+        }
+        d.set(NSNumber(value: m.retainTimeMs), forKey: K.retainTimePrefix + id)
+        d.set(NSNumber(value: m.preheatPeriodMs), forKey: K.preheatPeriodPrefix + id)
+        d.set(m.deviceVersion, forKey: K.deviceVersionPrefix + id)
+        d.set(m.deviceId, forKey: K.deviceIdPrefix + id)
+        setV3CredentialBootstrapPending(id, false)
+        return true
+    }
+
+    static func loadMaterials(sensorId: String) -> DeviceMaterials {
+        let id = canonical(sensorId)
+        let coefficient = d.string(forKey: K.coeffPrefix + id) ?? ""
+        let method = OttaiMethodDefaults.resolve(method: d.string(forKey: K.methodPrefix + id) ?? "", coefficient: coefficient)
+        let storedActiveTime = int64(K.activeTimePrefix + id)
+        let activeTimeMs = normalizeOttaiActiveTimeMs(storedActiveTime)
+        if activeTimeMs != storedActiveTime { d.set(NSNumber(value: activeTimeMs), forKey: K.activeTimePrefix + id) }
+        let storedExpire = int64(K.activeExpirePrefix + id)
+        let activeExpireTimeMs = OttaiConstants.sanitizeActiveExpireMs(storedExpire)
+        if activeExpireTimeMs != storedExpire { d.removeObject(forKey: K.activeExpirePrefix + id) }
+        return DeviceMaterials(
+            keyAHex: d.string(forKey: K.keyAPrefix + id) ?? "",
+            method: method,
+            coefficient: coefficient,
+            activeTimeMs: activeTimeMs,
+            deviceVersion: d.string(forKey: K.deviceVersionPrefix + id) ?? "",
+            deviceId: d.integer(forKey: K.deviceIdPrefix + id),
+            activeExpireTimeMs: activeExpireTimeMs,
+            retainTimeMs: int64(K.retainTimePrefix + id),
+            preheatPeriodMs: int64(K.preheatPeriodPrefix + id)
+        )
+    }
+
+    static func saveActiveTimeMs(_ id: String, _ activeTimeMs: Int64) {
+        d.set(NSNumber(value: normalizeOttaiActiveTimeMs(activeTimeMs)), forKey: K.activeTimePrefix + canonical(id))
+    }
+
+    static func loadProvisionalActiveTime(_ id: String) -> Int64 {
+        int64(K.provisionalActiveTimePrefix + canonical(id))
+    }
+
+    static func saveProvisionalActiveTime(_ id: String, _ activeTimeMs: Int64) {
+        d.set(NSNumber(value: activeTimeMs), forKey: K.provisionalActiveTimePrefix + canonical(id))
+    }
+
+    static func loadAcceptedMaxActive(_ id: String) -> Int64 {
+        int64(K.acceptedMaxActivePrefix + canonical(id))
+    }
+
+    static func saveAcceptedMaxActive(_ id: String, _ durationMs: Int64) {
+        d.set(NSNumber(value: durationMs), forKey: K.acceptedMaxActivePrefix + canonical(id))
+    }
+
+    static func loadLastDataNo(_ id: String) -> Int {
+        d.integer(forKey: K.lastDataNoPrefix + canonical(id))
+    }
+
+    static func saveLastDataNo(_ id: String, _ dataNo: Int) {
+        d.set(dataNo, forKey: K.lastDataNoPrefix + canonical(id))
+    }
+
+    /// The last good reading used by the spike filter. Saved so it is still there
+    /// after an app restart. Stored as "dataNo,sampleMs,mmol,rawCurrent".
+    struct ContinuityBaseline {
+        let dataNo: Int
+        let sampleMs: Int64
+        let mmol: Float
+        let rawCurrent: Int
+    }
+
+    static func saveContinuityBaseline(_ id: String, dataNo: Int, sampleMs: Int64, mmol: Float, rawCurrent: Int) {
+        guard mmol.isFinite else { return }
+        d.set("\(dataNo),\(sampleMs),\(mmol),\(rawCurrent)", forKey: K.continuityBaselinePrefix + canonical(id))
+    }
+
+    static func loadContinuityBaseline(_ id: String) -> ContinuityBaseline? {
+        guard let raw = d.string(forKey: K.continuityBaselinePrefix + canonical(id)) else { return nil }
+        let parts = raw.split(separator: ",").map(String.init)
+        guard parts.count == 4,
+              let dataNo = Int(parts[0]), let sampleMs = Int64(parts[1]),
+              let mmol = Float(parts[2]), mmol.isFinite, let raw = Int(parts[3]) else { return nil }
+        return ContinuityBaseline(dataNo: dataNo, sampleMs: sampleMs, mmol: mmol, rawCurrent: raw)
+    }
+
+    // MARK: - sensor record set
+
+    static func persistedRecords() -> [SensorRecord] { readRecords(K.sensorsSet) }
+
+    static func findRecord(_ sensorId: String?) -> SensorRecord? {
+        guard let id = sensorId?.trimmingCharacters(in: .whitespaces), !id.isEmpty else { return nil }
+        let target = OttaiConstants.canonicalSensorId(id)
+        return persistedRecords().first { OttaiConstants.canonicalSensorId($0.sensorId) == target }
+    }
+
+    static func ensureSensorRecord(sensorId: String, address: String, displayName: String) {
+        let id = canonical(sensorId)
+        if id.isEmpty { return }
+        var records = persistedRecords().filter { !$0.matchesId(id) }
+        let ble = OttaiConstants.normalizeBleAddress(address, allowPlain: false) ?? (findRecord(id)?.address ?? "")
+        records.append(SensorRecord(sensorId: id, address: ble, displayName: displayName.isEmpty ? id : displayName))
+        writeRecords(K.sensorsSet, records)
+    }
+
+    static func removeSensor(_ sensorId: String?) {
+        guard let raw = sensorId?.trimmingCharacters(in: .whitespaces) else { return }
+        let id = canonical(raw).isEmpty ? raw : canonical(raw)
+        writeRecords(K.sensorsSet, persistedRecords().filter { !$0.matchesId(id) })
+        for prefix in [K.keyAPrefix, K.methodPrefix, K.coeffPrefix, K.activeTimePrefix,
+                       K.provisionalActiveTimePrefix, K.activeExpirePrefix, K.retainTimePrefix,
+                       K.preheatPeriodPrefix, K.deviceVersionPrefix, K.lastDataNoPrefix,
+                       K.deviceIdPrefix, K.activationAttemptedPrefix, K.v3BootstrapPendingPrefix] {
+            d.removeObject(forKey: prefix + id)
+        }
+        d.removeObject(forKey: K.validatedVersion(id))
+        // The accepted lifetime is kept on purpose, same as in the Kotlin code.
+    }
+
+    // MARK: - private helpers
+
+    private static func canonical(_ s: String) -> String {
+        let c = OttaiConstants.canonicalSensorId(s)
+        return c.isEmpty ? s : c
+    }
+
+    private static func int64(_ key: String) -> Int64 {
+        (d.object(forKey: key) as? NSNumber)?.int64Value ?? 0
+    }
+
+    private static func setOrRemove(_ key: String, _ v: String?) {
+        if let v = v, !v.isEmpty { d.set(v, forKey: key) } else { d.removeObject(forKey: key) }
+    }
+
+    private static func readRecords(_ key: String) -> [SensorRecord] {
+        guard let raw = d.stringArray(forKey: key) else { return [] }
+        return raw.compactMap { line in
+            let parts = line.components(separatedBy: "|")
+            guard parts.count >= 3 else { return nil }
+            return SensorRecord(sensorId: parts[0], address: parts[1], displayName: parts[2])
+        }
+    }
+
+    private static func writeRecords(_ key: String, _ records: [SensorRecord]) {
+        d.set(records.map { "\($0.sensorId)|\($0.address)|\($0.displayName)" }, forKey: key)
+    }
+}

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiRegistry.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiRegistry.swift
@@ -54,6 +54,8 @@ enum OttaiRegistry {
         static let retainTimePrefix = "ottai_retain_time_"
         static let deviceVersionPrefix = "ottai_device_version_"
         static let lastDataNoPrefix = "ottai_last_datano_"
+        // xDrip only: the highest dataNo xDrip took over (see CGMOttaiTransmitter.noteDelivered)
+        static let deliveredDataNoPrefix = "ottai_delivered_datano_"
         // The record size (8 or 9 bytes) learned from this sensor, 0 until a big enough
         // packet has shown it. Saved, so the size is right from the first packet of the
         // next session too. See OttaiParser.decisiveRecordSize.
@@ -290,6 +292,14 @@ enum OttaiRegistry {
         d.set(dataNo, forKey: K.lastDataNoPrefix + canonical(id))
     }
 
+    static func loadDeliveredDataNo(_ id: String) -> Int {
+        d.integer(forKey: K.deliveredDataNoPrefix + canonical(id))
+    }
+
+    static func saveDeliveredDataNo(_ id: String, _ dataNo: Int) {
+        d.set(dataNo, forKey: K.deliveredDataNoPrefix + canonical(id))
+    }
+
     static func loadRecordSize(_ id: String) -> Int {
         d.integer(forKey: K.recordSizePrefix + canonical(id))
     }
@@ -346,7 +356,7 @@ enum OttaiRegistry {
         writeRecords(K.sensorsSet, persistedRecords().filter { !$0.matchesId(id) })
         for prefix in [K.keyAPrefix, K.methodPrefix, K.coeffPrefix, K.activeTimePrefix,
                        K.provisionalActiveTimePrefix, K.activeExpirePrefix, K.retainTimePrefix,
-                       K.preheatPeriodPrefix, K.deviceVersionPrefix, K.lastDataNoPrefix, K.recordSizePrefix,
+                       K.preheatPeriodPrefix, K.deviceVersionPrefix, K.lastDataNoPrefix, K.deliveredDataNoPrefix, K.recordSizePrefix,
                        K.deviceIdPrefix, K.activationAttemptedPrefix, K.v3BootstrapPendingPrefix] {
             d.removeObject(forKey: prefix + id)
         }

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiRegistry.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiRegistry.swift
@@ -54,6 +54,10 @@ enum OttaiRegistry {
         static let retainTimePrefix = "ottai_retain_time_"
         static let deviceVersionPrefix = "ottai_device_version_"
         static let lastDataNoPrefix = "ottai_last_datano_"
+        // The record size (8 or 9 bytes) learned from this sensor, 0 until a big enough
+        // packet has shown it. Saved, so the size is right from the first packet of the
+        // next session too. See OttaiParser.decisiveRecordSize.
+        static let recordSizePrefix = "ottai_record_size_"
         static let continuityBaselinePrefix = "ottai_continuity_baseline_"
         static let deviceIdPrefix = "ottai_device_id_"
         static let activationAttemptedPrefix = "ottai_act_tried_"
@@ -286,6 +290,14 @@ enum OttaiRegistry {
         d.set(dataNo, forKey: K.lastDataNoPrefix + canonical(id))
     }
 
+    static func loadRecordSize(_ id: String) -> Int {
+        d.integer(forKey: K.recordSizePrefix + canonical(id))
+    }
+
+    static func saveRecordSize(_ id: String, _ size: Int) {
+        d.set(size, forKey: K.recordSizePrefix + canonical(id))
+    }
+
     /// The last good reading used by the spike filter. Saved so it is still there
     /// after an app restart. Stored as "dataNo,sampleMs,mmol,rawCurrent".
     struct ContinuityBaseline {
@@ -334,7 +346,7 @@ enum OttaiRegistry {
         writeRecords(K.sensorsSet, persistedRecords().filter { !$0.matchesId(id) })
         for prefix in [K.keyAPrefix, K.methodPrefix, K.coeffPrefix, K.activeTimePrefix,
                        K.provisionalActiveTimePrefix, K.activeExpirePrefix, K.retainTimePrefix,
-                       K.preheatPeriodPrefix, K.deviceVersionPrefix, K.lastDataNoPrefix,
+                       K.preheatPeriodPrefix, K.deviceVersionPrefix, K.lastDataNoPrefix, K.recordSizePrefix,
                        K.deviceIdPrefix, K.activationAttemptedPrefix, K.v3BootstrapPendingPrefix] {
             d.removeObject(forKey: prefix + id)
         }

--- a/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiV3BootstrapPolicy.swift
+++ b/xDrip/BluetoothTransmitter/CGM/Ottai/Core/OttaiV3BootstrapPolicy.swift
@@ -1,0 +1,34 @@
+//
+//  OttaiV3BootstrapPolicy.swift
+//  xdrip
+//
+//  Ottai / Syai CGM driver — decides how a new V3 sensor may get its first keys.
+//  This is a Swift copy of OttaiV3BootstrapPolicy.kt from JugglucoNG.
+//
+
+import Foundation
+
+/// What to do after the Bluetooth services are found.
+enum OttaiAuthEntryMode {
+    case storedMaterialAuth
+    case v3CredentialBootstrap
+    case blocked
+}
+
+/// A new V3 sensor has no keyA yet. It may ask the server for one only when the
+/// user asked for it, the cloud checked this sensor and version, and the China
+/// login is still there. In every other case we do nothing with the sensor's
+/// login characteristics.
+func ottaiAuthEntryMode(
+    hasAuthKeys: Bool,
+    bootstrapPending: Bool,
+    cnSessionAvailable: Bool,
+    validatedDeviceVersion: String?
+) -> OttaiAuthEntryMode {
+    if hasAuthKeys { return .storedMaterialAuth }
+    if bootstrapPending, cnSessionAvailable,
+       let v = validatedDeviceVersion, !v.trimmingCharacters(in: .whitespaces).isEmpty {
+        return .v3CredentialBootstrap
+    }
+    return .blocked
+}

--- a/xDrip/BluetoothTransmitter/Generic/BluetoothTransmitter.swift
+++ b/xDrip/BluetoothTransmitter/Generic/BluetoothTransmitter.swift
@@ -300,6 +300,13 @@ class BluetoothTransmitter: NSObject, CBCentralManagerDelegate, CBPeripheralDele
         }
     }
 
+    /// Subclasses can refuse a discovered peripheral (return false to keep scanning).
+    /// Used by drivers that must move away from a wrong physical device that has the
+    /// same name and advertisement as the right one (e.g. an old Ottai/Syai sensor).
+    func shouldConnectToDiscoveredPeripheral(_ peripheral: CBPeripheral) -> Bool {
+        return true
+    }
+
     /// stops scanning
     func stopScanning() {
         centralQueue.async { [weak self] in
@@ -625,6 +632,12 @@ class BluetoothTransmitter: NSObject, CBCentralManagerDelegate, CBPeripheralDele
             deviceName = temp
         }
         trace("in didDiscover, found peripheral with name: %{public}@", log: log, category: ConstantsLog.categoryBlueToothTransmitter, type: .info, String(describing: deviceName))
+        
+        // give the subclass a chance to refuse this device (e.g. a wrong physical sensor with the same name)
+        guard shouldConnectToDiscoveredPeripheral(peripheral) else {
+            trace("in didDiscover, subclass refused peripheral %{public}@, keep scanning", log: log, category: ConstantsLog.categoryBlueToothTransmitter, type: .info, peripheral.identifier.uuidString)
+            return
+        }
         
         // check if stored address not nil, in which case we already connected before and we expect a full match with the already known device name
         if let deviceAddress = deviceAddress {

--- a/xDrip/Constants/ConstantsLog.swift
+++ b/xDrip/Constants/ConstantsLog.swift
@@ -41,7 +41,10 @@ enum ConstantsLog {
     
     /// Libre2
     static let categoryCGMLibre2 =                          "Libre2                        "
-    
+
+    /// Ottai / Syai CGM
+    static let categoryCGMOttai =                           "CGMOttai                      "
+
     /// core data manager
     static let categoryCoreDataManager =                    "CoreDataManager               "
 

--- a/xDrip/Constants/ConstantsMaster.swift
+++ b/xDrip/Constants/ConstantsMaster.swift
@@ -16,6 +16,10 @@ enum ConstantsMaster {
     /// warm-up time enforced by Dexcom G7/ONE+/Stelo sensors
     static let minimumSensorWarmUpRequiredInMinutesDexcomG7: Double = 30
     
+    /// warm-up time of Ottai / Syai sensors. The Syai manual says: "The first 30 minutes
+    /// after activation is a warm-up period."
+    static let minimumSensorWarmUpRequiredInMinutesOttai: Double = 30
+    
     /// warm-up time enfoced by an Anubis Dexcom G6 transmitter
     static let minimumSensorWarmUpRequiredInMinutesDexcomG6Anubis: Double = 50
     

--- a/xDrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
+++ b/xDrip/Core Data/classes/BLEPeripheral+CoreDataProperties.swift
@@ -50,7 +50,10 @@ extension BLEPeripheral {
     
     // a BLEPeripheral should only have one of dexcomG5, m5Stack, ...
     @NSManaged public var libre2: Libre2?
-    
+
+    // a BLEPeripheral should only have one of dexcomG5, m5Stack, ...
+    @NSManaged public var ottai: Ottai?
+
     // a BLEPeripheral should only have one of dexcomG5, m5Stack, ...
     @NSManaged public var libre2heartbeat: Libre2HeartBeat?
 

--- a/xDrip/Core Data/classes/Ottai+CoreDataClass.swift
+++ b/xDrip/Core Data/classes/Ottai+CoreDataClass.swift
@@ -1,0 +1,21 @@
+import Foundation
+import CoreData
+
+/// The Core Data object for an Ottai / Syai CGM. The keys and the cloud login are
+/// stored in UserDefaults (see OttaiRegistry). This object only holds the normal
+/// Bluetooth device data, so the sensor shows up in xDrip's device list.
+public class Ottai: NSManagedObject {
+
+    init(address: String, name: String, alias: String?, nsManagedObjectContext: NSManagedObjectContext) {
+
+        let entity = NSEntityDescription.entity(forEntityName: "Ottai", in: nsManagedObjectContext)!
+
+        super.init(entity: entity, insertInto: nsManagedObjectContext)
+
+        blePeripheral = BLEPeripheral(address: address, name: name, alias: alias, bluetoothPeripheralType: .OttaiType, nsManagedObjectContext: nsManagedObjectContext)
+    }
+
+    private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
+}

--- a/xDrip/Core Data/classes/Ottai+CoreDataProperties.swift
+++ b/xDrip/Core Data/classes/Ottai+CoreDataProperties.swift
@@ -1,0 +1,15 @@
+import Foundation
+import CoreData
+
+extension Ottai {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Ottai> {
+        return NSFetchRequest<Ottai>(entityName: "Ottai")
+    }
+
+    // blePeripheral is required to conform to protocol BluetoothPeripheral
+    @NSManaged public var blePeripheral: BLEPeripheral
+
+    /// the cloud id (12 hex characters); it can be different from the Bluetooth address
+    @NSManaged public var ottaiSensorId: String?
+}

--- a/xDrip/Core Data/xdrip.xcdatamodeld/xdrip v27.xcdatamodel/contents
+++ b/xDrip/Core Data/xdrip.xcdatamodeld/xdrip v27.xcdatamodel/contents
@@ -77,6 +77,7 @@
         <relationship name="medtrumTouchCareNano" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="MedtrumTouchCareNano" inverseName="blePeripheral" inverseEntity="MedtrumTouchCareNano"/>
         <relationship name="miaoMiao" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="MiaoMiao" inverseName="blePeripheral" inverseEntity="MiaoMiao"/>
         <relationship name="omniPodHeartBeat" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OmniPodHeartBeat" inverseName="blePeripheral" inverseEntity="OmniPodHeartBeat"/>
+        <relationship name="ottai" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Ottai" inverseName="blePeripheral" inverseEntity="Ottai"/>
     </entity>
     <entity name="Bubble" representedClassName=".Bubble" syncable="YES">
         <attribute name="firmware" optional="YES" attributeType="String"/>
@@ -147,6 +148,10 @@
     <entity name="MedtrumTouchCareNano" representedClassName=".MedtrumTouchCareNano" syncable="YES">
         <attribute name="firmware" optional="YES" attributeType="String"/>
         <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="medtrumTouchCareNano" inverseEntity="BLEPeripheral"/>
+    </entity>
+    <entity name="Ottai" representedClassName=".Ottai" syncable="YES">
+        <attribute name="ottaiSensorId" optional="YES" attributeType="String"/>
+        <relationship name="blePeripheral" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BLEPeripheral" inverseName="ottai" inverseEntity="BLEPeripheral"/>
     </entity>
     <entity name="MiaoMiao" representedClassName=".MiaoMiao" syncable="YES">
         <attribute name="firmware" optional="YES" attributeType="String"/>

--- a/xDrip/Managers/Application/RootApplicationCoordinator.swift
+++ b/xDrip/Managers/Application/RootApplicationCoordinator.swift
@@ -1787,6 +1787,10 @@ import AppIntents
                 calibrator = Libre1Calibrator()
             }
 
+        case .ottai:
+            // Ottai / Syai send glucose that is already calibrated
+            calibrator = NoCalibrator()
+
         case .medtrumTouchCareNano:
             // Values arrive already calibrated to mg/dL. The transmitter applies the Medtrum per-sensor
             // calibration factor decoded from each packet, so xDrip should not run its own calibrator.
@@ -2673,7 +2677,15 @@ extension RootApplicationCoordinator: @preconcurrency CGMTransmitterDelegate {
         
         if let sensorAgeInSeconds = sensorAge {
             let cgmTransmitterType = bluetoothPeripheralManager?.getCGMTransmitter()?.cgmTransmitterType()
-            let minimumWarmUpRequiredInMinutes = cgmTransmitterType == .dexcomG7 ? ConstantsMaster.minimumSensorWarmUpRequiredInMinutesDexcomG7 : ConstantsMaster.minimumSensorWarmUpRequiredInMinutes
+            let minimumWarmUpRequiredInMinutes: Double
+            switch cgmTransmitterType {
+            case .dexcomG7:
+                minimumWarmUpRequiredInMinutes = ConstantsMaster.minimumSensorWarmUpRequiredInMinutesDexcomG7
+            case .ottai:
+                minimumWarmUpRequiredInMinutes = ConstantsMaster.minimumSensorWarmUpRequiredInMinutesOttai
+            default:
+                minimumWarmUpRequiredInMinutes = ConstantsMaster.minimumSensorWarmUpRequiredInMinutes
+            }
             let secondsUntilWarmUpComplete = (minimumWarmUpRequiredInMinutes * 60) - sensorAgeInSeconds
             let isDexcomG7WithReceivedGlucose = cgmTransmitterType == .dexcomG7 && glucoseData.contains { $0.glucoseLevelRaw > 0 }
             

--- a/xDrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager+BluetoothTransmitterDelegate.swift
+++ b/xDrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager+BluetoothTransmitterDelegate.swift
@@ -150,6 +150,21 @@ extension BluetoothPeripheralManager: BluetoothTransmitterDelegate {
             coreDataManager.saveChanges()
         }
 
+        // On iOS the CoreBluetooth address of a sensor is not its cloud id. An Ottai/Syai
+        // peripheral can move to another physical sensor (a new sensor with the same name),
+        // and a peripheral whose address was cleared on a Cloud ID change reconnects by
+        // scanning. In both cases the stored address must follow the connected device.
+        if let connectedAddress = bluetoothTransmitter.deviceAddress,
+           let bluetoothPeripheral = getBluetoothPeripheral(for: bluetoothTransmitter),
+           bluetoothPeripheral.blePeripheral.address != connectedAddress,
+           bluetoothPeripheral.blePeripheral.address.isEmpty || bluetoothTransmitter is CGMOttaiTransmitter {
+            trace("in didConnect, adopting connected address %{public}@ (stored was '%{public}@')", log: log, category: ConstantsLog.categoryBluetoothPeripheralManager, type: .info, connectedAddress, bluetoothPeripheral.blePeripheral.address)
+            bluetoothPeripheral.blePeripheral.address = connectedAddress
+            if let connectedName = bluetoothTransmitter.deviceName {
+                bluetoothPeripheral.blePeripheral.name = connectedName
+            }
+        }
+
         /// helper function : if bluetoothTransmitter is a CGMTransmitter and if it's a new one (ie address is different than currentCgmTransmitterAddress then call cgmTransmitterChanged
         let checkCurrentCGMTransmitterHelper = {
             

--- a/xDrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
+++ b/xDrip/Managers/BluetoothPeripheral/BluetoothPeripheralManager.swift
@@ -171,18 +171,18 @@ class BluetoothPeripheralManager: NSObject {
                         _ = m5StackBluetoothTransmitter.writeBgReadingInfo(bgReading: bgReadingToSend[0])
                     }
                     
-                case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .DexcomG7Type, .MedtrumTouchCareNanoType:
+                case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .DexcomG7Type, .OttaiType, .MedtrumTouchCareNanoType:
                     // cgm's don't receive reading, they send it
                     break
-                    
+
                 case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
                     // heartbeat transmitters are just there to wake up the app
                     break
-                    
+
                 }
 
             }
-   
+
         }
     }
 
@@ -345,9 +345,25 @@ class BluetoothPeripheralManager: NSObject {
                         }
                         
                     }
-                    
+
+                case .OttaiType:
+
+                    if let ottai = bluetoothPeripheral as? Ottai {
+
+                        if let cgmTransmitterDelegate = cgmTransmitterDelegate {
+
+                            newTransmitter = CGMOttaiTransmitter(address: ottai.blePeripheral.address, name: ottai.blePeripheral.name, sensorId: ottai.ottaiSensorId ?? "", bluetoothTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate)
+
+                        } else {
+
+                            trace("in getBluetoothTransmitter, case OttaiType but cgmTransmitterDelegate is nil, looks like a coding error ", log: log, category: ConstantsLog.categoryBluetoothPeripheralManager, type: .error)
+
+                        }
+
+                    }
+
                 case .Libre3HeartBeatType:
-                    
+
                     if let libre2heartbeat = bluetoothPeripheral as? Libre2HeartBeat {
                         
                         if let transmitterId = libre2heartbeat.blePeripheral.transmitterId {
@@ -457,7 +473,12 @@ class BluetoothPeripheralManager: NSObject {
                 if bluetoothTransmitter is CGMLibre2Transmitter {
                     return .Libre2Type
                 }
-                
+
+            case .OttaiType:
+                if bluetoothTransmitter is CGMOttaiTransmitter {
+                    return .OttaiType
+                }
+
             case .Libre3HeartBeatType:
                 if bluetoothTransmitter is Libre3HeartBeatBluetoothTransmitter {
                     return .Libre3HeartBeatType
@@ -535,7 +556,19 @@ class BluetoothPeripheralManager: NSObject {
             }
             
             return CGMLibre2Transmitter(address: nil, name: nil, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate ?? self, cGMLibre2TransmitterDelegate: self, sensorSerialNumber: nil, cGMTransmitterDelegate: cgmTransmitterDelegate, nonFixedSlopeEnabled: nil, webOOPEnabled: nil)
-            
+
+        case .OttaiType:
+
+            guard let cgmTransmitterDelegate = cgmTransmitterDelegate else {
+                fatalError("in createNewTransmitter, OttaiType, cgmTransmitterDelegate is nil")
+            }
+
+            // A normal scan does not know the Ottai cloud id. The setup screen saves it
+            // (login or JSON import), and we take the last saved sensor here.
+            let stagedSensorId = OttaiRegistry.persistedRecords().last?.sensorId ?? ""
+
+            return CGMOttaiTransmitter(address: nil, name: nil, sensorId: stagedSensorId, bluetoothTransmitterDelegate: bluetoothTransmitterDelegate ?? self, cGMTransmitterDelegate: cgmTransmitterDelegate)
+
         case .Libre3HeartBeatType:
             
             guard let transmitterId = transmitterId else {
@@ -906,12 +939,37 @@ class BluetoothPeripheralManager: NSObject {
                         
                         
                     }
-                    
+
+                case .OttaiType:
+
+                    if let ottai = blePeripheral.ottai {
+
+                        blePeripheralFound = true
+
+                        // add it to the list of bluetoothPeripherals
+                        let index = insertInBluetoothPeripherals(bluetoothPeripheral: ottai)
+
+                        if ottai.blePeripheral.shouldconnect {
+
+                            bluetoothTransmitters.insert(CGMOttaiTransmitter(address: ottai.blePeripheral.address, name: ottai.blePeripheral.name, sensorId: ottai.ottaiSensorId ?? "", bluetoothTransmitterDelegate: self, cGMTransmitterDelegate: cgmTransmitterDelegate), at: index)
+
+                            if bluetoothPeripheralType.category() == .CGM {
+                                currentCgmTransmitterAddress = blePeripheral.address
+                            }
+
+                        } else {
+
+                            bluetoothTransmitters.insert(nil, at: index)
+
+                        }
+
+                    }
+
                 case .Libre3HeartBeatType:
                     if let libre2heartbeat = blePeripheral.libre2heartbeat {
-                        
+
                         blePeripheralFound = true
-                        
+
                         // add it to the list of bluetoothPeripherals
                         let index = insertInBluetoothPeripherals(bluetoothPeripheral: libre2heartbeat)
                         
@@ -1181,7 +1239,7 @@ class BluetoothPeripheralManager: NSObject {
                     bluetoothPeripheral.blePeripheral.parameterUpdateNeededAtNextConnect = true
                 }
              
-            case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType, .DexcomG7Type, .MedtrumTouchCareNanoType:
+            case .DexcomType, .BubbleType, .MiaoMiaoType, .Libre2Type, .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType, .DexcomG7Type, .OttaiType, .MedtrumTouchCareNanoType:
 
                 // nothing to check
                 break

--- a/xDrip/Managers/Loop/LoopManager.swift
+++ b/xDrip/Managers/Loop/LoopManager.swift
@@ -287,6 +287,7 @@ enum XDripCGMMetadataBuilder {
         case .miaomiao: return "libre_miaomiao"
         case .Bubble: return "libre_bubble"
         case .medtrumTouchCareNano: return "medtrum_nano"
+        case .ottai: return "ottai_syai"
         case nil: return nil
         }
     }
@@ -306,7 +307,7 @@ enum XDripCGMMetadataBuilder {
     private static func directExpectedInterval(_ type: CGMTransmitterType?) -> Double? {
         switch type {
         case .dexcom, .dexcomG7: return 300
-        case .Libre2, .miaomiao, .Bubble, .medtrumTouchCareNano: return 60
+        case .Libre2, .miaomiao, .Bubble, .medtrumTouchCareNano, .ottai: return 60
         case nil: return nil
         }
     }
@@ -331,6 +332,8 @@ enum XDripCGMMetadataBuilder {
             return .minutes(transmitter?.isAnubisG6() == true
                 ? ConstantsMaster.minimumSensorWarmUpRequiredInMinutesDexcomG6Anubis
                 : ConstantsMaster.minimumSensorWarmUpRequiredInMinutesDexcomG5G6)
+        case .ottai:
+            return .minutes(ConstantsMaster.minimumSensorWarmUpRequiredInMinutesOttai)
         case .Libre2, .miaomiao, .Bubble, .medtrumTouchCareNano:
             return .minutes(ConstantsMaster.minimumSensorWarmUpRequiredInMinutes)
         case nil:

--- a/xDrip/Managers/PostProcessing/BgPostProcessingManager.swift
+++ b/xDrip/Managers/PostProcessing/BgPostProcessingManager.swift
@@ -1203,7 +1203,7 @@ class BgPostProcessingManager {
             return currentMasterLibreUsesNativeAlgorithm() ? nil : .masterLibreUsesCalibration
         case .dexcom:
             return currentMasterSourceIsDexcomG6() ? .masterDexcomG6UsesCalibration : nil
-        case .dexcomG7, .medtrumTouchCareNano:
+        case .dexcomG7, .medtrumTouchCareNano, .ottai:
             return nil
         }
     }
@@ -1242,6 +1242,8 @@ class BgPostProcessingManager {
             return connectedCGMPeripherals.first { $0.dexcomG7 != nil }
         case .medtrumTouchCareNano:
             return connectedCGMPeripherals.first { $0.medtrumTouchCareNano != nil }
+        case .ottai:
+            return connectedCGMPeripherals.first { $0.ottai != nil }
         case nil:
             return nil
         }

--- a/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralDetailState.swift
+++ b/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralDetailState.swift
@@ -70,6 +70,11 @@ final class BluetoothPeripheralDetailState: NSObject, ObservableObject {
     private var didAddObservers = false
     private var didStart = false
 
+    /// Shown as the detail of the Ottai row that is waiting for the cloud, so the screen gives
+    /// feedback while a sign-in or a fetch is running.
+    fileprivate var ottaiBusyMessage: String?
+    fileprivate let ottaiCloudQueue = DispatchQueue(label: "OttaiCloud.work")
+
     private var webOOPSettingsSectionIsShown = false
     private var nonFixedSettingsSectionIsShown = false
     private var webOOPAndNonFixedSlopeVisibilityIsKnown = false
@@ -415,6 +420,8 @@ final class BluetoothPeripheralDetailState: NSObject, ObservableObject {
             return makeMiaoMiaoSections(bluetoothPeripheral: bluetoothPeripheral)
         case .BubbleType:
             return makeBubbleSections(bluetoothPeripheral: bluetoothPeripheral)
+        case .OttaiType:
+            return makeOttaiSections(bluetoothPeripheral: bluetoothPeripheral)
         case .MedtrumTouchCareNanoType:
             return makeMedtrumTouchCareNanoSections(bluetoothPeripheral: bluetoothPeripheral)
         case .M5StackType:
@@ -1696,6 +1703,8 @@ struct BluetoothPeripheralTextEntry: Identifiable {
     let actionHandler: (String) -> Void
     let actionIsEnabled: ((String) -> Bool)?
     let inputValidator: ((String) -> String?)?
+    /// Render the field as a SecureField (passwords).
+    let isSecureTextEntry: Bool
 
     init(
         title: String?,
@@ -1708,7 +1717,8 @@ struct BluetoothPeripheralTextEntry: Identifiable {
         cancelTitle: String,
         actionHandler: @escaping (String) -> Void,
         actionIsEnabled: ((String) -> Bool)?,
-        inputValidator: ((String) -> String?)?
+        inputValidator: ((String) -> String?)?,
+        isSecureTextEntry: Bool = false
     ) {
         self.title = title
         self.message = message
@@ -1721,6 +1731,7 @@ struct BluetoothPeripheralTextEntry: Identifiable {
         self.actionHandler = actionHandler
         self.actionIsEnabled = actionIsEnabled
         self.inputValidator = inputValidator
+        self.isSecureTextEntry = isSecureTextEntry
     }
 }
 
@@ -2290,6 +2301,614 @@ private extension BluetoothPeripheralDetailState {
                 }
             )
         ]
+    }
+}
+
+// MARK: - Ottai / Syai
+
+/// The cloud region for an Ottai / Syai account: which server and which sign-in flow.
+private enum OttaiRegion: String, CaseIterable {
+    case china = "China"
+    case global = "Global"
+    case syai = "Syai"
+
+    var apiBase: String {
+        switch self {
+        case .china: return OttaiConstants.apiBase
+        case .global: return OttaiConstants.apiBaseGlobal
+        case .syai: return OttaiConstants.apiBaseSyai
+        }
+    }
+
+    var webBase: String? {
+        switch self {
+        case .china: return nil
+        case .global: return OttaiConstants.webBaseOttai
+        case .syai: return OttaiConstants.webBaseSyai
+        }
+    }
+
+    var usesSms: Bool { self == .china }
+
+    static func from(apiBase: String) -> OttaiRegion {
+        OttaiRegion.allCases.first { $0.apiBase == apiBase } ?? .syai
+    }
+}
+
+private extension BluetoothPeripheralDetailState {
+    /// The settings screen for an Ottai / Syai CGM.
+    ///
+    /// Here the user picks a region, signs in (Syai / Global with email and password, China with
+    /// phone and SMS), gets the sensor keys from the cloud, and starts the sensor. The real work is done in OttaiCloudClient and
+    /// OttaiRegistry; this only builds the rows.
+    func makeOttaiSections(bluetoothPeripheral: BluetoothPeripheral) -> [BluetoothPeripheralDetailSection] {
+        guard let ottai = bluetoothPeripheral as? Ottai else { return [] }
+
+        let sensorId = ottaiCloudId(for: ottai)
+        let signedIn = ottaiIsSignedIn
+        let materials = OttaiRegistry.loadMaterials(sensorId: sensorId)
+        let hasMaterials = materials.authKeys != nil
+        let uploadEnabled = OttaiRegistry.loadCloudUploadEnabled()
+        let uploadStatus = OttaiRegistry.loadCloudUploadStatus()
+
+        let accountDetail: String
+        if let busy = ottaiBusyMessage {
+            accountDetail = busy
+        } else if signedIn {
+            let login = OttaiRegistry.loadAccountLogin()
+            accountDetail = login.isEmpty ? "Signed in — tap to sign out" : "\(login) — tap to sign out"
+        } else {
+            accountDetail = "Tap to sign in"
+        }
+
+        // After activation, show when the sensor started and until when it is valid.
+        // The start is the confirmed activation time, or the provisional one (marked ~).
+        var sensorInfoRows: [BluetoothPeripheralDetailRow] = []
+        let startMs = materials.activeTimeMs > 0 ? materials.activeTimeMs : OttaiRegistry.loadProvisionalActiveTime(sensorId)
+        if startMs > 0 {
+            let startDate = Date(timeIntervalSince1970: Double(startMs) / 1000.0)
+            let lifetimeMs = OttaiConstants.expectedLifetimeMs(
+                cloudActiveExpireMs: materials.activeExpireTimeMs,
+                acceptedMaxActiveMs: OttaiRegistry.loadAcceptedMaxActive(sensorId)
+            )
+            let endDate = startDate.addingTimeInterval(Double(lifetimeMs) / 1000.0)
+            let commandStatus = ottaiTransmitter(for: ottai)?.sensorCommandStatus ?? -1
+            let approximate = materials.activeTimeMs <= 0 ? "~ " : ""
+
+            let activatedDetail = approximate + startDate.toStringInUserLocale(timeStyle: .short, dateStyle: .short)
+                + " (" + startDate.daysAndHoursAgo() + " " + Texts_HomeView.ago + ")"
+
+            let validDetail: String
+            if commandStatus >= 4 {
+                validDetail = "Sensor has ended"
+            } else if endDate <= Date() {
+                validDetail = "Expired " + endDate.toStringInUserLocale(timeStyle: .short, dateStyle: .short)
+            } else {
+                let minutesLeft = endDate.timeIntervalSinceNow / 60.0
+                validDetail = endDate.toStringInUserLocale(timeStyle: .short, dateStyle: .short)
+                    + " (" + minutesLeft.minutesToDaysAndHours() + " left)"
+            }
+
+            sensorInfoRows = [
+                row(
+                    id: "ottai-sensor-activated",
+                    title: "Activated",
+                    detail: activatedDetail,
+                    showsDisclosure: true,
+                    action: { [weak self] in self?.showOttaiSensorInfo(for: ottai) }
+                ),
+                row(
+                    id: "ottai-sensor-valid-until",
+                    title: "Valid until",
+                    detail: validDetail,
+                    showsDisclosure: true,
+                    action: { [weak self] in self?.showOttaiSensorInfo(for: ottai) }
+                )
+            ]
+        }
+
+        let sensorSection = BluetoothPeripheralDetailSection(
+            id: "ottai-sensor",
+            title: BluetoothPeripheralType.OttaiType.rawValue,
+            rows: sensorInfoRows + [
+                row(
+                    id: "ottai-region",
+                    title: "Region",
+                    detail: OttaiRegion.from(apiBase: OttaiRegistry.loadApiBase()).rawValue,
+                    showsDisclosure: true,
+                    action: { [weak self] in self?.requestOttaiRegion() }
+                ),
+                row(
+                    id: "ottai-account",
+                    title: "Account",
+                    detail: accountDetail,
+                    showsDisclosure: true,
+                    action: { [weak self] in self?.requestOttaiAccount() }
+                ),
+                row(
+                    id: "ottai-cloud-id",
+                    title: "Cloud ID (MAC)",
+                    detail: sensorId.isEmpty ? "Tap to enter (from sensor box)" : sensorId,
+                    showsDisclosure: true,
+                    action: { [weak self] in self?.requestOttaiCloudId(for: ottai) }
+                ),
+                row(
+                    id: "ottai-fetch-materials",
+                    title: "Fetch sensor from cloud",
+                    detail: hasMaterials ? "Materials present ✓" : (signedIn ? "Tap to fetch" : "Sign in first"),
+                    showsDisclosure: true,
+                    action: { [weak self] in self?.requestOttaiFetchMaterials(for: ottai) }
+                ),
+                row(
+                    id: "ottai-activate",
+                    title: "Start / activate sensor",
+                    detail: OttaiRegistry.loadActivationAttempted(sensorId) ? "Activation requested" : nil,
+                    showsDisclosure: true,
+                    action: { [weak self] in self?.requestOttaiActivation(for: ottai) }
+                )
+            ]
+        )
+
+        var uploadRows: [BluetoothPeripheralDetailRow] = [
+            toggleRow(
+                id: "ottai-cloud-upload",
+                title: "Upload readings to Syai cloud",
+                isOn: uploadEnabled,
+                setValue: { [weak self] isOn in
+                    OttaiRegistry.saveCloudUploadEnabled(isOn)
+                    OttaiRegistry.saveCloudUploadStatus(nil)
+                    self?.refresh()
+                }
+            ),
+            row(
+                id: "ottai-cloud-upload-status",
+                title: "Last upload",
+                detail: OttaiCloudUploader.unavailableReason()
+                    ?? (uploadStatus.isEmpty ? "Waiting for the next reading" : uploadStatus),
+                showsDisclosure: true,
+                action: { [weak self] in self?.showOttaiUploadStatus() }
+            )
+        ]
+
+        // Keep the section shape identical whether or not the upload is switched on; the rows below
+        // the switch stay readable as the explanation of what the switch does.
+        if !uploadEnabled {
+            uploadRows = [uploadRows[0]]
+        }
+
+        return [
+            sensorSection,
+            BluetoothPeripheralDetailSection(
+                id: "ottai-cloud-upload-section",
+                title: "Syai cloud",
+                rows: uploadRows
+            )
+        ]
+    }
+
+    // MARK: Ottai helpers
+
+    var ottaiIsSignedIn: Bool {
+        !OttaiRegistry.loadAccessToken().isEmpty && !OttaiRegistry.loadGlucoseSecretKey().isEmpty
+    }
+
+    /// The cloud id of the sensor (12 hex characters). On iOS the Bluetooth address is not the MAC,
+    /// so the user must type the id from the sensor box or QR code.
+    func ottaiCloudId(for ottai: Ottai) -> String {
+        ottai.ottaiSensorId ?? ""
+    }
+
+    func ottaiTransmitter(for ottai: Ottai) -> CGMOttaiTransmitter? {
+        bluetoothPeripheralManager?.getBluetoothTransmitter(for: ottai, createANewOneIfNecesssary: false) as? CGMOttaiTransmitter
+    }
+
+    /// Full sensor detail — start, expiry, lifetime, firmware and state — shown when the
+    /// user taps the Activated / Valid until rows.
+    func showOttaiSensorInfo(for ottai: Ottai) {
+        let sensorId = ottaiCloudId(for: ottai)
+        let materials = OttaiRegistry.loadMaterials(sensorId: sensorId)
+        let startMs = materials.activeTimeMs > 0 ? materials.activeTimeMs : OttaiRegistry.loadProvisionalActiveTime(sensorId)
+        guard startMs > 0 else { return }
+
+        let startDate = Date(timeIntervalSince1970: Double(startMs) / 1000.0)
+        let acceptedMs = OttaiRegistry.loadAcceptedMaxActive(sensorId)
+        let lifetimeMs = OttaiConstants.expectedLifetimeMs(cloudActiveExpireMs: materials.activeExpireTimeMs, acceptedMaxActiveMs: acceptedMs)
+        let endDate = startDate.addingTimeInterval(Double(lifetimeMs) / 1000.0)
+
+        var lines: [String] = []
+        lines.append("Activated: " + startDate.toStringInUserLocale(timeStyle: .short, dateStyle: .medium))
+        if materials.activeTimeMs <= 0 { lines.append("(start time not confirmed yet — taken from the activation moment)") }
+        lines.append("Valid until: " + endDate.toStringInUserLocale(timeStyle: .short, dateStyle: .medium))
+        lines.append("Lifetime: \(Int(lifetimeMs / 86_400_000)) days" + (OttaiConstants.sanitizeActiveExpireMs(acceptedMs) > 0 ? " (accepted by the sensor)" : " (from the cloud)"))
+        if !materials.deviceVersion.isEmpty { lines.append("Firmware: " + materials.deviceVersion) }
+        if let status = ottaiTransmitter(for: ottai)?.sensorCommandStatus, status >= 0 {
+            let text = status == 3 ? "active" : (status >= 4 ? "ended" : "not activated yet")
+            lines.append("Sensor state: \(text) (command \(status))")
+        }
+        showInfo(title: "Sensor", message: lines.joined(separator: "\n"))
+    }
+
+    // MARK: Ottai row actions
+
+    func requestOttaiRegion() {
+        let regions = OttaiRegion.allCases
+        let current = OttaiRegion.from(apiBase: OttaiRegistry.loadApiBase())
+
+        presentSelectionListView(BluetoothPeripheralSelectionList(
+            title: "Region",
+            data: regions.map(\.rawValue),
+            selectedRow: regions.firstIndex(of: current),
+            actionHandler: { [weak self] index in
+                OttaiRegistry.saveApiBase(regions[index].apiBase)
+                self?.refresh()
+            }
+        ))
+    }
+
+    func requestOttaiAccount() {
+        guard !ottaiIsSignedIn else {
+            pendingAlert = BluetoothPeripheralDetailAlert(
+                title: "Sign out",
+                message: "Sign out of the Ottai/Syai cloud?",
+                primaryButtonTitle: "Sign out",
+                primaryAction: { [weak self] in
+                    guard let self = self else { return }
+                    self.ottaiCloudQueue.async {
+                        OttaiCloudClient.logout()
+                        DispatchQueue.main.async { self.refresh() }
+                    }
+                },
+                secondaryButtonTitle: Texts_Common.Cancel
+            )
+            return
+        }
+
+        let region = OttaiRegion.from(apiBase: OttaiRegistry.loadApiBase())
+        if region.usesSms {
+            requestOttaiPhoneNumber()
+        } else {
+            requestOttaiEmail(region: region)
+        }
+    }
+
+    /// Email sign-in, asked in two steps because the shared text-entry route holds one field.
+    func requestOttaiEmail(region: OttaiRegion) {
+        guard let webBase = region.webBase else { return }
+
+        presentTextEntryView(BluetoothPeripheralTextEntry(
+            title: "Sign in to \(region.rawValue)",
+            message: "Enter your account email.",
+            keyboardType: .emailAddress,
+            textInputAutocapitalization: .never,
+            text: OttaiRegistry.loadAccountLogin().isEmpty ? nil : OttaiRegistry.loadAccountLogin(),
+            placeholder: "Email",
+            actionTitle: Texts_Common.Ok,
+            cancelTitle: Texts_Common.Cancel,
+            actionHandler: { [weak self] email in
+                self?.requestOttaiPassword(email: email, webBase: webBase)
+            },
+            actionIsEnabled: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty },
+            inputValidator: nil
+        ))
+    }
+
+    func requestOttaiPassword(email: String, webBase: String) {
+        presentTextEntryView(BluetoothPeripheralTextEntry(
+            title: "Sign in",
+            message: "Enter the password for \(email).",
+            keyboardType: .default,
+            textInputAutocapitalization: .never,
+            text: nil,
+            placeholder: "Password",
+            actionTitle: Texts_Common.Ok,
+            cancelTitle: Texts_Common.Cancel,
+            actionHandler: { [weak self] password in
+                OttaiRegistry.saveAccountLogin(email)
+                self?.runOttaiSignIn { OttaiCloudClient.mailLogin(email: email, password: password, webBase: webBase)?.ok == true }
+            },
+            actionIsEnabled: { !$0.isEmpty },
+            inputValidator: nil,
+            isSecureTextEntry: true
+        ))
+    }
+
+    func requestOttaiPhoneNumber() {
+        presentTextEntryView(BluetoothPeripheralTextEntry(
+            title: "Sign in to China",
+            message: "Enter your mobile number (China +86).",
+            keyboardType: .phonePad,
+            textInputAutocapitalization: .never,
+            text: OttaiRegistry.loadAccountLogin().isEmpty ? nil : OttaiRegistry.loadAccountLogin(),
+            placeholder: "Phone number",
+            actionTitle: "Send code",
+            cancelTitle: Texts_Common.Cancel,
+            actionHandler: { [weak self] phone in
+                self?.sendOttaiSmsCode(phone: phone)
+            },
+            actionIsEnabled: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty },
+            inputValidator: nil
+        ))
+    }
+
+    func sendOttaiSmsCode(phone: String) {
+        setOttaiBusy("Sending code…")
+
+        ottaiCloudQueue.async { [weak self] in
+            let requestId = OttaiCloudClient.requestSmsCode(phone: phone)
+
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.setOttaiBusy(nil)
+
+                guard let requestId = requestId else {
+                    self.showInfo(
+                        title: "Could not send code",
+                        message: OttaiCloudClient.lastError.isEmpty ? "The server did not accept the number." : OttaiCloudClient.lastError
+                    )
+                    return
+                }
+
+                self.requestOttaiSmsCode(phone: phone, requestId: requestId)
+            }
+        }
+    }
+
+    func requestOttaiSmsCode(phone: String, requestId: String) {
+        presentTextEntryView(BluetoothPeripheralTextEntry(
+            title: "Enter SMS code",
+            message: "Enter the verification code sent to \(phone).",
+            keyboardType: .numberPad,
+            textInputAutocapitalization: .never,
+            text: nil,
+            placeholder: "Code",
+            actionTitle: Texts_Common.Ok,
+            cancelTitle: Texts_Common.Cancel,
+            actionHandler: { [weak self] code in
+                OttaiRegistry.saveAccountLogin(phone)
+                self?.runOttaiSignIn { OttaiCloudClient.smsLogin(phone: phone, code: code, requestId: requestId)?.ok == true }
+            },
+            actionIsEnabled: { !$0.isEmpty },
+            inputValidator: nil
+        ))
+    }
+
+    /// Run the sign-in in the background, show the result, and rebuild the rows.
+    func runOttaiSignIn(_ work: @escaping () -> Bool) {
+        setOttaiBusy("Signing in…")
+
+        ottaiCloudQueue.async { [weak self] in
+            let ok = work()
+
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.setOttaiBusy(nil)
+
+                if ok {
+                    self.showInfo(title: "Signed in", message: "You can now fetch the sensor from the cloud.")
+                } else {
+                    self.showInfo(
+                        title: "Sign-in failed",
+                        message: OttaiCloudClient.lastError.isEmpty ? "Check your credentials and region." : OttaiCloudClient.lastError
+                    )
+                }
+            }
+        }
+    }
+
+    func requestOttaiCloudId(for ottai: Ottai) {
+        let sensorId = ottaiCloudId(for: ottai)
+
+        presentTextEntryView(BluetoothPeripheralTextEntry(
+            title: "Cloud ID (MAC)",
+            message: "Enter the sensor's 12-hex ID (from the box label / QR). iOS can't read it over Bluetooth.",
+            keyboardType: .asciiCapable,
+            textInputAutocapitalization: .never,
+            text: sensorId.isEmpty ? nil : sensorId,
+            placeholder: "e.g. 6CA04230E260",
+            actionTitle: Texts_Common.Ok,
+            cancelTitle: Texts_Common.Cancel,
+            actionHandler: { [weak self] entered in
+                // accept a plain MAC, a MAC with colons, or a scanned QR code text
+                let mac = OttaiConstants.extractMacFromQr(entered) ?? OttaiConstants.canonicalSensorId(entered)
+
+                guard OttaiConstants.looksLikeMac(mac) else {
+                    self?.showInfo(title: "Invalid ID", message: "Expected a 12-character hex ID like 6CA04230E260.")
+                    return
+                }
+
+                let newId = OttaiConstants.canonicalSensorId(mac)
+                let oldId = OttaiConstants.canonicalSensorId(ottai.ottaiSensorId)
+                ottai.ottaiSensorId = newId
+                if newId != oldId {
+                    self?.forgetOttaiBleAddress(for: ottai)
+                }
+                self?.refresh()
+                self?.recreateOttaiTransmitterIfMaterialsReady(for: ottai)
+            },
+            actionIsEnabled: nil,
+            inputValidator: nil
+        ))
+    }
+
+    func requestOttaiFetchMaterials(for ottai: Ottai) {
+        let sensorId = ottaiCloudId(for: ottai)
+
+        guard !sensorId.isEmpty else {
+            showInfo(title: "Cloud ID needed", message: "Enter the sensor's Cloud ID (MAC) first.")
+            return
+        }
+
+        guard ottaiIsSignedIn else {
+            showInfo(title: "Not signed in", message: "Sign in to your Ottai/Syai account first, then fetch the sensor.")
+            return
+        }
+
+        fetchOttaiMaterials(sensorId: sensorId, for: ottai)
+    }
+
+    /// Fetches and saves the sensor's cloud keys. The Syai cloud allows only one bound
+    /// sensor per account: if another one is still bound, this offers to release it and
+    /// try again, instead of just showing "Fetch failed".
+    private func fetchOttaiMaterials(sensorId: String, for ottai: Ottai, busyMessage: String = "Fetching sensor…") {
+        setOttaiBusy(busyMessage)
+
+        ottaiCloudQueue.async { [weak self] in
+            let ok = OttaiCloudClient.fetchAndSaveMaterials(cloudId: sensorId)
+            let failureCode = OttaiCloudClient.lastFailure?.code ?? ""
+            let failureText = OttaiCloudClient.lastError
+
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.setOttaiBusy(nil)
+
+                if ok {
+                    ottai.ottaiSensorId = OttaiConstants.canonicalSensorId(sensorId)
+                    self.showInfo(title: "Sensor ready", message: "Materials saved. Reconnecting to the sensor with the new credentials.")
+                    self.recreateOttaiTransmitterIfMaterialsReady(for: ottai)
+                } else if failureCode.caseInsensitiveCompare(OttaiCloudClient.bizAlreadyBinding) == .orderedSame {
+                    self.offerToUnbindPreviousSensor(newCloudId: sensorId, for: ottai)
+                } else {
+                    self.showInfo(
+                        title: "Fetch failed",
+                        message: failureText.isEmpty ? "No materials for this Cloud ID on this account." : failureText
+                    )
+                }
+
+                self.refresh()
+            }
+        }
+    }
+
+    /// The account already has a different sensor bound (server error AppUser_AlreadyBinding).
+    /// Finds which one that is and asks the user before releasing it — unbinding is not
+    /// reversible from here.
+    private func offerToUnbindPreviousSensor(newCloudId: String, for ottai: Ottai) {
+        setOttaiBusy("Checking the account…")
+        ottaiCloudQueue.async { [weak self] in
+            let bound = OttaiCloudClient.getBindDevice()
+
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.setOttaiBusy(nil)
+
+                guard let bound = bound, !bound.mac.isEmpty else {
+                    self.showInfo(
+                        title: "Sensor already bound",
+                        message: "Your Syai account has another sensor bound, but it could not be identified here. Unbind it in the Syai app, then fetch again."
+                    )
+                    return
+                }
+
+                let boundId = OttaiConstants.canonicalSensorId(bound.mac)
+                self.pendingAlert = BluetoothPeripheralDetailAlert(
+                    title: "Sensor already bound",
+                    message: "Your Syai account still has sensor \(boundId) bound. It must be released before \(newCloudId) can be fetched.\n\nUnbind \(boundId) and fetch \(newCloudId) again? This cannot be undone.",
+                    primaryButtonTitle: "Unbind and retry",
+                    primaryAction: { [weak self] in
+                        self?.unbindPreviousSensorAndRetryFetch(oldMac: boundId, newCloudId: newCloudId, for: ottai)
+                    },
+                    secondaryButtonTitle: Texts_Common.Cancel
+                )
+            }
+        }
+    }
+
+    private func unbindPreviousSensorAndRetryFetch(oldMac: String, newCloudId: String, for ottai: Ottai) {
+        setOttaiBusy("Unbinding \(oldMac)…")
+        ottaiCloudQueue.async { [weak self] in
+            let unbound = OttaiCloudClient.unbind(mac: oldMac)
+            // Give the server a moment to release the old binding before the next fetch.
+            if unbound { usleep(1_000_000) }
+
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                if unbound {
+                    self.fetchOttaiMaterials(sensorId: newCloudId, for: ottai)
+                } else {
+                    self.setOttaiBusy(nil)
+                    self.showInfo(
+                        title: "Unbind failed",
+                        message: OttaiCloudClient.lastError.isEmpty ? "Could not unbind \(oldMac). Try again, or unbind it in the Syai app." : OttaiCloudClient.lastError
+                    )
+                    self.refresh()
+                }
+            }
+        }
+    }
+
+    func requestOttaiActivation(for ottai: Ottai) {
+        // Like Android's Advanced "Activate", this always sends the activation. Warn the user when
+        // the sensor is already active or has ended.
+        let status = ottaiTransmitter(for: ottai)?.sensorCommandStatus ?? -1
+        let message: String
+
+        if status == 3 {
+            message = "The sensor is already active. This sends the activation again and may change its lifetime. This cannot be undone. Continue?"
+        } else if status >= 4 {
+            message = "The sensor reports that it has ended. This tries to start it again. This cannot be undone. Continue?"
+        } else {
+            message = "Activation is irreversible and starts the sensor's lifetime. Continue?"
+        }
+
+        pendingAlert = BluetoothPeripheralDetailAlert(
+            title: "Activate sensor",
+            message: message,
+            primaryButtonTitle: "Activate",
+            primaryAction: { [weak self] in
+                guard let self = self else { return }
+                self.ottaiTransmitter(for: ottai)?.startSensor(sensorCode: nil, startDate: Date())
+                OttaiRegistry.setActivationAttempted(self.ottaiCloudId(for: ottai), true)
+                self.refresh()
+            },
+            secondaryButtonTitle: Texts_Common.Cancel
+        )
+    }
+
+    func showOttaiUploadStatus() {
+        let status = OttaiRegistry.loadCloudUploadStatus()
+        let message = OttaiCloudUploader.unavailableReason()
+            ?? (status.isEmpty ? "Nothing uploaded yet. Readings are sent a few seconds after the sensor delivers them." : status)
+
+        showInfo(title: "Upload to Syai cloud", message: message)
+    }
+
+    /// The transmitter reads the cloud id and the keys only when it is created. A running one never
+    /// sees keys entered later; it just stays connected and does nothing. So we replace it: the
+    /// manager disconnects and drops the old one (its slot is cleared a moment later), then we
+    /// connect again and the new one logs in with the new keys.
+    func recreateOttaiTransmitterIfMaterialsReady(for ottai: Ottai) {
+        guard let manager = bluetoothPeripheralManager else { return }
+
+        let sensorId = ottaiCloudId(for: ottai)
+        guard !sensorId.isEmpty, OttaiRegistry.loadMaterials(sensorId: sensorId).authKeys != nil else { return }
+
+        manager.setBluetoothTransmitterToNil(forBluetoothPeripheral: ottai)
+
+        guard ottai.blePeripheral.shouldconnect else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+            self?.bluetoothPeripheralManager?.connect(to: ottai)
+        }
+    }
+
+    /// The stored BLE address belongs to the physical sensor, not to the cloud id. After
+    /// a Cloud ID change it would still point to the old sensor, and the app would keep
+    /// connecting there with the new keys (login fails with a bad device signature). So
+    /// forget it: drop the transmitter, clear the address, and let the next connect scan
+    /// for the sensor that matches the new keys.
+    func forgetOttaiBleAddress(for ottai: Ottai) {
+        guard let manager = bluetoothPeripheralManager else { return }
+        guard !ottai.blePeripheral.address.isEmpty else { return }
+        trace("Ottai cloud id changed — forgetting stored BLE address %{public}@ so the app scans for the new sensor", log: log, category: ConstantsLog.categoryBluetoothPeripheralViewController, type: .info, ottai.blePeripheral.address)
+        manager.getBluetoothTransmitter(for: ottai, createANewOneIfNecesssary: false)?.disconnectAndForget()
+        manager.setBluetoothTransmitterToNil(forBluetoothPeripheral: ottai)
+        ottai.blePeripheral.address = ""
+        coreDataManager.saveChanges()
+    }
+
+    func setOttaiBusy(_ message: String?) {
+        ottaiBusyMessage = message
+        refresh()
     }
 }
 

--- a/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralDetailState.swift
+++ b/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralDetailState.swift
@@ -48,6 +48,7 @@ final class BluetoothPeripheralDetailState: NSObject, ObservableObject {
     private let presentTextEntryView: (BluetoothPeripheralTextEntry) -> Void
     private let presentSelectionListView: (BluetoothPeripheralSelectionList) -> Void
     private let presentReadSuccessView: (TransmitterReadSuccessDisplay, BluetoothPeripheralType) -> Void
+    private let presentDangerousConfirmation: (BluetoothPeripheralDangerousConfirmation) -> Void
 
     var onlineHelpTopic: OnlineHelpTopic {
         expectedBluetoothPeripheralType.onlineHelpTopic
@@ -92,7 +93,8 @@ final class BluetoothPeripheralDetailState: NSObject, ObservableObject {
         closeDetailView: @escaping () -> Void,
         presentTextEntryView: @escaping (BluetoothPeripheralTextEntry) -> Void,
         presentSelectionListView: @escaping (BluetoothPeripheralSelectionList) -> Void,
-        presentReadSuccessView: @escaping (TransmitterReadSuccessDisplay, BluetoothPeripheralType) -> Void
+        presentReadSuccessView: @escaping (TransmitterReadSuccessDisplay, BluetoothPeripheralType) -> Void,
+        presentDangerousConfirmation: @escaping (BluetoothPeripheralDangerousConfirmation) -> Void
     ) {
         self.bluetoothPeripheral = bluetoothPeripheral
         self.expectedBluetoothPeripheralType = expectedBluetoothPeripheralType
@@ -104,6 +106,7 @@ final class BluetoothPeripheralDetailState: NSObject, ObservableObject {
         self.presentTextEntryView = presentTextEntryView
         self.presentSelectionListView = presentSelectionListView
         self.presentReadSuccessView = presentReadSuccessView
+        self.presentDangerousConfirmation = presentDangerousConfirmation
         self.transmitterIdTempValue = bluetoothPeripheral?.blePeripheral.transmitterId
         self.dexcomG6BluetoothSlot = (bluetoothPeripheral as? DexcomG5)?
             .resolvedDexcomG6BluetoothSlot() ?? .defaultSlot
@@ -1690,6 +1693,36 @@ struct BluetoothPeripheralDetailAlert: Identifiable {
 }
 
 /// Text-entry route supplied by transmitter-specific configuration logic.
+/// A warning screen for an action that can break something that works now, like stopping
+/// or re-activating a running sensor. The Confirm button is disabled for a few seconds and
+/// counts down, so nobody can tap through the warning without reading it, as happens with
+/// a normal "Continue?" alert.
+struct BluetoothPeripheralDangerousConfirmation: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+    let confirmTitle: String
+    let cancelTitle: String
+    let countdownSeconds: Int
+    let action: () -> Void
+
+    init(
+        title: String,
+        message: String,
+        confirmTitle: String = "Confirm",
+        cancelTitle: String = Texts_Common.Cancel,
+        countdownSeconds: Int = 5,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.message = message
+        self.confirmTitle = confirmTitle
+        self.cancelTitle = cancelTitle
+        self.countdownSeconds = countdownSeconds
+        self.action = action
+    }
+}
+
 struct BluetoothPeripheralTextEntry: Identifiable {
     let id = UUID()
     let title: String?
@@ -2840,26 +2873,42 @@ private extension BluetoothPeripheralDetailState {
         // Like Android's Advanced "Activate", this always sends the activation. Warn the user when
         // the sensor is already active or has ended.
         let status = ottaiTransmitter(for: ottai)?.sensorCommandStatus ?? -1
-        let message: String
+        let confirmAndActivate: () -> Void = { [weak self] in
+            guard let self = self else { return }
+            self.ottaiTransmitter(for: ottai)?.startSensor(sensorCode: nil, startDate: Date())
+            OttaiRegistry.setActivationAttempted(self.ottaiCloudId(for: ottai), true)
+            self.refresh()
+        }
 
+        // Forcing activation on a running sensor is what killed a tester's working sensor:
+        // the second activation write failed (as a first one sometimes does) and the sensor
+        // reported "ended" less than a minute later. A simple "Continue?" alert is too easy
+        // to tap through, so this one has a countdown before Confirm can be tapped.
         if status == 3 {
-            message = "The sensor is already active. This sends the activation again and may change its lifetime. This cannot be undone. Continue?"
-        } else if status >= 4 {
-            message = "The sensor reports that it has ended. This tries to start it again. This cannot be undone. Continue?"
-        } else {
-            message = "Activation is irreversible and starts the sensor's lifetime. Continue?"
+            presentDangerousConfirmation(BluetoothPeripheralDangerousConfirmation(
+                title: "Sensor is already running",
+                message: "This sensor is already active and gives readings. Activating it again can change its lifetime. In one case it ended a working sensor. Only do this if you know what you are doing.",
+                confirmTitle: "Force activation anyway",
+                countdownSeconds: 5,
+                action: confirmAndActivate
+            ))
+            return
+        }
+        // An ended sensor cannot be started again: the sensor refused every try in the logs
+        // we have. Showing the button would only invite more useless tries.
+        if status >= 4 {
+            showInfo(
+                title: "Sensor has ended",
+                message: "This sensor reports that it has ended. An ended sensor cannot be started again. Put on a new sensor and enter its Cloud ID."
+            )
+            return
         }
 
         pendingAlert = BluetoothPeripheralDetailAlert(
             title: "Activate sensor",
-            message: message,
+            message: "Activation cannot be undone and starts the sensor's lifetime. Continue?",
             primaryButtonTitle: "Activate",
-            primaryAction: { [weak self] in
-                guard let self = self else { return }
-                self.ottaiTransmitter(for: ottai)?.startSensor(sensorCode: nil, startDate: Date())
-                OttaiRegistry.setActivationAttempted(self.ottaiCloudId(for: ottai), true)
-                self.refresh()
-            },
+            primaryAction: confirmAndActivate,
             secondaryButtonTitle: Texts_Common.Cancel
         )
     }

--- a/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralDetailView.swift
+++ b/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralDetailView.swift
@@ -277,12 +277,21 @@ struct BluetoothPeripheralTextEntryView: View {
             }
 
             Section {
-                TextField(textEntry.placeholder ?? "", text: $text)
-                    .keyboardType(textEntry.keyboardType)
-                    .textInputAutocapitalization(textEntry.textInputAutocapitalization)
-                    .autocorrectionDisabled()
-                    .submitLabel(.done)
-                    .onSubmit(submit)
+                if textEntry.isSecureTextEntry {
+                    SecureField(textEntry.placeholder ?? "", text: $text)
+                        .keyboardType(textEntry.keyboardType)
+                        .textInputAutocapitalization(textEntry.textInputAutocapitalization)
+                        .autocorrectionDisabled()
+                        .submitLabel(.done)
+                        .onSubmit(submit)
+                } else {
+                    TextField(textEntry.placeholder ?? "", text: $text)
+                        .keyboardType(textEntry.keyboardType)
+                        .textInputAutocapitalization(textEntry.textInputAutocapitalization)
+                        .autocorrectionDisabled()
+                        .submitLabel(.done)
+                        .onSubmit(submit)
+                }
             }
 
             if let validationMessage {
@@ -324,8 +333,12 @@ struct BluetoothPeripheralTextEntryView: View {
             return
         }
 
-        textEntry.actionHandler(text)
+        // Close this entry BEFORE running the handler. The entry is a navigation push and
+        // close() pops the last pushed view — a handler that presents the next step (email →
+        // password, phone → SMS code) pushes it, and closing afterwards would pop that new
+        // step instead of this one, so the second field never appeared.
         close()
+        textEntry.actionHandler(text)
     }
 }
 

--- a/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralDetailView.swift
+++ b/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralDetailView.swift
@@ -342,6 +342,71 @@ struct BluetoothPeripheralTextEntryView: View {
     }
 }
 
+/// A full-screen warning for an action that can break something that works now (see
+/// `BluetoothPeripheralDangerousConfirmation`). Confirm is disabled and counts down, so it
+/// cannot be tapped through like the second button of a system alert.
+struct BluetoothPeripheralDangerousConfirmationView: View {
+    let confirmation: BluetoothPeripheralDangerousConfirmation
+    let close: () -> Void
+
+    @State private var secondsRemaining: Int
+
+    init(confirmation: BluetoothPeripheralDangerousConfirmation, close: @escaping () -> Void) {
+        self.confirmation = confirmation
+        self.close = close
+        _secondsRemaining = State(initialValue: max(confirmation.countdownSeconds, 0))
+    }
+
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(ConstantsAppColors.urgent)
+                .padding(.top, 32)
+
+            Text(confirmation.title)
+                .font(.title2.bold())
+                .multilineTextAlignment(.center)
+
+            Text(confirmation.message)
+                .font(.body)
+                .foregroundStyle(Color(.colorSecondary))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+
+            Spacer()
+
+            Button(action: confirm) {
+                Text(secondsRemaining > 0 ? "\(confirmation.confirmTitle) (\(secondsRemaining))" : confirmation.confirmTitle)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(ConstantsAppColors.urgent)
+            .disabled(secondsRemaining > 0)
+            .padding(.horizontal, 24)
+
+            Button(confirmation.cancelTitle, action: close)
+                .padding(.bottom, 24)
+        }
+        .navigationBarBackButtonHidden(true)
+        .background(ConstantsUI.listBackGroundColor)
+        .colorScheme(.dark)
+        .onReceive(timer) { _ in
+            if secondsRemaining > 0 { secondsRemaining -= 1 }
+        }
+    }
+
+    private func confirm() {
+        guard secondsRemaining <= 0 else { return }
+        // Close first, then run the action (same as the text-entry screen): the action can
+        // open a new screen, and closing after it would close that new screen instead of this one.
+        close()
+        confirmation.action()
+    }
+}
+
 /// Native selection destination requested by a peripheral detail row.
 struct BluetoothPeripheralSelectionListView: View {
     let selectionList: BluetoothPeripheralSelectionList

--- a/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralsView.swift
+++ b/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralsView.swift
@@ -92,6 +92,9 @@ struct BluetoothPeripheralsNavigationView: View {
 
         case let .readSuccess(display, type):
             TransmitterReadSuccessView(display: display, bluetoothPeripheralType: type)
+
+        case let .dangerousConfirmation(confirmation):
+            BluetoothPeripheralDangerousConfirmationView(confirmation: confirmation, close: router.closeCurrentView)
         }
     }
 
@@ -150,7 +153,8 @@ private struct BluetoothPeripheralDetailContainerView: View {
             },
             presentTextEntryView: router.showTextEntry,
             presentSelectionListView: router.showSelectionList,
-            presentReadSuccessView: router.showReadSuccess
+            presentReadSuccessView: router.showReadSuccess,
+            presentDangerousConfirmation: router.showDangerousConfirmation
         ))
     }
 

--- a/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralsViewModel.swift
+++ b/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralsViewModel.swift
@@ -489,7 +489,8 @@ extension BluetoothPeripheralType {
             .DexcomG7Type,
             .MiaoMiaoType,
             .BubbleType,
-            .MedtrumTouchCareNanoType
+            .MedtrumTouchCareNanoType,
+            .OttaiType
         ]
     ]
 }

--- a/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralsViewModel.swift
+++ b/xDrip/SwiftUIViews/BluetoothPeripherals/BluetoothPeripheralsViewModel.swift
@@ -40,6 +40,10 @@ final class BluetoothPeripheralsRouter: ObservableObject {
         path.append(BluetoothPeripheralsRoute(.readSuccess(display, type)))
     }
 
+    func showDangerousConfirmation(_ confirmation: BluetoothPeripheralDangerousConfirmation) {
+        path.append(BluetoothPeripheralsRoute(.dangerousConfirmation(confirmation)))
+    }
+
     func closeCurrentView() {
         guard !path.isEmpty else { return }
 
@@ -59,6 +63,7 @@ struct BluetoothPeripheralsRoute: Hashable {
         case textEntry(BluetoothPeripheralTextEntry)
         case selectionList(BluetoothPeripheralSelectionList)
         case readSuccess(TransmitterReadSuccessDisplay, BluetoothPeripheralType)
+        case dangerousConfirmation(BluetoothPeripheralDangerousConfirmation)
     }
 
     let id = UUID()

--- a/xDrip/SwiftUIViews/RootHomeState.swift
+++ b/xDrip/SwiftUIViews/RootHomeState.swift
@@ -613,6 +613,10 @@ final class RootHomeStateModel: ObservableObject {
            sensorAgeInMinutes < ConstantsLibreLinkUp.sensorWarmUpRequiredInMinutesForLibre {
             warmUpMinutes = ConstantsLibreLinkUp.sensorWarmUpRequiredInMinutesForLibre
         } else if UserDefaults.standard.isMaster,
+                  cgmTransmitter?.cgmTransmitterType() == .ottai {
+            let requiredMinutes = ConstantsMaster.minimumSensorWarmUpRequiredInMinutesOttai
+            warmUpMinutes = sensorAgeInMinutes < requiredMinutes ? requiredMinutes : nil
+        } else if UserDefaults.standard.isMaster,
                   sensorType == .Libre,
                   sensorAgeInMinutes < ConstantsMaster.minimumSensorWarmUpRequiredInMinutes {
             warmUpMinutes = ConstantsMaster.minimumSensorWarmUpRequiredInMinutes

--- a/xDrip/SwiftUIViews/Sensor/SensorManagementView.swift
+++ b/xDrip/SwiftUIViews/Sensor/SensorManagementView.swift
@@ -476,7 +476,10 @@ struct SensorManagementView: View {
 
         switch sensorType {
         case .Libre:
-            warmupMinutes = ConstantsMaster.minimumSensorWarmUpRequiredInMinutes
+            // Ottai/Syai maps to the Libre sensor type but has its own 30-minute warm-up
+            warmupMinutes = transmitter?.cgmTransmitterType() == .ottai
+                ? ConstantsMaster.minimumSensorWarmUpRequiredInMinutesOttai
+                : ConstantsMaster.minimumSensorWarmUpRequiredInMinutes
         case .Dexcom:
             if transmitter?.cgmTransmitterType() == .dexcomG7 {
                 warmupMinutes = ConstantsMaster.minimumSensorWarmUpRequiredInMinutesDexcomG7

--- a/xDrip/Utilities/OnlineHelp.swift
+++ b/xDrip/Utilities/OnlineHelp.swift
@@ -394,6 +394,10 @@ extension BluetoothPeripheralType {
             return .dexcomG7OnePlusStelo
         case .Libre3HeartBeatType, .DexcomG7HeartBeatType, .OmniPodHeartBeatType:
             return .followerHeartbeat
+        case .OttaiType:
+            // No dedicated documentation page exists for the Ottai/Syai driver, so fall back to
+            // the generic "add a direct CGM" overview.
+            return .addDirectCGM
         case .MedtrumTouchCareNanoType:
             return .medtrumNano
         }

--- a/xDrip/Utilities/Trace.swift
+++ b/xDrip/Utilities/Trace.swift
@@ -650,11 +650,20 @@ class Trace {
                         
                     case .Libre2Type:
                         if blePeripheral.libre2 != nil {
-                            
+
                             traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
                             
                         }
-                        
+
+                    case .OttaiType:
+                        if blePeripheral.ottai != nil {
+
+                            traceInfo.appendStringAndNewLine("        Type: " + bluetoothPeripheralType.rawValue)
+                            traceInfo.appendStringAndNewLine("    Upload to Syai cloud: " + OttaiRegistry.loadCloudUploadEnabled().description)
+                            traceInfo.appendStringAndNewLine("    Last Syai upload: " + OttaiRegistry.loadCloudUploadStatus())
+
+                        }
+
                     case .Libre3HeartBeatType:
                         if blePeripheral.libre2heartbeat != nil {
                             

--- a/xDrip/Utilities/TroubleshootingLog.swift
+++ b/xDrip/Utilities/TroubleshootingLog.swift
@@ -40,6 +40,7 @@ enum TroubleshootingLogSource: String, Codable {
     case libre2
     case libre2EU
     case libre2PlusEU
+    case ottai
     case medtrumNano
     case nightscout
     case libreLinkUp
@@ -93,6 +94,8 @@ enum TroubleshootingLogSource: String, Codable {
             self = .bubble
         case .Libre2:
             self = description == "Libre 2 Plus EU" ? .libre2PlusEU : .libre2EU
+        case .ottai:
+            self = .ottai
         case .medtrumTouchCareNano:
             self = .medtrumNano
         }
@@ -128,6 +131,8 @@ enum TroubleshootingLogSource: String, Codable {
             self = .bubble
         case .Libre2Type:
             self = .libre2
+        case .OttaiType:
+            self = .ottai
         case .MedtrumTouchCareNanoType:
             self = .medtrumNano
         case .M5StackType, .M5StickCType, .Libre3HeartBeatType,
@@ -151,6 +156,7 @@ enum TroubleshootingLogSource: String, Codable {
         case .libre2: return "Libre 2/2+ EU"
         case .libre2EU: return "Libre 2 EU"
         case .libre2PlusEU: return "Libre 2 Plus EU"
+        case .ottai: return "Ottai/Syai CGM"
         case .medtrumNano: return "Medtrum Nano Pump CGM"
         case .nightscout: return "Nightscout"
         case .libreLinkUp: return "LibreLinkUp"
@@ -171,7 +177,7 @@ enum TroubleshootingLogSource: String, Codable {
             return true
         case .dexcom, .dexcomG5, .dexcomG6, .dexcomOne, .dexcomG7, .dexcomOnePlus,
              .dexcomStelo, .miaoMiao, .bubble, .libre2, .libre2EU, .libre2PlusEU,
-             .medtrumNano:
+             .ottai, .medtrumNano:
             return false
         }
     }

--- a/xdrip.xcodeproj/project.pbxproj
+++ b/xdrip.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13A4747AD828AEAD1B723DFE /* OttaiParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4C2CD24CCBDD12F4AAD88F /* OttaiParser.swift */; };
+		20F4EB764FB424E5A06F2695 /* OttaiFormula.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDDE308B4B89A171F4D37B1 /* OttaiFormula.swift */; };
+		284B12C5555D9CA475E0D576 /* OttaiMethodDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24908660CE15BFB909B35AC2 /* OttaiMethodDefaults.swift */; };
+		4071F7FB5794CBC8DE811814 /* Ottai+BluetoothPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35E0E6A27CECBA8ACF864CE /* Ottai+BluetoothPeripheral.swift */; };
+		4294841340A00CD35B2FE78C /* Ottai+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D3DC0FFED93EC7192B8943 /* Ottai+CoreDataProperties.swift */; };
 		4D7B00023014000200000001 /* CGMG5SensorSessionDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D7B00013014000200000001 /* CGMG5SensorSessionDetectionTests.swift */; };
 		4D7E00023017000200000001 /* DexcomG6BluetoothSlotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D7E00013017000200000001 /* DexcomG6BluetoothSlotTests.swift */; };
 		4D7D00023016000200000001 /* BluetoothPeripheralDisplayStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D7D00013016000200000001 /* BluetoothPeripheralDisplayStatusTests.swift */; };
@@ -361,6 +366,13 @@
 		C8BA6BBA5746888144511D55 /* GlucoseChartStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685B5F8D633F5492574F0567 /* GlucoseChartStateManager.swift */; };
 		CA1E00010000000000000001 /* CareLinkTherapyImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1E00020000000000000001 /* CareLinkTherapyImporter.swift */; };
 		CA1E00030000000000000001 /* CareLinkPumpStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1E00040000000000000001 /* CareLinkPumpStatusView.swift */; };
+		4C1A430E1DFC09DF02914AE6 /* OttaiOutputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADD70B4E5132F31AFDCDE39 /* OttaiOutputFilter.swift */; };
+		4EC6804439696544CF369887 /* Ottai+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F9DC54A8DE3925EF7CD5B8C /* Ottai+CoreDataClass.swift */; };
+		58281D5256BFCC099E79E7B9 /* CGMOttaiTransmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865572E2A097E6DBB6175393 /* CGMOttaiTransmitter.swift */; };
+		5E654193B5CBF596D6D66001 /* OttaiCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA1EB69C25CDA25ADA2E74D /* OttaiCrypto.swift */; };
+		6B8581D1BDABE338819A6B84 /* OttaiPhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EFAF67ABC87895110E03927 /* OttaiPhoneNumber.swift */; };
+		A394DC7F0CC35A564469332E /* OttaiRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7097940AE41A4C3A698607 /* OttaiRegistry.swift */; };
+		B8EA54913CEE6B223ACC6A4B /* OttaiConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40108EB773324614E41E9731 /* OttaiConstants.swift */; };
 		D400F8032778BD8000B57648 /* TextsTreatmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D400F8022778BD8000B57648 /* TextsTreatmentsView.swift */; };
 		D40C3DA4277542C400111B73 /* TreatmentEntry+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40C3DA3277542C400111B73 /* TreatmentEntry+CoreDataClass.swift */; };
 		D40C3DA62775438F00111B73 /* TreatmentEntry+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40C3DA52775438F00111B73 /* TreatmentEntry+CoreDataProperties.swift */; };
@@ -370,9 +382,13 @@
 		D4E499AB277B43E3000F8CBA /* TreatmentCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E499AA277B43E3000F8CBA /* TreatmentCollection.swift */; };
 		D4E499AD277B4CE7000F8CBA /* DateOnly.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E499AC277B4CE7000F8CBA /* DateOnly.swift */; };
 		D4FD899727772F9100689788 /* TreatmentEntryAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FD899627772F9100689788 /* TreatmentEntryAccessor.swift */; };
+		DF60C8F6A6C18C5CB7F098A2 /* OttaiCloudClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EE74853FB148C4278C1DD1 /* OttaiCloudClient.swift */; };
+		14FD801068B18CBB8EC4FCBA /* OttaiCloudUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310FB85B4345230331321EEA /* OttaiCloudUploader.swift */; };
 		DAF100012E7A000100000001 /* DataFlowPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF100022E7A000100000001 /* DataFlowPolicy.swift */; };
 		DB718DBF9805AC4B21C95739 /* TimeScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD00FB5270FD0E5E2F710BE6 /* TimeScheduleView.swift */; };
 		E4C006212B3DE8EC00D59303 /* GlucoseIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C006202B3DE8EC00D59303 /* GlucoseIntent.swift */; };
+		E8393C9948F10303A38E7BDA /* OttaiBleAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187BAE275FDE4E081346A887 /* OttaiBleAuth.swift */; };
+		F112B4E7317472D8D52D276E /* OttaiV3BootstrapPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521D08EAAAFF5A14216FA21D /* OttaiV3BootstrapPolicy.swift */; };
 		F227BF192B9DF76D00CEEAAD /* SettingsViewContactImageSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F227BF182B9DF76D00CEEAAD /* SettingsViewContactImageSettingsViewModel.swift */; };
 		F227BF1C2B9E426B00CEEAAD /* ContactImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F227BF1B2B9E426B00CEEAAD /* ContactImageManager.swift */; };
 		F51B9F7D24B216CD00FC0643 /* Libre1NonFixedSlopeCalibrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51B9F7C24B216CD00FC0643 /* Libre1NonFixedSlopeCalibrator.swift */; };
@@ -881,6 +897,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		09EE74853FB148C4278C1DD1 /* OttaiCloudClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiCloudClient.swift; sourceTree = "<group>"; };
+		310FB85B4345230331321EEA /* OttaiCloudUploader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiCloudUploader.swift; sourceTree = "<group>"; };
+		0F9DC54A8DE3925EF7CD5B8C /* Ottai+CoreDataClass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Ottai+CoreDataClass.swift"; sourceTree = "<group>"; };
+		187BAE275FDE4E081346A887 /* OttaiBleAuth.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiBleAuth.swift; sourceTree = "<group>"; };
 		4D7B00013014000200000001 /* CGMG5SensorSessionDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGMG5SensorSessionDetectionTests.swift; sourceTree = "<group>"; };
 		4D7E00013017000200000001 /* DexcomG6BluetoothSlotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DexcomG6BluetoothSlotTests.swift; sourceTree = "<group>"; };
 		4D7D00013016000200000001 /* BluetoothPeripheralDisplayStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothPeripheralDisplayStatusTests.swift; sourceTree = "<group>"; };
@@ -909,6 +929,7 @@
 		198D44D8260A3A3400A2B4A2 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/LibreNFC.strings; sourceTree = "<group>"; };
 		198D44E7260A822000A2B4A2 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/RootTab.strings; sourceTree = "<group>"; };
 		2867F5C925BC209500AA1E98 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/RootTab.strings; sourceTree = "<group>"; };
+		24908660CE15BFB909B35AC2 /* OttaiMethodDefaults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiMethodDefaults.swift; sourceTree = "<group>"; };
 		2867F5CB25BC209500AA1E98 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Alerts.strings; sourceTree = "<group>"; };
 		2867F5CC25BC209500AA1E98 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/AlertTypesSettingsView.strings; sourceTree = "<group>"; };
 		2867F5CD25BC209500AA1E98 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/BluetoothPeripheralsView.strings; sourceTree = "<group>"; };
@@ -929,6 +950,7 @@
 		2BBDAD3BFBEF70B1B2A1AFAD /* CareLinkTokenStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CareLinkTokenStore.swift; sourceTree = "<group>"; };
 		3DBC8BB898BFD4C30858ED5D /* CareLinkFollowerSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CareLinkFollowerSettings.swift; sourceTree = "<group>"; };
 		4166BFB828C3501500199980 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/RootTab.strings; sourceTree = "<group>"; };
+		40108EB773324614E41E9731 /* OttaiConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiConstants.swift; sourceTree = "<group>"; };
 		4166BFBA28C3501500199980 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Treatments.strings; sourceTree = "<group>"; };
 		4166BFBB28C3501500199980 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Alerts.strings; sourceTree = "<group>"; };
 		4166BFBC28C3501500199980 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/AlertTypesSettingsView.strings; sourceTree = "<group>"; };
@@ -1243,6 +1265,14 @@
 		CA1E00020000000000000001 /* CareLinkTherapyImporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CareLinkTherapyImporter.swift; sourceTree = "<group>"; };
 		CA1E00040000000000000001 /* CareLinkPumpStatusView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CareLinkPumpStatusView.swift; sourceTree = "<group>"; };
 		CD00FB5270FD0E5E2F710BE6 /* TimeScheduleView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimeScheduleView.swift; sourceTree = "<group>"; };
+		4EFAF67ABC87895110E03927 /* OttaiPhoneNumber.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiPhoneNumber.swift; sourceTree = "<group>"; };
+		521D08EAAAFF5A14216FA21D /* OttaiV3BootstrapPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiV3BootstrapPolicy.swift; sourceTree = "<group>"; };
+		5ADD70B4E5132F31AFDCDE39 /* OttaiOutputFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiOutputFilter.swift; sourceTree = "<group>"; };
+		6BDDE308B4B89A171F4D37B1 /* OttaiFormula.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiFormula.swift; sourceTree = "<group>"; };
+		7FA1EB69C25CDA25ADA2E74D /* OttaiCrypto.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiCrypto.swift; sourceTree = "<group>"; };
+		865572E2A097E6DBB6175393 /* CGMOttaiTransmitter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CGMOttaiTransmitter.swift; sourceTree = "<group>"; };
+		AE7097940AE41A4C3A698607 /* OttaiRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiRegistry.swift; sourceTree = "<group>"; };
+		B35E0E6A27CECBA8ACF864CE /* Ottai+BluetoothPeripheral.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Ottai+BluetoothPeripheral.swift"; sourceTree = "<group>"; };
 		CE1B2FC825D0261500F642F5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Alerts.strings; sourceTree = "<group>"; };
 		CE1B2FCD25D0264900F642F5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/AlertTypesSettingsView.strings; sourceTree = "<group>"; };
 		CE1B2FCF25D0264900F642F5 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LibreNFC.strings; sourceTree = "<group>"; };
@@ -1286,6 +1316,7 @@
 		E4D530622B418FF80018C6A4 /* AppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShortcuts.swift; sourceTree = "<group>"; };
 		E64C4CC1DCC94C18B184021D /* SettingsSharedUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsSharedUtilities.swift; sourceTree = "<group>"; };
 		F081BB1D5F106F950C4A8EA4 /* CareLinkAccountState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CareLinkAccountState.swift; sourceTree = "<group>"; };
+		F0D3DC0FFED93EC7192B8943 /* Ottai+CoreDataProperties.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Ottai+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		F227BF182B9DF76D00CEEAAD /* SettingsViewContactImageSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewContactImageSettingsViewModel.swift; sourceTree = "<group>"; };
 		F227BF1B2B9E426B00CEEAAD /* ContactImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactImageManager.swift; sourceTree = "<group>"; };
 		F40AD096DBCD9BD7C4BA770E /* CareLinkClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CareLinkClient.swift; sourceTree = "<group>"; };
@@ -1952,6 +1983,7 @@
 		F8FDFEA7260DE1A70047597D /* DTCustomColoredAccessory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DTCustomColoredAccessory.h; sourceTree = "<group>"; };
 		F8FDFEA8260DE1A70047597D /* DTCustomColoredAccessory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DTCustomColoredAccessory.m; sourceTree = "<group>"; };
 		F8FDFEAC260DE1B90047597D /* ConstantsUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstantsUI.swift; sourceTree = "<group>"; };
+		FC4C2CD24CCBDD12F4AAD88F /* OttaiParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OttaiParser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2009,6 +2041,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1BF2F101CFCCD2F3D73F2EAD /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				40108EB773324614E41E9731 /* OttaiConstants.swift */,
+				7FA1EB69C25CDA25ADA2E74D /* OttaiCrypto.swift */,
+				187BAE275FDE4E081346A887 /* OttaiBleAuth.swift */,
+				FC4C2CD24CCBDD12F4AAD88F /* OttaiParser.swift */,
+				6BDDE308B4B89A171F4D37B1 /* OttaiFormula.swift */,
+				5ADD70B4E5132F31AFDCDE39 /* OttaiOutputFilter.swift */,
+				24908660CE15BFB909B35AC2 /* OttaiMethodDefaults.swift */,
+				521D08EAAAFF5A14216FA21D /* OttaiV3BootstrapPolicy.swift */,
+				4EFAF67ABC87895110E03927 /* OttaiPhoneNumber.swift */,
+				AE7097940AE41A4C3A698607 /* OttaiRegistry.swift */,
+				09EE74853FB148C4278C1DD1 /* OttaiCloudClient.swift */,
+				310FB85B4345230331321EEA /* OttaiCloudUploader.swift */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
 		065EEDCFBA12133E67945FEA /* CareLink */ = {
 			isa = PBXGroup;
 			children = (
@@ -2394,6 +2445,23 @@
 				4716A4EE2B406C3D00419052 /* WidgetKit.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6D5AA1B8EE1345A92487C156 /* Ottai */ = {
+			isa = PBXGroup;
+			children = (
+				1BF2F101CFCCD2F3D73F2EAD /* Core */,
+				865572E2A097E6DBB6175393 /* CGMOttaiTransmitter.swift */,
+			);
+			path = Ottai;
+			sourceTree = "<group>";
+		};
+		AE40321AAEBC6D228E1DAD91 /* Ottai */ = {
+			isa = PBXGroup;
+			children = (
+				B35E0E6A27CECBA8ACF864CE /* Ottai+BluetoothPeripheral.swift */,
+			);
+			path = Ottai;
 			sourceTree = "<group>";
 		};
 		4A9B10212F0A000100000001 /* PostProcessing */ = {
@@ -3407,6 +3475,8 @@
 				F85FF3CC252F9FD7004E6FF1 /* SnoozeParameters+CoreDataProperties.swift */,
 				D40C3DA3277542C400111B73 /* TreatmentEntry+CoreDataClass.swift */,
 				D40C3DA52775438F00111B73 /* TreatmentEntry+CoreDataProperties.swift */,
+				0F9DC54A8DE3925EF7CD5B8C /* Ottai+CoreDataClass.swift */,
+				F0D3DC0FFED93EC7192B8943 /* Ottai+CoreDataProperties.swift */,
 			);
 			path = classes;
 			sourceTree = "<group>";
@@ -3525,6 +3595,7 @@
 			children = (
 				F8DF765923E350B100063910 /* Dexcom */,
 				F808D2CF240329D40084B5DB /* Libre */,
+				AE40321AAEBC6D228E1DAD91 /* Ottai */,
 				4D7180102FE8000100000001 /* Medtrum */,
 			);
 			path = CGM;
@@ -3582,6 +3653,7 @@
 				F8F971BB23A5915900C3F17D /* Dexcom */,
 				F8F971F023A5915900C3F17D /* Generic */,
 				F8F971D623A5915900C3F17D /* Libre */,
+				6D5AA1B8EE1345A92487C156 /* Ottai */,
 				4D7180122FE8000100000001 /* Medtrum */,
 			);
 			path = CGM;
@@ -4765,6 +4837,22 @@
 				F8A1586522EDB89D007F5B5D /* ConstantsDefaultAlertTypeSettings.swift in Sources */,
 				D41F32922827240E00861B3D /* SettingsViewHousekeeperSettingsViewModel.swift in Sources */,
 				F8FDFEAD260DE1B90047597D /* ConstantsUI.swift in Sources */,
+				B8EA54913CEE6B223ACC6A4B /* OttaiConstants.swift in Sources */,
+				5E654193B5CBF596D6D66001 /* OttaiCrypto.swift in Sources */,
+				E8393C9948F10303A38E7BDA /* OttaiBleAuth.swift in Sources */,
+				13A4747AD828AEAD1B723DFE /* OttaiParser.swift in Sources */,
+				20F4EB764FB424E5A06F2695 /* OttaiFormula.swift in Sources */,
+				4C1A430E1DFC09DF02914AE6 /* OttaiOutputFilter.swift in Sources */,
+				284B12C5555D9CA475E0D576 /* OttaiMethodDefaults.swift in Sources */,
+				F112B4E7317472D8D52D276E /* OttaiV3BootstrapPolicy.swift in Sources */,
+				6B8581D1BDABE338819A6B84 /* OttaiPhoneNumber.swift in Sources */,
+				A394DC7F0CC35A564469332E /* OttaiRegistry.swift in Sources */,
+				DF60C8F6A6C18C5CB7F098A2 /* OttaiCloudClient.swift in Sources */,
+				14FD801068B18CBB8EC4FCBA /* OttaiCloudUploader.swift in Sources */,
+				58281D5256BFCC099E79E7B9 /* CGMOttaiTransmitter.swift in Sources */,
+				4EC6804439696544CF369887 /* Ottai+CoreDataClass.swift in Sources */,
+				4294841340A00CD35B2FE78C /* Ottai+CoreDataProperties.swift in Sources */,
+				4071F7FB5794CBC8DE811814 /* Ottai+BluetoothPeripheral.swift in Sources */,
 				7DDD89BD4ECFCE7BDA8D3AE2 /* SettingsSharedUtilities.swift in Sources */,
 				2BB9AEE4FF9AF41B59A1AA52 /* SettingsView.swift in Sources */,
 				DB718DBF9805AC4B21C95739 /* TimeScheduleView.swift in Sources */,

--- a/xdrip.xcodeproj/project.pbxproj
+++ b/xdrip.xcodeproj/project.pbxproj
@@ -322,6 +322,7 @@
 		4F2500013002000100000001 /* SensorHealthIssueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2500113002000100000001 /* SensorHealthIssueManager.swift */; };
 		4F2500143002000100000001 /* SensorHealthModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2500133002000100000001 /* SensorHealthModels.swift */; };
 		4F2600013002000200000001 /* SensorNoisePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2600113002000200000001 /* SensorNoisePersistenceTests.swift */; };
+		4F2600013002000200000099 /* OttaiStartupBackfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2600113002000200000099 /* OttaiStartupBackfillTests.swift */; };
 		4F2600023002000200000001 /* SensorHealthIssueManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2600123002000200000001 /* SensorHealthIssueManagerTests.swift */; };
 		4F2800013004000100000001 /* RootHomeInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2800113004000100000001 /* RootHomeInteractionTests.swift */; };
 		4F2800023004000100000001 /* GlucoseChartYAxisRetentionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2800123004000100000001 /* GlucoseChartYAxisRetentionTests.swift */; };
@@ -1220,6 +1221,7 @@
 		4F2500113002000100000001 /* SensorHealthIssueManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorHealthIssueManager.swift; sourceTree = "<group>"; };
 		4F2500133002000100000001 /* SensorHealthModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorHealthModels.swift; sourceTree = "<group>"; };
 		4F2600113002000200000001 /* SensorNoisePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorNoisePersistenceTests.swift; sourceTree = "<group>"; };
+		4F2600113002000200000099 /* OttaiStartupBackfillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OttaiStartupBackfillTests.swift; sourceTree = "<group>"; };
 		4F2600123002000200000001 /* SensorHealthIssueManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorHealthIssueManagerTests.swift; sourceTree = "<group>"; };
 		4F2800113004000100000001 /* RootHomeInteractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootHomeInteractionTests.swift; sourceTree = "<group>"; };
 		4F2800123004000100000001 /* GlucoseChartYAxisRetentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseChartYAxisRetentionTests.swift; sourceTree = "<group>"; };
@@ -2609,6 +2611,7 @@
 				4F2800113004000100000001 /* RootHomeInteractionTests.swift */,
 				4F2600123002000200000001 /* SensorHealthIssueManagerTests.swift */,
 				4F2600113002000200000001 /* SensorNoisePersistenceTests.swift */,
+				4F2600113002000200000099 /* OttaiStartupBackfillTests.swift */,
 				15CBE00BF86A714EC59FA546 /* CareLink */,
 			);
 			path = "xDrip Tests";
@@ -4371,6 +4374,7 @@
 				4F2800013004000100000001 /* RootHomeInteractionTests.swift in Sources */,
 				A40000010000000000000001 /* FollowerSettingsTests.swift in Sources */,
 				4F2600013002000200000001 /* SensorNoisePersistenceTests.swift in Sources */,
+				4F2600013002000200000099 /* OttaiStartupBackfillTests.swift in Sources */,
 				377EBC0A484BFC8EA77C623C /* CareLinkTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This is a backport of the Ottai / Syai CGM driver from JugglucoNG (https://github.com/ctqvva/JugglucoNG, Android) to Swift for xDrip4iOS.

xDrip4iOS can now read Syai and Ottai sensors directly over Bluetooth, activate them, and upload the readings to the Syai cloud, so the Syai Link and a Syai Doctor also see the data.

- The sensor sends calibrated values, so xDrip4iOS does not ask for a calibration.
- The sensor sends one reading per minute. xDrip4iOS keeps every one of them, but the chart still shows a point every 5 minutes, like with other CGMs.
- Every reading xDrip4iOS accepts is also sent to the Syai cloud, the same way the Syai app does it.
- The sensor already sends values after 10 minutes, but to be safe the warm-up is set to 30 minutes, as stated in the Syai manual.